### PR TITLE
Implement diff-based policy runner MVP for path, budget, and co-change enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -22,4 +24,7 @@ jobs:
         run: node src/repo-guard.mjs
 
       - name: Run schema tests
-        run: npm test
+        run: npm run test:schemas
+
+      - name: Run diff-rule tests
+        run: npm run test:diff

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T12:25:05.282Z for PR creation at branch issue-3-de117ec7e21a for issue https://github.com/netkeep80/repo-guard/issues/3

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T12:25:05.282Z for PR creation at branch issue-3-de117ec7e21a for issue https://github.com/netkeep80/repo-guard/issues/3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "repo-guard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repo-guard",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Unlicense",
       "dependencies": {
-        "ajv": "^8.17.1"
+        "ajv": "^8.17.1",
+        "minimatch": "^10.2.5"
       },
       "bin": {
         "repo-guard": "src/repo-guard.mjs"
@@ -32,6 +33,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -61,6 +83,21 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "repo-guard",
-  "version": "0.1.0",
-  "description": "Executable repository policy enforcement via JSON Schema validation",
+  "version": "0.2.0",
+  "description": "Executable repository policy enforcement via JSON Schema validation and diff-based rule checking",
   "type": "module",
   "main": "src/repo-guard.mjs",
   "bin": {
@@ -9,14 +9,22 @@
   },
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs"
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs",
+    "test:schemas": "node tests/validate-schemas.mjs",
+    "test:diff": "node tests/test-diff-rules.mjs"
   },
-  "keywords": ["repo-policy", "json-schema", "validation", "ci"],
+  "keywords": [
+    "repo-policy",
+    "json-schema",
+    "validation",
+    "ci"
+  ],
   "license": "Unlicense",
   "engines": {
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "ajv": "^8.17.1"
+    "ajv": "^8.17.1",
+    "minimatch": "^10.2.5"
   }
 }

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,5 +1,5 @@
 {
-  "policy_format_version": "0.1.0",
+  "policy_format_version": "0.2.0",
   "repository_kind": "tooling",
   "paths": {
     "forbidden": [
@@ -13,11 +13,15 @@
     "governance_paths": [
       "repo-policy.json",
       "schemas/"
+    ],
+    "public_api": [
+      "src/repo-guard.mjs"
     ]
   },
   "diff_rules": {
     "max_new_docs": 2,
-    "max_new_files": 10
+    "max_new_files": 15,
+    "max_net_added_lines": 2000
   },
   "content_rules": [
     {
@@ -27,5 +31,10 @@
       "message": "TODO comments must reference an issue: TODO(#123)"
     }
   ],
-  "cochange_rules": []
+  "cochange_rules": [
+    {
+      "if_changed": ["src/**"],
+      "must_change_any": ["tests/**"]
+    }
+  ]
 }

--- a/schemas/change-contract.schema.json
+++ b/schemas/change-contract.schema.json
@@ -33,6 +33,10 @@
         "max_new_docs": {
           "type": "integer",
           "minimum": 0
+        },
+        "max_net_added_lines": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -37,6 +37,10 @@
         "governance_paths": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "public_api": {
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     },
@@ -52,6 +56,10 @@
         "max_new_files": {
           "type": "integer",
           "minimum": 0
+        },
+        "max_net_added_lines": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     },
@@ -59,7 +67,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "pattern", "severity", "message"],
+        "required": ["id"],
         "additionalProperties": false,
         "properties": {
           "id": { "type": "string" },
@@ -68,7 +76,17 @@
             "type": "string",
             "enum": ["error", "warn", "info"]
           },
-          "message": { "type": "string" }
+          "message": { "type": "string" },
+          "glob": { "type": "string" },
+          "mode": {
+            "type": "string",
+            "enum": ["added_lines"]
+          },
+          "forbid_regex": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1
+          }
         }
       }
     },

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -12,7 +12,7 @@ export function parseDiff(diffText) {
     if (line.startsWith("diff --git")) {
       if (current) files.push(current);
       const match = line.match(/diff --git a\/.+ b\/(.+)/);
-      current = { path: match ? match[1] : "", addedLines: [], status: "modified" };
+      current = { path: match ? match[1] : "", addedLines: [], deletedLines: [], status: "modified" };
       continue;
     }
 
@@ -24,6 +24,8 @@ export function parseDiff(diffText) {
       current.status = "deleted";
     } else if (line.startsWith("+") && !line.startsWith("+++")) {
       current.addedLines.push(line.slice(1));
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      current.deletedLines.push(line.slice(1));
     }
   }
 
@@ -77,7 +79,7 @@ export function checkNetAddedLinesBudget(files, maxNetAddedLines) {
 
   let netAdded = 0;
   for (const f of files) {
-    netAdded += f.addedLines.length;
+    netAdded += f.addedLines.length - (f.deletedLines ? f.deletedLines.length : 0);
   }
 
   return {

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -1,0 +1,174 @@
+import { minimatch } from "minimatch";
+
+export function matchesAny(filePath, patterns) {
+  return patterns.some((p) => minimatch(filePath, p, { dot: true }));
+}
+
+export function parseDiff(diffText) {
+  const files = [];
+  let current = null;
+
+  for (const line of diffText.split("\n")) {
+    if (line.startsWith("diff --git")) {
+      if (current) files.push(current);
+      const match = line.match(/diff --git a\/.+ b\/(.+)/);
+      current = { path: match ? match[1] : "", addedLines: [], status: "modified" };
+      continue;
+    }
+
+    if (!current) continue;
+
+    if (line.startsWith("new file")) {
+      current.status = "added";
+    } else if (line.startsWith("deleted file")) {
+      current.status = "deleted";
+    } else if (line.startsWith("+") && !line.startsWith("+++")) {
+      current.addedLines.push(line.slice(1));
+    }
+  }
+
+  if (current) files.push(current);
+  return files;
+}
+
+export function checkForbiddenPaths(files, forbidden) {
+  const violations = [];
+  for (const f of files) {
+    if (f.status === "deleted") continue;
+    if (matchesAny(f.path, forbidden)) {
+      violations.push(f.path);
+    }
+  }
+  return violations;
+}
+
+export function checkCanonicalDocsBudget(files, canonicalDocs, maxNewDocs) {
+  if (maxNewDocs === undefined) return { ok: true };
+
+  const newDocs = files.filter(
+    (f) =>
+      f.status === "added" &&
+      f.path.match(/\.md$/i) &&
+      !canonicalDocs.includes(f.path)
+  );
+
+  return {
+    ok: newDocs.length <= maxNewDocs,
+    actual: newDocs.length,
+    limit: maxNewDocs,
+    files: newDocs.map((f) => f.path),
+  };
+}
+
+export function checkNewFilesBudget(files, maxNewFiles) {
+  if (maxNewFiles === undefined) return { ok: true };
+
+  const newFiles = files.filter((f) => f.status === "added");
+  return {
+    ok: newFiles.length <= maxNewFiles,
+    actual: newFiles.length,
+    limit: maxNewFiles,
+    files: newFiles.map((f) => f.path),
+  };
+}
+
+export function checkNetAddedLinesBudget(files, maxNetAddedLines) {
+  if (maxNetAddedLines === undefined) return { ok: true };
+
+  let netAdded = 0;
+  for (const f of files) {
+    netAdded += f.addedLines.length;
+  }
+
+  return {
+    ok: netAdded <= maxNetAddedLines,
+    actual: netAdded,
+    limit: maxNetAddedLines,
+  };
+}
+
+export function checkCochangeRules(files, rules) {
+  const changedPaths = files.map((f) => f.path);
+  const violations = [];
+
+  for (const rule of rules) {
+    const triggered = changedPaths.some((p) => matchesAny(p, rule.if_changed));
+    if (!triggered) continue;
+
+    const satisfied = changedPaths.some((p) => matchesAny(p, rule.must_change_any));
+    if (!satisfied) {
+      violations.push({
+        if_changed: rule.if_changed,
+        must_change_any: rule.must_change_any,
+      });
+    }
+  }
+
+  return violations;
+}
+
+export function checkContentRules(files, rules) {
+  const violations = [];
+
+  for (const rule of rules) {
+    if (!rule.forbid_regex || rule.mode !== "added_lines") continue;
+
+    const regexes = rule.forbid_regex.map((r) => new RegExp(r));
+    const glob = rule.glob || "**";
+
+    for (const f of files) {
+      if (!minimatch(f.path, glob, { dot: true })) continue;
+
+      for (const line of f.addedLines) {
+        for (let i = 0; i < regexes.length; i++) {
+          if (regexes[i].test(line)) {
+            violations.push({
+              rule_id: rule.id,
+              file: f.path,
+              line: line.trim(),
+              matched_regex: rule.forbid_regex[i],
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+export function checkMustTouch(files, mustTouch) {
+  if (!mustTouch || mustTouch.length === 0) return { ok: true };
+
+  const changedPaths = files.map((f) => f.path);
+  const satisfied = mustTouch.some((p) =>
+    changedPaths.some((cp) => minimatch(cp, p, { dot: true }))
+  );
+
+  return {
+    ok: satisfied,
+    must_touch: mustTouch,
+    changed: changedPaths,
+  };
+}
+
+export function checkMustNotTouch(files, mustNotTouch) {
+  if (!mustNotTouch || mustNotTouch.length === 0) return { ok: true };
+
+  const changedPaths = files.map((f) => f.path);
+  const touched = [];
+
+  for (const pattern of mustNotTouch) {
+    for (const cp of changedPaths) {
+      if (minimatch(cp, pattern, { dot: true })) {
+        touched.push(cp);
+      }
+    }
+  }
+
+  return {
+    ok: touched.length === 0,
+    touched,
+    must_not_touch: mustNotTouch,
+  };
+}

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -1,9 +1,21 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
+import {
+  parseDiff,
+  checkForbiddenPaths,
+  checkCanonicalDocsBudget,
+  checkNewFilesBudget,
+  checkNetAddedLinesBudget,
+  checkCochangeRules,
+  checkContentRules,
+  checkMustTouch,
+  checkMustNotTouch,
+} from "./diff-checker.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
@@ -25,7 +37,16 @@ function validate(ajv, schema, data, label) {
   return true;
 }
 
-function run() {
+function getDiff(base, head) {
+  if (base && head) {
+    return execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: root });
+  }
+  const staged = execSync("git diff --cached", { encoding: "utf-8", cwd: root });
+  if (staged.trim()) return staged;
+  return execSync("git diff HEAD", { encoding: "utf-8", cwd: root });
+}
+
+function runCheckDiff(args) {
   const policySchemaPath = resolve(root, "schemas/repo-policy.schema.json");
   const contractSchemaPath = resolve(root, "schemas/change-contract.schema.json");
   const policyPath = resolve(root, "repo-policy.json");
@@ -37,10 +58,117 @@ function run() {
   const ajv = new Ajv({ allErrors: true });
 
   let ok = true;
-
   ok = validate(ajv, policySchema, policy, "repo-policy.json") && ok;
 
-  const contractArg = process.argv[2];
+  let contract = null;
+  let base = null;
+  let head = null;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--base" && args[i + 1]) base = args[++i];
+    else if (args[i] === "--head" && args[i + 1]) head = args[++i];
+    else if (args[i] === "--contract" && args[i + 1]) {
+      const contractPath = resolve(args[++i]);
+      contract = loadJSON(contractPath);
+      ok = validate(ajv, contractSchema, contract, contractPath) && ok;
+    }
+  }
+
+  const diffText = getDiff(base, head);
+  const files = parseDiff(diffText);
+
+  console.log(`\nDiff analysis: ${files.length} file(s) changed`);
+
+  let passed = 0;
+  let failed = 0;
+
+  function report(name, check) {
+    if (check.ok) {
+      passed++;
+      console.log(`  PASS: ${name}`);
+    } else {
+      failed++;
+      ok = false;
+      console.error(`  FAIL: ${name}`);
+      if (check.actual !== undefined) {
+        console.error(`    actual: ${check.actual}, limit: ${check.limit}`);
+      }
+      if (check.files) {
+        for (const f of check.files) console.error(`    - ${f}`);
+      }
+      if (check.touched) {
+        for (const f of check.touched) console.error(`    - ${f}`);
+      }
+      if (check.must_touch) {
+        console.error(`    must_touch: ${check.must_touch.join(", ")}`);
+      }
+    }
+  }
+
+  const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
+  report("forbidden-paths", {
+    ok: forbiddenViolations.length === 0,
+    files: forbiddenViolations,
+  });
+
+  const budgets = contract?.budgets || {};
+  const maxNewDocs = budgets.max_new_docs ?? policy.diff_rules.max_new_docs;
+  const maxNewFiles = budgets.max_new_files ?? policy.diff_rules.max_new_files;
+  const maxNetAddedLines = budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines;
+
+  report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
+  report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
+  report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+
+  const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
+  if (cochangeViolations.length > 0) {
+    for (const v of cochangeViolations) {
+      report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
+        ok: false,
+        must_touch: v.must_change_any,
+      });
+    }
+  } else {
+    report("cochange-rules", { ok: true });
+  }
+
+  const contentViolations = checkContentRules(files, policy.content_rules);
+  if (contentViolations.length > 0) {
+    ok = false;
+    failed++;
+    console.error(`  FAIL: content-rules`);
+    for (const v of contentViolations) {
+      console.error(`    [${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`);
+    }
+  } else {
+    passed++;
+    console.log(`  PASS: content-rules`);
+  }
+
+  if (contract) {
+    report("must-touch", checkMustTouch(files, contract.must_touch));
+    report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
+  }
+
+  console.log(`\nSummary: ${passed} passed, ${failed} failed`);
+  process.exit(ok ? 0 : 1);
+}
+
+function runValidate(args) {
+  const policySchemaPath = resolve(root, "schemas/repo-policy.schema.json");
+  const contractSchemaPath = resolve(root, "schemas/change-contract.schema.json");
+  const policyPath = resolve(root, "repo-policy.json");
+
+  const policySchema = loadJSON(policySchemaPath);
+  const contractSchema = loadJSON(contractSchemaPath);
+  const policy = loadJSON(policyPath);
+
+  const ajv = new Ajv({ allErrors: true });
+
+  let ok = true;
+  ok = validate(ajv, policySchema, policy, "repo-policy.json") && ok;
+
+  const contractArg = args[0];
   if (contractArg) {
     const contract = loadJSON(resolve(contractArg));
     ok = validate(ajv, contractSchema, contract, contractArg) && ok;
@@ -49,4 +177,10 @@ function run() {
   process.exit(ok ? 0 : 1);
 }
 
-run();
+const command = process.argv[2];
+
+if (command === "check-diff") {
+  runCheckDiff(process.argv.slice(3));
+} else {
+  runValidate(process.argv.slice(2));
+}

--- a/tests/fixtures/diff-contract.json
+++ b/tests/fixtures/diff-contract.json
@@ -1,0 +1,13 @@
+{
+  "change_type": "feature",
+  "scope": ["src/**"],
+  "budgets": {
+    "max_new_files": 3,
+    "max_new_docs": 1,
+    "max_net_added_lines": 500
+  },
+  "must_touch": ["src/repo-guard.mjs"],
+  "must_not_touch": ["LICENSE"],
+  "expected_effects": ["Diff-based enforcement checks work in CI"],
+  "overrides": []
+}

--- a/tests/fixtures/valid-contract.json
+++ b/tests/fixtures/valid-contract.json
@@ -3,7 +3,8 @@
   "scope": ["src/**", "schemas/**", "tests/**"],
   "budgets": {
     "max_new_files": 15,
-    "max_new_docs": 2
+    "max_new_docs": 2,
+    "max_net_added_lines": 1000
   },
   "must_touch": ["package.json", "src/repo-guard.mjs"],
   "must_not_touch": ["LICENSE"],

--- a/tests/fixtures/valid-policy.json
+++ b/tests/fixtures/valid-policy.json
@@ -4,12 +4,26 @@
   "paths": {
     "forbidden": ["*.bak"],
     "canonical_docs": ["README.md"],
-    "governance_paths": ["repo-policy.json"]
+    "governance_paths": ["repo-policy.json"],
+    "public_api": ["include/**/*.h"]
   },
   "diff_rules": {
     "max_new_docs": 3,
-    "max_new_files": 20
+    "max_new_files": 20,
+    "max_net_added_lines": 500
   },
-  "content_rules": [],
-  "cochange_rules": []
+  "content_rules": [
+    {
+      "id": "forbid_doxygen_tags_in_headers",
+      "glob": "include/**/*.h",
+      "mode": "added_lines",
+      "forbid_regex": ["@brief", "@param", "@return"]
+    }
+  ],
+  "cochange_rules": [
+    {
+      "if_changed": ["include/**/*.h"],
+      "must_change_any": ["tests/**"]
+    }
+  ]
 }

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -33,11 +33,13 @@ const sampleDiff = [
   "diff --git a/README.md b/README.md",
   "--- a/README.md",
   "+++ b/README.md",
+  "-Old line in readme",
   "+New line in readme",
   "diff --git a/old.bak b/old.bak",
   "deleted file mode 100644",
   "--- a/old.bak",
   "+++ /dev/null",
+  "-old content",
 ].join("\n");
 
 const files = parseDiff(sampleDiff);
@@ -46,12 +48,14 @@ expect("parseDiff: new file status", files[0].status, "added");
 expect("parseDiff: modified file status", files[1].status, "modified");
 expect("parseDiff: deleted file status", files[2].status, "deleted");
 expect("parseDiff: added lines count", files[0].addedLines.length, 2);
+expect("parseDiff: deleted lines count (modified)", files[1].deletedLines.length, 1);
+expect("parseDiff: deleted lines count (deleted file)", files[2].deletedLines.length, 1);
 
 // --- 1. Valid diff passes ---
 
 const validFiles = [
-  { path: "src/utils.mjs", addedLines: ["const x = 1;"], status: "modified" },
-  { path: "tests/test-utils.mjs", addedLines: ["assert(true);"], status: "added" },
+  { path: "src/utils.mjs", addedLines: ["const x = 1;"], deletedLines: [], status: "modified" },
+  { path: "tests/test-utils.mjs", addedLines: ["assert(true);"], deletedLines: [], status: "added" },
 ];
 
 const forbiddenPatterns = ["*.bak", "docs/phase-*"];
@@ -109,7 +113,7 @@ expect("3. canonical doc excluded from count", canonicalResult.ok, true);
 // --- 4. Max net added lines exceeded ---
 
 const manyLinesFiles = [
-  { path: "src/big.mjs", addedLines: new Array(101).fill("line"), status: "added" },
+  { path: "src/big.mjs", addedLines: new Array(101).fill("line"), deletedLines: [], status: "added" },
 ];
 
 const linesResult = checkNetAddedLinesBudget(manyLinesFiles, 100);
@@ -117,9 +121,26 @@ expect("4. max net added lines exceeded", linesResult.ok, false);
 expect("4. net added lines actual", linesResult.actual, 101);
 
 const exactLinesFiles = [
-  { path: "src/exact.mjs", addedLines: new Array(100).fill("line"), status: "added" },
+  { path: "src/exact.mjs", addedLines: new Array(100).fill("line"), deletedLines: [], status: "added" },
 ];
 expect("4. exact budget passes", checkNetAddedLinesBudget(exactLinesFiles, 100).ok, true);
+
+// net = added - deleted: 80 added, 30 deleted => net 50, within budget of 60
+const netFiles = [
+  { path: "src/refactor.mjs", addedLines: new Array(80).fill("new"), deletedLines: new Array(30).fill("old"), status: "modified" },
+];
+expect("4. net lines (added-deleted) within budget", checkNetAddedLinesBudget(netFiles, 60).ok, true);
+expect("4. net lines actual is 50", checkNetAddedLinesBudget(netFiles, 60).actual, 50);
+
+// net = added - deleted: 80 added, 30 deleted => net 50, exceeds budget of 40
+expect("4. net lines exceeds tighter budget", checkNetAddedLinesBudget(netFiles, 40).ok, false);
+
+// net can be negative when more lines deleted than added
+const shrinkFiles = [
+  { path: "src/cleanup.mjs", addedLines: new Array(5).fill("new"), deletedLines: new Array(20).fill("old"), status: "modified" },
+];
+expect("4. negative net always passes", checkNetAddedLinesBudget(shrinkFiles, 0).ok, true);
+expect("4. negative net actual", checkNetAddedLinesBudget(shrinkFiles, 0).actual, -15);
 
 // --- 5. Co-change rule violation ---
 

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -1,0 +1,240 @@
+import {
+  parseDiff,
+  checkForbiddenPaths,
+  checkCanonicalDocsBudget,
+  checkNewFilesBudget,
+  checkNetAddedLinesBudget,
+  checkCochangeRules,
+  checkContentRules,
+  checkMustTouch,
+  checkMustNotTouch,
+} from "../src/diff-checker.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${expected}, got: ${actual}`);
+  }
+}
+
+// --- parseDiff ---
+
+const sampleDiff = [
+  "diff --git a/src/app.mjs b/src/app.mjs",
+  "new file mode 100644",
+  "--- /dev/null",
+  "+++ b/src/app.mjs",
+  "+console.log('hello');",
+  "+console.log('world');",
+  "diff --git a/README.md b/README.md",
+  "--- a/README.md",
+  "+++ b/README.md",
+  "+New line in readme",
+  "diff --git a/old.bak b/old.bak",
+  "deleted file mode 100644",
+  "--- a/old.bak",
+  "+++ /dev/null",
+].join("\n");
+
+const files = parseDiff(sampleDiff);
+expect("parseDiff: file count", files.length, 3);
+expect("parseDiff: new file status", files[0].status, "added");
+expect("parseDiff: modified file status", files[1].status, "modified");
+expect("parseDiff: deleted file status", files[2].status, "deleted");
+expect("parseDiff: added lines count", files[0].addedLines.length, 2);
+
+// --- 1. Valid diff passes ---
+
+const validFiles = [
+  { path: "src/utils.mjs", addedLines: ["const x = 1;"], status: "modified" },
+  { path: "tests/test-utils.mjs", addedLines: ["assert(true);"], status: "added" },
+];
+
+const forbiddenPatterns = ["*.bak", "docs/phase-*"];
+expect("1. valid diff: no forbidden paths", checkForbiddenPaths(validFiles, forbiddenPatterns).length, 0);
+expect("1. valid diff: docs budget ok", checkCanonicalDocsBudget(validFiles, ["README.md"], 2).ok, true);
+expect("1. valid diff: new files budget ok", checkNewFilesBudget(validFiles, 5).ok, true);
+expect("1. valid diff: net added lines ok", checkNetAddedLinesBudget(validFiles, 100).ok, true);
+
+const cochangeRules = [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }];
+expect("1. valid diff: cochange satisfied", checkCochangeRules(validFiles, cochangeRules).length, 0);
+
+// --- 2. Forbidden path fails ---
+
+const forbiddenFiles = [
+  { path: "backup.bak", addedLines: ["data"], status: "added" },
+  { path: "src/main.mjs", addedLines: [], status: "modified" },
+];
+
+const forbiddenResult = checkForbiddenPaths(forbiddenFiles, forbiddenPatterns);
+expect("2. forbidden path detected", forbiddenResult.length, 1);
+expect("2. forbidden path file", forbiddenResult[0], "backup.bak");
+
+const forbiddenFiles2 = [
+  { path: "docs/phase-1.md", addedLines: ["plan"], status: "added" },
+];
+expect("2. forbidden glob pattern", checkForbiddenPaths(forbiddenFiles2, forbiddenPatterns).length, 1);
+
+// deleted files should not trigger forbidden
+const deletedForbidden = [
+  { path: "backup.bak", addedLines: [], status: "deleted" },
+];
+expect("2. deleted forbidden path ignored", checkForbiddenPaths(deletedForbidden, forbiddenPatterns).length, 0);
+
+// --- 3. Max new docs exceeded ---
+
+const manyDocsFiles = [
+  { path: "docs/guide.md", addedLines: ["# Guide"], status: "added" },
+  { path: "docs/faq.md", addedLines: ["# FAQ"], status: "added" },
+  { path: "docs/changelog.md", addedLines: ["# Changelog"], status: "added" },
+];
+
+const docsResult = checkCanonicalDocsBudget(manyDocsFiles, ["README.md"], 2);
+expect("3. max new docs exceeded", docsResult.ok, false);
+expect("3. max new docs actual", docsResult.actual, 3);
+expect("3. max new docs limit", docsResult.limit, 2);
+
+// canonical docs don't count against budget
+const canonicalFiles = [
+  { path: "README.md", addedLines: ["# Readme"], status: "added" },
+  { path: "docs/extra.md", addedLines: ["# Extra"], status: "added" },
+];
+const canonicalResult = checkCanonicalDocsBudget(canonicalFiles, ["README.md"], 1);
+expect("3. canonical doc excluded from count", canonicalResult.ok, true);
+
+// --- 4. Max net added lines exceeded ---
+
+const manyLinesFiles = [
+  { path: "src/big.mjs", addedLines: new Array(101).fill("line"), status: "added" },
+];
+
+const linesResult = checkNetAddedLinesBudget(manyLinesFiles, 100);
+expect("4. max net added lines exceeded", linesResult.ok, false);
+expect("4. net added lines actual", linesResult.actual, 101);
+
+const exactLinesFiles = [
+  { path: "src/exact.mjs", addedLines: new Array(100).fill("line"), status: "added" },
+];
+expect("4. exact budget passes", checkNetAddedLinesBudget(exactLinesFiles, 100).ok, true);
+
+// --- 5. Co-change rule violation ---
+
+const srcOnlyFiles = [
+  { path: "src/feature.mjs", addedLines: ["export function foo() {}"], status: "added" },
+];
+
+const cochangeViolations = checkCochangeRules(srcOnlyFiles, cochangeRules);
+expect("5. cochange violation detected", cochangeViolations.length, 1);
+
+// no trigger = no violation
+const docsOnlyFiles = [
+  { path: "docs/readme.md", addedLines: ["# Docs"], status: "added" },
+];
+expect("5. cochange not triggered", checkCochangeRules(docsOnlyFiles, cochangeRules).length, 0);
+
+// --- 6. Forbidden regex found in added lines ---
+
+const contentRules = [
+  {
+    id: "forbid_doxygen_tags_in_headers",
+    glob: "include/**/*.h",
+    mode: "added_lines",
+    forbid_regex: ["@brief", "@param", "@return"],
+  },
+];
+
+const headerFiles = [
+  {
+    path: "include/pmm/core.h",
+    addedLines: ["/// @brief Does something", "void foo();"],
+    status: "modified",
+  },
+];
+
+const contentViolations = checkContentRules(headerFiles, contentRules);
+expect("6. forbidden regex detected", contentViolations.length, 1);
+expect("6. violation rule_id", contentViolations[0].rule_id, "forbid_doxygen_tags_in_headers");
+expect("6. violation file", contentViolations[0].file, "include/pmm/core.h");
+
+// non-matching glob should not trigger
+const nonHeaderFiles = [
+  {
+    path: "src/impl.cpp",
+    addedLines: ["/// @brief Implementation"],
+    status: "modified",
+  },
+];
+expect("6. non-matching glob skipped", checkContentRules(nonHeaderFiles, contentRules).length, 0);
+
+// clean added lines should pass
+const cleanHeaderFiles = [
+  {
+    path: "include/pmm/clean.h",
+    addedLines: ["void bar();", "int baz();"],
+    status: "modified",
+  },
+];
+expect("6. clean header passes", checkContentRules(cleanHeaderFiles, contentRules).length, 0);
+
+// --- 7. must_not_touch violation ---
+
+const touchedFiles = [
+  { path: "src/main.mjs", addedLines: [], status: "modified" },
+  { path: "migrations/001.sql", addedLines: ["CREATE TABLE"], status: "added" },
+];
+
+const mustNotTouchResult = checkMustNotTouch(touchedFiles, ["migrations/**"]);
+expect("7. must_not_touch violation", mustNotTouchResult.ok, false);
+expect("7. touched file", mustNotTouchResult.touched[0], "migrations/001.sql");
+
+// no violation when pattern doesn't match
+expect("7. must_not_touch passes", checkMustNotTouch(validFiles, ["migrations/**"]).ok, true);
+
+// empty must_not_touch always passes
+expect("7. empty must_not_touch", checkMustNotTouch(touchedFiles, []).ok, true);
+
+// --- 8. must_touch missing ---
+
+const missingTouchFiles = [
+  { path: "src/other.mjs", addedLines: ["code"], status: "modified" },
+];
+
+const mustTouchResult = checkMustTouch(missingTouchFiles, ["tests/**", "package.json"]);
+expect("8. must_touch missing", mustTouchResult.ok, false);
+
+// satisfied when at least one pattern matches
+const satisfiedFiles = [
+  { path: "src/other.mjs", addedLines: ["code"], status: "modified" },
+  { path: "tests/new-test.mjs", addedLines: ["test"], status: "added" },
+];
+expect("8. must_touch satisfied", checkMustTouch(satisfiedFiles, ["tests/**"]).ok, true);
+
+// empty must_touch always passes
+expect("8. empty must_touch", checkMustTouch(missingTouchFiles, []).ok, true);
+
+// --- Budget undefined = skip check ---
+
+expect("budget: undefined max_new_docs skipped", checkCanonicalDocsBudget(manyDocsFiles, [], undefined).ok, true);
+expect("budget: undefined max_new_files skipped", checkNewFilesBudget(manyDocsFiles, undefined).ok, true);
+expect("budget: undefined max_net_added_lines skipped", checkNetAddedLinesBudget(manyLinesFiles, undefined).ok, true);
+
+// --- Max new files budget ---
+
+const manyNewFiles = [
+  { path: "a.mjs", addedLines: [], status: "added" },
+  { path: "b.mjs", addedLines: [], status: "added" },
+  { path: "c.mjs", addedLines: [], status: "added" },
+];
+
+const newFilesResult = checkNewFilesBudget(manyNewFiles, 2);
+expect("budget: max new files exceeded", newFilesResult.ok, false);
+expect("budget: max new files actual", newFilesResult.actual, 3);
+
+// --- Summary ---
+
+console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Adds `check-diff` CLI command to `repo-guard` for analyzing git diffs against policy rules
- Implements all 6 required enforcement checks: forbidden paths, canonical docs budget, new files budget, net added lines budget, co-change rules, and content regex rules on added lines
- Adds change-contract support for `must_touch` / `must_not_touch` validation and budget overrides
- Extracts diff-checking logic into `src/diff-checker.mjs` for testability
- Adds 46 unit tests covering all 8 required test scenarios
- Extends JSON Schemas with `public_api` paths, `max_net_added_lines`, and content rule fields (`glob`, `mode`, `forbid_regex`)
- Updates CI to run both schema validation and diff-rule tests

## CLI usage

```bash
# Validate policy/contracts (existing behavior)
node src/repo-guard.mjs

# Check diff against policy rules
node src/repo-guard.mjs check-diff

# Check diff between two revisions
node src/repo-guard.mjs check-diff --base <sha> --head <sha>

# Check diff with a change-contract
node src/repo-guard.mjs check-diff --contract path/to/contract.json
```

## Enforcement checks implemented

1. **Forbidden paths** — fails if diff adds/modifies files matching `paths.forbidden` globs
2. **Canonical docs budget** — fails if new markdown files (outside whitelist) exceed `max_new_docs`
3. **Max new files** — fails if total new files exceed `max_new_files`
4. **Max net added lines** — fails if net line change (added minus deleted) exceeds `max_net_added_lines`
5. **Co-change rules** — fails if files matching `if_changed` are modified without also modifying files matching `must_change_any`
6. **Content rules** — fails if added lines in files matching `glob` contain any `forbid_regex` pattern
7. **must_touch** — (contract) fails if none of the required files were changed
8. **must_not_touch** — (contract) fails if any protected files were changed

## Budget resolution

Budgets are resolved with contract-first priority:
- If a change-contract provides `budgets.max_new_files`, use that
- Otherwise fall back to `diff_rules.max_new_files` from `repo-policy.json`
- If neither specifies a budget, the check is skipped

## Fix for `max_net_added_lines` calculation

Addressed reviewer feedback: `max_net_added_lines` now correctly computes **net** line changes as `added - deleted`, not just total added lines. The diff parser now tracks both added and deleted lines, and the budget check subtracts deletions from additions. Tests verify:
- Net calculation (80 added, 30 deleted = 50 net)
- Negative net (more deleted than added) always passes
- Exact budget boundary behavior

## Test plan

- [x] `npm test` runs 5 schema tests + 46 diff-rule tests — all pass
- [x] `node src/repo-guard.mjs` validates repo-policy.json — exits 0
- [x] `node src/repo-guard.mjs tests/fixtures/valid-contract.json` — exits 0
- [x] `node src/repo-guard.mjs tests/fixtures/diff-contract.json` — exits 0
- [x] CI passes on GitHub Actions

## Files changed

```
.github/workflows/ci.yml              — add diff-rule test step, fetch-depth: 0
package.json                           — bump to 0.2.0, add test:schemas/test:diff scripts, minimatch dep
repo-policy.json                       — add public_api, max_net_added_lines, cochange rule
schemas/repo-policy.schema.json        — add public_api, max_net_added_lines, content rule fields
schemas/change-contract.schema.json    — add max_net_added_lines to budgets
src/diff-checker.mjs                   — NEW: extracted diff-checking functions (tracks added + deleted lines)
src/repo-guard.mjs                     — add check-diff CLI command, import from diff-checker
tests/test-diff-rules.mjs             — NEW: 46 unit tests for all diff enforcement rules
tests/fixtures/diff-contract.json     — NEW: example contract for diff-based checks
tests/fixtures/valid-policy.json       — updated with new schema fields
tests/fixtures/valid-contract.json     — updated with max_net_added_lines
```

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)