### PR TITLE
Decouple repo execution context from package directory and introduce explicit repo-root resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run GitHub PR integration tests
         run: npm run test:github-pr
 
+      - name: Run repo-root separation tests
+        run: npm run test:repo-root
+
       - name: Run PR policy check
         if: github.event_name == 'pull_request'
         run: node src/repo-guard.mjs check-pr

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T16:41:00.843Z for PR creation at branch issue-9-ff1df18d446f for issue https://github.com/netkeep80/repo-guard/issues/9

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T16:41:00.843Z for PR creation at branch issue-9-ff1df18d446f for issue https://github.com/netkeep80/repo-guard/issues/9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "repo-guard",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "repo-guard",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Unlicense",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-guard",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Executable repository policy enforcement via JSON Schema validation and diff-based rule checking",
   "type": "module",
   "main": "src/repo-guard.mjs",
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-repo-root.mjs",
+    "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
     "test:diff": "node tests/test-diff-rules.mjs",
     "test:contract": "node tests/test-markdown-contract.mjs",

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -1,7 +1,6 @@
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import Ajv from "ajv";
 import { extractContract, extractLinkedIssueNumbers, resolveContract } from "./markdown-contract.mjs";
 import {
@@ -16,9 +15,6 @@ import {
   checkMustTouch,
   checkMustNotTouch,
 } from "./diff-checker.mjs";
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, "..");
 
 function loadJSON(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
@@ -77,7 +73,7 @@ export function fetchIssueBody(repoFullName, issueNumber) {
   }
 }
 
-export function runCheckPR() {
+export function runCheckPR(roots) {
   const eventInfo = loadGitHubEvent();
   if (!eventInfo.ok) {
     console.error(`ERROR: ${eventInfo.message}`);
@@ -113,9 +109,9 @@ export function runCheckPR() {
   const contract = contractResult.contract;
   console.log("OK: change-contract extracted");
 
-  const policySchema = loadJSON(resolve(root, "schemas/repo-policy.schema.json"));
-  const contractSchema = loadJSON(resolve(root, "schemas/change-contract.schema.json"));
-  const policy = loadJSON(resolve(root, "repo-policy.json"));
+  const policySchema = loadJSON(resolve(roots.packageRoot, "schemas/repo-policy.schema.json"));
+  const contractSchema = loadJSON(resolve(roots.packageRoot, "schemas/change-contract.schema.json"));
+  const policy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
 
   const ajv = new Ajv({ allErrors: true });
 
@@ -128,7 +124,7 @@ export function runCheckPR() {
     process.exit(1);
   }
 
-  const diffText = execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: root });
+  const diffText = execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: roots.repoRoot });
   const allFiles = parseDiff(diffText);
   const files = filterOperationalPaths(allFiles, policy.paths.operational_paths);
 

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -19,7 +19,20 @@ import {
 } from "./diff-checker.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, "..");
+const packageRoot = resolve(__dirname, "..");
+
+export function resolveRoots(args) {
+  let repoRoot = process.cwd();
+  const filtered = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--repo-root" && args[i + 1]) {
+      repoRoot = resolve(args[++i]);
+    } else {
+      filtered.push(args[i]);
+    }
+  }
+  return { packageRoot, repoRoot, args: filtered };
+}
 
 function loadJSON(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
@@ -38,19 +51,19 @@ function validate(ajv, schema, data, label) {
   return true;
 }
 
-function getDiff(base, head) {
+function getDiff(base, head, cwd) {
   if (base && head) {
-    return execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: root });
+    return execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd });
   }
-  const staged = execSync("git diff --cached", { encoding: "utf-8", cwd: root });
+  const staged = execSync("git diff --cached", { encoding: "utf-8", cwd });
   if (staged.trim()) return staged;
-  return execSync("git diff HEAD", { encoding: "utf-8", cwd: root });
+  return execSync("git diff HEAD", { encoding: "utf-8", cwd });
 }
 
-function runCheckDiff(args) {
-  const policySchemaPath = resolve(root, "schemas/repo-policy.schema.json");
-  const contractSchemaPath = resolve(root, "schemas/change-contract.schema.json");
-  const policyPath = resolve(root, "repo-policy.json");
+function runCheckDiff(roots, args) {
+  const policySchemaPath = resolve(roots.packageRoot, "schemas/repo-policy.schema.json");
+  const contractSchemaPath = resolve(roots.packageRoot, "schemas/change-contract.schema.json");
+  const policyPath = resolve(roots.repoRoot, "repo-policy.json");
 
   const policySchema = loadJSON(policySchemaPath);
   const contractSchema = loadJSON(contractSchemaPath);
@@ -75,7 +88,7 @@ function runCheckDiff(args) {
     }
   }
 
-  const diffText = getDiff(base, head);
+  const diffText = getDiff(base, head, roots.repoRoot);
   const allFiles = parseDiff(diffText);
   const files = filterOperationalPaths(allFiles, policy.paths.operational_paths);
 
@@ -157,10 +170,10 @@ function runCheckDiff(args) {
   process.exit(ok ? 0 : 1);
 }
 
-function runValidate(args) {
-  const policySchemaPath = resolve(root, "schemas/repo-policy.schema.json");
-  const contractSchemaPath = resolve(root, "schemas/change-contract.schema.json");
-  const policyPath = resolve(root, "repo-policy.json");
+function runValidate(roots, args) {
+  const policySchemaPath = resolve(roots.packageRoot, "schemas/repo-policy.schema.json");
+  const contractSchemaPath = resolve(roots.packageRoot, "schemas/change-contract.schema.json");
+  const policyPath = resolve(roots.repoRoot, "repo-policy.json");
 
   const policySchema = loadJSON(policySchemaPath);
   const contractSchema = loadJSON(contractSchemaPath);
@@ -180,13 +193,20 @@ function runValidate(args) {
   process.exit(ok ? 0 : 1);
 }
 
-const command = process.argv[2];
+const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(__dirname, "repo-guard.mjs");
 
-if (command === "check-diff") {
-  runCheckDiff(process.argv.slice(3));
-} else if (command === "check-pr") {
-  const { runCheckPR } = await import("./github-pr.mjs");
-  runCheckPR();
-} else {
-  runValidate(process.argv.slice(2));
+if (isMain) {
+  const command = process.argv[2];
+
+  if (command === "check-diff") {
+    const roots = resolveRoots(process.argv.slice(3));
+    runCheckDiff(roots, roots.args);
+  } else if (command === "check-pr") {
+    const roots = resolveRoots(process.argv.slice(3));
+    const { runCheckPR } = await import("./github-pr.mjs");
+    runCheckPR(roots);
+  } else {
+    const roots = resolveRoots(process.argv.slice(2));
+    runValidate(roots, roots.args);
+  }
 }

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -82,7 +82,7 @@ function runCheckDiff(roots, args) {
     if (args[i] === "--base" && args[i + 1]) base = args[++i];
     else if (args[i] === "--head" && args[i + 1]) head = args[++i];
     else if (args[i] === "--contract" && args[i + 1]) {
-      const contractPath = resolve(args[++i]);
+      const contractPath = resolve(roots.repoRoot, args[++i]);
       contract = loadJSON(contractPath);
       ok = validate(ajv, contractSchema, contract, contractPath) && ok;
     }
@@ -186,7 +186,7 @@ function runValidate(roots, args) {
 
   const contractArg = args[0];
   if (contractArg) {
-    const contract = loadJSON(resolve(contractArg));
+    const contract = loadJSON(resolve(roots.repoRoot, contractArg));
     ok = validate(ajv, contractSchema, contract, contractArg) && ok;
   }
 

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -173,6 +173,105 @@ function expect(label, actual, expected) {
   rmSync(tmp, { recursive: true });
 }
 
+// --- validate resolves contract path relative to repoRoot ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-contract-validate-"));
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+
+  mkdirSync(join(tmp, "contracts"));
+  const contract = {
+    change_type: "feature",
+    scope: ["src/**"],
+    budgets: { max_new_files: 5 },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["test"],
+  };
+  writeFileSync(join(tmp, "contracts", "change.json"), JSON.stringify(contract));
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs --repo-root ${tmp} contracts/change.json`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("validate resolves contract relative to repoRoot", output.includes("OK: repo-policy.json"), true);
+    expect("validate contract passes schema check", output.includes("OK: contracts/change.json"), true);
+  } catch (e) {
+    const stderr = e.stderr || e.message || "";
+    expect("validate resolves contract relative to repoRoot (no ENOENT)", !stderr.includes("ENOENT"), true);
+    expect("validate resolves contract relative to repoRoot", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- check-diff resolves --contract path relative to repoRoot ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-contract-diff-"));
+  execSync("git init", { cwd: tmp });
+  execSync("git config user.email test@test.com && git config user.name Test", { cwd: tmp });
+
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+
+  mkdirSync(join(tmp, "contracts"));
+  const contract = {
+    change_type: "feature",
+    scope: ["**"],
+    budgets: { max_new_files: 5, max_net_added_lines: 500 },
+    must_touch: ["hello.txt"],
+    must_not_touch: [],
+    expected_effects: ["test"],
+  };
+  writeFileSync(join(tmp, "contracts", "change.json"), JSON.stringify(contract));
+
+  writeFileSync(join(tmp, "hello.txt"), "hello");
+  execSync("git add -A && git commit -m init", { cwd: tmp });
+
+  writeFileSync(join(tmp, "hello.txt"), "hello world");
+  execSync("git add -A && git commit -m second", { cwd: tmp });
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD --contract contracts/change.json`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("check-diff resolves --contract relative to repoRoot", output.includes("1 file(s) changed"), true);
+    expect("check-diff --contract passes with repoRoot", output.includes("0 failed"), true);
+  } catch (e) {
+    const stderr = e.stderr || e.message || "";
+    expect("check-diff resolves --contract relative to repoRoot (no ENOENT)", !stderr.includes("ENOENT"), true);
+    expect("check-diff resolves --contract relative to repoRoot", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
 // --- check-pr respects repo root via roots parameter ---
 
 {

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -1,0 +1,185 @@
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolveRoots } from "../src/repo-guard.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+// --- resolveRoots: default uses process.cwd() ---
+
+{
+  const roots = resolveRoots([]);
+  expect("default repoRoot is cwd", roots.repoRoot, process.cwd());
+  expect("packageRoot is project root", roots.packageRoot, projectRoot);
+  expect("args empty when no args given", roots.args.length, 0);
+}
+
+// --- resolveRoots: --repo-root override ---
+
+{
+  const roots = resolveRoots(["--repo-root", "/tmp/other-repo"]);
+  expect("--repo-root overrides repoRoot", roots.repoRoot, resolve("/tmp/other-repo"));
+  expect("--repo-root stripped from args", roots.args.length, 0);
+  expect("packageRoot unchanged with --repo-root", roots.packageRoot, projectRoot);
+}
+
+// --- resolveRoots: --repo-root mixed with other args ---
+
+{
+  const roots = resolveRoots(["--base", "main", "--repo-root", "/tmp/other", "--head", "dev"]);
+  expect("mixed args: repoRoot", roots.repoRoot, resolve("/tmp/other"));
+  expect("mixed args: filtered length", roots.args.length, 4);
+  expect("mixed args: --base preserved", roots.args[0], "--base");
+  expect("mixed args: main preserved", roots.args[1], "main");
+  expect("mixed args: --head preserved", roots.args[2], "--head");
+  expect("mixed args: dev preserved", roots.args[3], "dev");
+}
+
+// --- resolveRoots: packageRoot and repoRoot are independent ---
+
+{
+  const roots = resolveRoots(["--repo-root", "/tmp/target"]);
+  expect("packageRoot != repoRoot when --repo-root set",
+    roots.packageRoot !== roots.repoRoot, true);
+}
+
+// --- self-hosted mode: validate works when cwd is repo-guard ---
+
+{
+  try {
+    const output = execSync(`node src/repo-guard.mjs`, {
+      encoding: "utf-8",
+      cwd: projectRoot,
+    });
+    expect("self-hosted validate passes", output.includes("OK: repo-policy.json"), true);
+  } catch (e) {
+    expect("self-hosted validate passes", false, true);
+  }
+}
+
+// --- explicit --repo-root: validate loads policy from target repo ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-repo-root-"));
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs --repo-root ${tmp}`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("--repo-root validate loads external policy", output.includes("OK: repo-policy.json"), true);
+  } catch (e) {
+    expect("--repo-root validate loads external policy", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- schemas still load from package assets, not from --repo-root ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-repo-root-"));
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs --repo-root ${tmp}`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("schemas load from package (no schemas/ in target)", output.includes("OK: repo-policy.json"), true);
+  } catch (e) {
+    expect("schemas load from package (no schemas/ in target)", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- check-diff with --repo-root uses target repo git ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-repo-root-"));
+  execSync("git init", { cwd: tmp });
+  execSync("git config user.email test@test.com && git config user.name Test", { cwd: tmp });
+
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+  writeFileSync(join(tmp, "hello.txt"), "hello");
+  execSync("git add -A && git commit -m init", { cwd: tmp });
+
+  writeFileSync(join(tmp, "world.txt"), "world");
+  execSync("git add -A && git commit -m second", { cwd: tmp });
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("check-diff --repo-root uses target git", output.includes("1 file(s) changed"), true);
+    expect("check-diff --repo-root passes", output.includes("0 failed"), true);
+  } catch (e) {
+    expect("check-diff --repo-root uses target git", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- check-pr respects repo root via roots parameter ---
+
+{
+  const roots = resolveRoots(["--repo-root", "/tmp/some-repo"]);
+  expect("check-pr receives repoRoot through roots", roots.repoRoot, resolve("/tmp/some-repo"));
+  expect("check-pr receives packageRoot through roots", roots.packageRoot, projectRoot);
+}
+
+console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes #9

Introduces explicit separation of `packageRoot` (where schemas and package assets live) from `repoRoot` (the target repository being checked), removing the architectural assumption that `repo-guard` runs from its own package directory.

```repo-guard-json
{
  "change_type": "feature",
  "scope": ["src/**", "tests/**"],
  "budgets": {
    "max_new_files": 3,
    "max_new_docs": 0,
    "max_net_added_lines": 350
  },
  "must_touch": ["src/repo-guard.mjs", "src/github-pr.mjs"],
  "must_not_touch": ["schemas/"],
  "expected_effects": [
    "repo-guard can validate policy on external repos via --repo-root flag",
    "Schemas load from package assets, policy loads from target repo",
    "Contract file paths resolve relative to repoRoot, not process.cwd()",
    "All CLI modes use shared repo-root resolution model",
    "Backward-compatible self-hosted mode preserved"
  ]
}
```

### Key changes

- **`resolveRoots(args)`** — new exported function in `repo-guard.mjs` that parses `--repo-root <path>` from CLI args (defaults to `process.cwd()`) and returns `{ packageRoot, repoRoot, args }`
- **Schemas** load from `packageRoot`; **`repo-policy.json`** and **git operations** use `repoRoot`
- **Contract file paths** (`--contract` in `check-diff`, positional arg in `validate`) resolve relative to `repoRoot`, not `process.cwd()` — closes the last package-root leak
- All three CLI modes (`validate`, `check-diff`, `check-pr`) use the shared roots model
- `github-pr.mjs` no longer computes its own root — receives `roots` from the caller
- CLI dispatch is guarded with `isMain` check so `resolveRoots` can be imported without triggering the runner
- Version bumped to `0.5.0`

### Usage

```bash
# Self-hosted (same as before — uses cwd as repo root)
node src/repo-guard.mjs
node src/repo-guard.mjs check-diff

# Against another repository
node src/repo-guard.mjs --repo-root /path/to/other/repo
node src/repo-guard.mjs check-diff --repo-root /path/to/other/repo --base main --head feature
node src/repo-guard.mjs check-diff --repo-root /path/to/other/repo --contract contracts/change.json
node src/repo-guard.mjs check-pr --repo-root /path/to/other/repo
```

## Test plan

- [x] 24 tests in `tests/test-repo-root.mjs` covering:
  - Default `repoRoot` is `process.cwd()`
  - `--repo-root` override works and is stripped from remaining args
  - `packageRoot` remains unchanged regardless of `--repo-root`
  - Self-hosted validate still works
  - External `--repo-root` loads policy from target directory
  - Schemas load from package assets (not from target repo)
  - `check-diff --repo-root` uses target repo's git history
  - `check-pr` receives roots through shared model
  - **`validate` resolves contract path relative to `repoRoot`** (new)
  - **`check-diff --contract` resolves path relative to `repoRoot`** (new)
- [x] All existing tests continue to pass (schemas, diff-rules, contracts, github-pr)
- [x] Self-hosted `node src/repo-guard.mjs` validates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)