### PR TITLE
Make --repo-root a true global CLI option and fix pre-command argument parsing

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T20:40:34.991Z for PR creation at branch issue-15-a76a28847a58 for issue https://github.com/netkeep80/repo-guard/issues/15

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T20:40:34.991Z for PR creation at branch issue-15-a76a28847a58 for issue https://github.com/netkeep80/repo-guard/issues/15

--- a/README.md
+++ b/README.md
@@ -136,9 +136,20 @@ node src/repo-guard.mjs check-pr
 
 ### Использование в другом репозитории
 
+`--repo-root` — глобальный флаг, который можно ставить как до, так и после команды:
+
 ```bash
+# validate
 node src/repo-guard.mjs --repo-root /path/to/other/repo
+node src/repo-guard.mjs --repo-root /path/to/other/repo contract.json
+
+# check-diff (--repo-root до или после команды)
+node src/repo-guard.mjs --repo-root /path/to/other/repo check-diff --base main --head feature
 node src/repo-guard.mjs check-diff --repo-root /path/to/other/repo --base main --head feature
+
+# check-pr (--repo-root до или после команды)
+node src/repo-guard.mjs --repo-root /path/to/other/repo check-pr
+node src/repo-guard.mjs check-pr --repo-root /path/to/other/repo
 ```
 
 Флаг `--repo-root` указывает, где искать `repo-policy.json` и выполнять git-операции. Схемы загружаются из пакета `repo-guard`.

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -241,17 +241,24 @@ function runValidate(roots, args) {
 const isMain = process.argv[1] && resolve(process.argv[1]) === resolve(__dirname, "repo-guard.mjs");
 
 if (isMain) {
-  const command = process.argv[2];
+  const MODES = new Set(["check-diff", "check-pr"]);
+  const roots = resolveRoots(process.argv.slice(2));
+  const command = roots.args[0];
+
+  if (command && !MODES.has(command) && command.startsWith("-")) {
+    console.error(`Unknown option: ${command}`);
+    console.error("Usage: repo-guard [--repo-root <path>] [check-diff|check-pr] [options]");
+    process.exit(1);
+  }
 
   if (command === "check-diff") {
-    const roots = resolveRoots(process.argv.slice(3));
+    roots.args = roots.args.slice(1);
     runCheckDiff(roots, roots.args);
   } else if (command === "check-pr") {
-    const roots = resolveRoots(process.argv.slice(3));
+    roots.args = roots.args.slice(1);
     const { runCheckPR } = await import("./github-pr.mjs");
     runCheckPR(roots);
   } else {
-    const roots = resolveRoots(process.argv.slice(2));
     runValidate(roots, roots.args);
   }
 }

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -30,7 +30,13 @@ export function resolveRoots(args) {
   let repoRoot = process.cwd();
   const filtered = [];
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--repo-root" && args[i + 1]) {
+    if (args[i] === "--repo-root") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error("Error: --repo-root requires a path argument");
+        console.error("Usage: repo-guard [--repo-root <path>] [check-diff|check-pr] [options]");
+        process.exit(1);
+      }
       repoRoot = resolve(args[++i]);
     } else {
       filtered.push(args[i]);
@@ -95,6 +101,7 @@ function runCheckDiff(roots, args) {
   let contract = null;
   let base = null;
   let head = null;
+  const KNOWN_DIFF_OPTS = new Set(["--base", "--head", "--contract"]);
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--base" && args[i + 1]) base = args[++i];
@@ -106,6 +113,10 @@ function runCheckDiff(roots, args) {
       for (const w of warnReservedContractFields(contract)) {
         console.warn(`WARN: ${w}`);
       }
+    } else if (args[i].startsWith("-") && !KNOWN_DIFF_OPTS.has(args[i])) {
+      console.error(`Unknown option for check-diff: ${args[i]}`);
+      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>]");
+      process.exit(1);
     }
   }
 

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -454,5 +454,91 @@ function expect(label, actual, expected) {
   rmSync(tmp, { recursive: true });
 }
 
+// --- --repo-root without value produces clear error ---
+
+{
+  try {
+    execSync(
+      `node src/repo-guard.mjs --repo-root 2>&1`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("--repo-root without value exits with error", false, true);
+  } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    expect("--repo-root without value shows error", output.includes("--repo-root requires a path argument"), true);
+    expect("--repo-root without value shows usage hint", output.includes("Usage:"), true);
+  }
+}
+
+// --- --repo-root followed by flag (missing value) produces clear error ---
+
+{
+  try {
+    execSync(
+      `node src/repo-guard.mjs check-diff --repo-root --base HEAD~1 --head HEAD 2>&1`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("--repo-root --base exits with error", false, true);
+  } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    expect("--repo-root followed by flag shows error", output.includes("--repo-root requires a path argument"), true);
+  }
+}
+
+// --- unknown option in check-diff mode produces clear error ---
+
+{
+  try {
+    execSync(
+      `node src/repo-guard.mjs check-diff --hed HEAD 2>&1`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("unknown check-diff option exits with error", false, true);
+  } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    expect("unknown check-diff option shows error message", output.includes("Unknown option for check-diff: --hed"), true);
+    expect("unknown check-diff option shows usage hint", output.includes("Usage:"), true);
+  }
+}
+
+// --- known check-diff options still work (no false positive) ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-known-opts-"));
+  execSync("git init", { cwd: tmp });
+  execSync("git config user.email test@test.com && git config user.name Test", { cwd: tmp });
+
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+  writeFileSync(join(tmp, "a.txt"), "a");
+  execSync("git add -A && git commit -m init", { cwd: tmp });
+
+  writeFileSync(join(tmp, "b.txt"), "b");
+  execSync("git add -A && git commit -m second", { cwd: tmp });
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("known check-diff options still accepted", output.includes("1 file(s) changed"), true);
+  } catch (e) {
+    expect("known check-diff options still accepted", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -301,7 +301,7 @@ function expect(label, actual, expected) {
   try {
     const result = execSync(
       `node src/repo-guard.mjs --repo-root ${tmp} check-pr 2>&1`,
-      { encoding: "utf-8", cwd: projectRoot }
+      { encoding: "utf-8", cwd: projectRoot, env: Object.fromEntries(Object.entries(process.env).filter(([k]) => k !== "GITHUB_EVENT_PATH")) }
     );
     const isCheckPR = result.includes("check-pr") && !result.includes("ENOENT");
     expect("pre-command --repo-root check-pr enters check-pr mode", isCheckPR, true);

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -280,5 +280,179 @@ function expect(label, actual, expected) {
   expect("check-pr receives packageRoot through roots", roots.packageRoot, projectRoot);
 }
 
+// --- pre-command --repo-root with check-pr (regression for issue #15) ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-precommand-pr-"));
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+
+  try {
+    const result = execSync(
+      `node src/repo-guard.mjs --repo-root ${tmp} check-pr 2>&1`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    const isCheckPR = result.includes("check-pr") && !result.includes("ENOENT");
+    expect("pre-command --repo-root check-pr enters check-pr mode", isCheckPR, true);
+  } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    const isCheckPR = output.includes("check-pr") && !output.includes("ENOENT");
+    expect("pre-command --repo-root check-pr enters check-pr mode", isCheckPR, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- pre-command --repo-root with check-diff ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-precommand-diff-"));
+  execSync("git init", { cwd: tmp });
+  execSync("git config user.email test@test.com && git config user.name Test", { cwd: tmp });
+
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+  writeFileSync(join(tmp, "hello.txt"), "hello");
+  execSync("git add -A && git commit -m init", { cwd: tmp });
+
+  writeFileSync(join(tmp, "world.txt"), "world");
+  execSync("git add -A && git commit -m second", { cwd: tmp });
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs --repo-root ${tmp} check-diff --base HEAD~1 --head HEAD`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("pre-command --repo-root check-diff works", output.includes("1 file(s) changed"), true);
+    expect("pre-command --repo-root check-diff passes", output.includes("0 failed"), true);
+  } catch (e) {
+    expect("pre-command --repo-root check-diff works", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- pre-command --repo-root with validate (positional contract) ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-precommand-validate-"));
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+
+  mkdirSync(join(tmp, "contracts"));
+  const contract = {
+    change_type: "feature",
+    scope: ["src/**"],
+    budgets: { max_new_files: 5 },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["test"],
+  };
+  writeFileSync(join(tmp, "contracts", "change.json"), JSON.stringify(contract));
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs --repo-root ${tmp} contracts/change.json`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("pre-command --repo-root validate with contract works", output.includes("OK: repo-policy.json"), true);
+    expect("pre-command --repo-root validate contract passes", output.includes("OK: contracts/change.json"), true);
+  } catch (e) {
+    const stderr = e.stderr || e.message || "";
+    expect("pre-command --repo-root validate with contract (no ENOENT)", !stderr.includes("ENOENT"), true);
+    expect("pre-command --repo-root validate with contract works", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
+// --- unknown option produces clear error ---
+
+{
+  try {
+    execSync(
+      `node src/repo-guard.mjs --unknown-flag 2>&1`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("unknown option exits with error", false, true);
+  } catch (e) {
+    const output = (e.stdout || "") + (e.stderr || "");
+    expect("unknown option shows error message", output.includes("Unknown option: --unknown-flag"), true);
+    expect("unknown option shows usage hint", output.includes("Usage:"), true);
+  }
+}
+
+// --- post-command --repo-root still works (backward compat) ---
+
+{
+  const tmp = mkdtempSync(join(tmpdir(), "rg-postcommand-"));
+  execSync("git init", { cwd: tmp });
+  execSync("git config user.email test@test.com && git config user.name Test", { cwd: tmp });
+
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
+  writeFileSync(join(tmp, "a.txt"), "a");
+  execSync("git add -A && git commit -m init", { cwd: tmp });
+
+  writeFileSync(join(tmp, "b.txt"), "b");
+  execSync("git add -A && git commit -m second", { cwd: tmp });
+
+  try {
+    const output = execSync(
+      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
+      { encoding: "utf-8", cwd: projectRoot }
+    );
+    expect("post-command --repo-root check-diff still works", output.includes("1 file(s) changed"), true);
+  } catch (e) {
+    expect("post-command --repo-root check-diff still works", false, true);
+  }
+
+  rmSync(tmp, { recursive: true });
+}
+
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes #15

- **Fix CLI parsing order**: extract `--repo-root` from all args before mode resolution, so both `--repo-root /repo check-pr` and `check-pr --repo-root /repo` work correctly
- **Validate `--repo-root` value**: missing or flag-like values (e.g. `--repo-root --base`) now produce a clear error instead of silently consuming the next flag
- **Reject unknown options in check-diff**: typos like `--hed` now produce a clear error with usage hint instead of being silently ignored
- **Add error diagnostics**: unknown CLI options at top level also produce clear error messages
- **Add regression tests**: 11 new tests covering pre-command `--repo-root` with all three modes, unknown option errors (top-level and check-diff), missing `--repo-root` value, and backward compatibility
- **Update README**: document `--repo-root` as a global flag with examples showing both pre- and post-command placement

## Root cause

In the original code, mode resolution checked `process.argv[2]` directly. When `--repo-root /path` appeared before the subcommand, `argv[2]` was `"--repo-root"` instead of `"check-pr"`, so the CLI fell into the validate else-branch and tried to open the subcommand name as a JSON file path.

## Fix

Changed the entry point to call `resolveRoots(process.argv.slice(2))` first (extracting `--repo-root` from the full arg list), then determine the mode from `roots.args[0]` (the first remaining non-flag argument). Added validation in `resolveRoots` to reject missing `--repo-root` values, and unknown-option guards in both top-level and `check-diff` argument parsing.

```repo-guard-json
{
  "change_type": "bugfix",
  "scope": ["src/**", "tests/**", "README.md"],
  "budgets": {
    "max_new_files": 0,
    "max_new_docs": 0,
    "max_net_added_lines": 350
  },
  "must_touch": ["src/repo-guard.mjs"],
  "must_not_touch": ["schemas/**", "repo-policy.json"],
  "expected_effects": [
    "--repo-root works as true global CLI option before any subcommand",
    "Missing --repo-root value produces clear error diagnostic",
    "Unknown CLI options in check-diff produce clear error diagnostics",
    "Regression tests prevent re-introduction of parsing bugs"
  ]
}
```

## Test plan

- [x] All existing tests pass (no regressions)
- [x] `node src/repo-guard.mjs --repo-root /repo check-pr` enters check-pr mode (was ENOENT)
- [x] `node src/repo-guard.mjs --repo-root /repo check-diff --base HEAD~1 --head HEAD` works
- [x] `node src/repo-guard.mjs --repo-root /repo contracts/change.json` works in validate mode
- [x] `node src/repo-guard.mjs check-diff --repo-root /repo` still works (backward compat)
- [x] `node src/repo-guard.mjs --unknown-flag` shows clear error message
- [x] `node src/repo-guard.mjs --repo-root` (no value) shows clear error
- [x] `node src/repo-guard.mjs check-diff --repo-root --base HEAD~1` shows clear error (missing value)
- [x] `node src/repo-guard.mjs check-diff --hed HEAD` shows clear error (unknown check-diff option)
- [x] All existing command forms unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)