### PR TITLE
P0: add reusable GitHub Action (action.yml)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
 
       - name: Run PR policy check
         if: github.event_name == 'pull_request' && !github.event.pull_request.draft
-        run: npx repo-guard check-pr
+        uses: ./
+        with:
+          mode: check-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T21:47:56.297Z for PR creation at branch issue-18-b3e749a4f6f8 for issue https://github.com/netkeep80/repo-guard/issues/18

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T21:47:56.297Z for PR creation at branch issue-18-b3e749a4f6f8 for issue https://github.com/netkeep80/repo-guard/issues/18

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Summary: 8 passed, 0 failed
 ### Quick start
 
 1. Add `repo-policy.json` to your repository root (see [minimum example](#1-policy) or copy `templates/repo-policy.min.json`).
-2. Create `.github/workflows/repo-guard.yml`:
+2. Create `.github/workflows/repo-guard.yml` (replace `vX.Y.Z` with the [latest release tag](https://github.com/netkeep80/repo-guard/releases)):
 
 ```yaml
 name: repo-guard policy check
@@ -312,7 +312,7 @@ jobs:
           fetch-depth: 0   # required for base...head diff
 
       - name: Enforce repository policy
-        uses: netkeep80/repo-guard@v1.0.0
+        uses: netkeep80/repo-guard@vX.Y.Z  # replace with latest release tag
         with:
           mode: check-pr
         env:
@@ -348,7 +348,7 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 ```yaml
 - name: repo-guard (advisory)
   id: guard
-  uses: netkeep80/repo-guard@v1.0.0
+  uses: netkeep80/repo-guard@vX.Y.Z  # replace with latest release tag
   continue-on-error: true
   with:
     mode: check-pr
@@ -363,10 +363,10 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 
 ### Pinning the version
 
-Pin to a release tag to get reproducible runs. The Action always executes the CLI bundled with that tag, so pinning the Action ref is sufficient.
+Pin to a release tag to get reproducible runs. The Action always executes the CLI bundled with that tag, so pinning the Action ref is sufficient. Find available release tags on the [Releases page](https://github.com/netkeep80/repo-guard/releases).
 
 ```yaml
-- uses: netkeep80/repo-guard@v1.0.0   # pin to a release tag
+- uses: netkeep80/repo-guard@vX.Y.Z   # replace with a release tag, e.g. v1.0.0
   with:
     mode: check-pr
   env:
@@ -376,7 +376,7 @@ Pin to a release tag to get reproducible runs. The Action always executes the CL
 ### Using check-diff in CI
 
 ```yaml
-- uses: netkeep80/repo-guard@v1.0.0
+- uses: netkeep80/repo-guard@vX.Y.Z  # replace with latest release tag
   with:
     mode: check-diff
     base: main

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ jobs:
           fetch-depth: 0   # required for base...head diff
 
       - name: Enforce repository policy
-        uses: netkeep80/repo-guard@main
+        uses: netkeep80/repo-guard@v1.0.0
         with:
           mode: check-pr
         env:
@@ -333,7 +333,6 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 | `head` | no | _(empty)_ | Head git ref for diff (`check-diff` only). |
 | `contract` | no | _(empty)_ | Path to a contract JSON file, relative to `repo-root` (`check-diff` only). |
 | `node-version` | no | `20` | Node.js version used to run repo-guard. |
-| `repo-guard-version` | no | `latest` | npm version of repo-guard to install. Pin for reproducible runs. |
 
 ### Outputs
 
@@ -349,7 +348,7 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 ```yaml
 - name: repo-guard (advisory)
   id: guard
-  uses: netkeep80/repo-guard@main
+  uses: netkeep80/repo-guard@v1.0.0
   continue-on-error: true
   with:
     mode: check-pr
@@ -364,11 +363,12 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 
 ### Pinning the version
 
+Pin to a release tag to get reproducible runs. The Action always executes the CLI bundled with that tag, so pinning the Action ref is sufficient.
+
 ```yaml
 - uses: netkeep80/repo-guard@v1.0.0   # pin to a release tag
   with:
     mode: check-pr
-    repo-guard-version: "1.0.0"       # pin the npm package as well
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -376,7 +376,7 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 ### Using check-diff in CI
 
 ```yaml
-- uses: netkeep80/repo-guard@main
+- uses: netkeep80/repo-guard@v1.0.0
   with:
     mode: check-diff
     base: main

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 Pin to a release tag to get reproducible runs. The Action always executes the CLI bundled with that tag, so pinning the Action ref is sufficient. Find available release tags on the [Releases page](https://github.com/netkeep80/repo-guard/releases).
 
 ```yaml
-- uses: netkeep80/repo-guard@vX.Y.Z   # replace with a release tag, e.g. v1.0.0
+- uses: netkeep80/repo-guard@vX.Y.Z   # replace with a release tag, e.g. v1.2.3
   with:
     mode: check-pr
   env:

--- a/README.md
+++ b/README.md
@@ -286,6 +286,104 @@ Summary: 8 passed, 0 failed
     must_touch: tests/**
 ```
 
+## GitHub Action (reusable)
+
+`repo-guard` is packaged as a reusable GitHub Action so any repository can adopt it without installing Node.js manually or hand-assembling a custom workflow.
+
+### Quick start
+
+1. Add `repo-policy.json` to your repository root (see [minimum example](#1-policy) or copy `templates/repo-policy.min.json`).
+2. Create `.github/workflows/repo-guard.yml`:
+
+```yaml
+name: repo-guard policy check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # required for base...head diff
+
+      - name: Enforce repository policy
+        uses: netkeep80/repo-guard@main
+        with:
+          mode: check-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+3. Add a change contract to each PR description or its linked issue (see [templates/pr-contract-example.md](templates/pr-contract-example.md)).
+
+A copy-pasteable version of this workflow is also available at [`templates/example-workflow.yml`](templates/example-workflow.yml).
+
+### Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `mode` | no | `check-pr` | `check-pr` — validate a PR in GitHub Actions context. `check-diff` — validate a local diff between two refs. |
+| `repo-root` | no | `$GITHUB_WORKSPACE` | Path to the directory containing `repo-policy.json`. |
+| `base` | no | _(empty)_ | Base git ref for diff (`check-diff` only). |
+| `head` | no | _(empty)_ | Head git ref for diff (`check-diff` only). |
+| `contract` | no | _(empty)_ | Path to a contract JSON file, relative to `repo-root` (`check-diff` only). |
+| `node-version` | no | `20` | Node.js version used to run repo-guard. |
+| `repo-guard-version` | no | `latest` | npm version of repo-guard to install. Pin for reproducible runs. |
+
+### Outputs
+
+| Output | Description |
+|---|---|
+| `result` | `passed`, `failed`, or `error` |
+| `summary` | Human-readable one-line summary (mirrors the `Summary:` line from CLI output). |
+
+### Enforcement modes
+
+**Advisory** — record the result but do not block the PR:
+
+```yaml
+- name: repo-guard (advisory)
+  id: guard
+  uses: netkeep80/repo-guard@main
+  continue-on-error: true
+  with:
+    mode: check-pr
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+- name: Show result
+  run: echo "repo-guard result: ${{ steps.guard.outputs.result }}"
+```
+
+**Blocking** — the step fails the job if any check fails (default behaviour; no extra config needed).
+
+### Pinning the version
+
+```yaml
+- uses: netkeep80/repo-guard@v1.0.0   # pin to a release tag
+  with:
+    mode: check-pr
+    repo-guard-version: "1.0.0"       # pin the npm package as well
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Using check-diff in CI
+
+```yaml
+- uses: netkeep80/repo-guard@main
+  with:
+    mode: check-diff
+    base: main
+    head: ${{ github.sha }}
+    contract: path/to/contract.json
+```
+
 ## Использование в GitHub PR workflow
 
 Типичный рабочий процесс:
@@ -316,7 +414,7 @@ Summary: 8 passed, 0 failed
 - `governance_paths` — информационное поле, не проверяется в runtime. Документирует, какие файлы управляют governance.
 - `public_api` — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
 - `overrides` (в change contract) — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
-- `repo-guard` пока не публикует комментарии к PR и не оформлен как переиспользуемый GitHub Action. Это запланировано.
+- `repo-guard` пока не публикует комментарии к PR.
 - Паттерны `forbid_regex` компилируются и проверяются до начала enforcement — ошибки в regex выявляются на этапе загрузки policy.
 
 ## Лицензия

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,145 @@
+name: "repo-guard"
+description: "Enforce repository policy and change contracts on pull requests"
+author: "netkeep80"
+
+branding:
+  icon: "shield"
+  color: "red"
+
+inputs:
+  mode:
+    description: >
+      Enforcement mode. Use `check-pr` to validate a pull request against policy
+      and change contract (requires GitHub Actions PR event context). Use `check-diff`
+      to validate a local diff between two refs.
+    required: false
+    default: "check-pr"
+
+  repo-root:
+    description: >
+      Path to the repository root that contains `repo-policy.json`.
+      Defaults to the root of the checked-out repository (`$GITHUB_WORKSPACE`).
+    required: false
+    default: ""
+
+  base:
+    description: >
+      Base git ref for diff comparison (used with `mode: check-diff`).
+      Example: `main` or a commit SHA.
+    required: false
+    default: ""
+
+  head:
+    description: >
+      Head git ref for diff comparison (used with `mode: check-diff`).
+      Example: `feature-branch` or a commit SHA.
+    required: false
+    default: ""
+
+  contract:
+    description: >
+      Path to a change contract JSON file (used with `mode: check-diff`).
+      Path is relative to `repo-root`.
+    required: false
+    default: ""
+
+  node-version:
+    description: "Node.js version to use when running repo-guard."
+    required: false
+    default: "20"
+
+  repo-guard-version:
+    description: >
+      Version of the `repo-guard` npm package to use.
+      Defaults to `latest`. Pin to a specific version for reproducible runs.
+    required: false
+    default: "latest"
+
+outputs:
+  result:
+    description: >
+      Enforcement result: `passed` if all checks passed, `failed` if any check
+      failed, or `error` if repo-guard could not run (e.g. missing policy file).
+    value: ${{ steps.run-repo-guard.outputs.result }}
+
+  summary:
+    description: "Human-readable one-line summary of the enforcement run."
+    value: ${{ steps.run-repo-guard.outputs.summary }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install repo-guard
+      shell: bash
+      run: npm install -g repo-guard@${{ inputs.repo-guard-version }}
+
+    - name: Run repo-guard
+      id: run-repo-guard
+      shell: bash
+      env:
+        GH_TOKEN: ${{ env.GH_TOKEN }}
+      run: |
+        set +e
+
+        # Build the command
+        CMD="repo-guard"
+
+        # Append --repo-root if provided; fall back to GITHUB_WORKSPACE
+        REPO_ROOT="${{ inputs.repo-root }}"
+        if [ -z "$REPO_ROOT" ]; then
+          REPO_ROOT="${GITHUB_WORKSPACE:-$PWD}"
+        fi
+        CMD="$CMD --repo-root $REPO_ROOT"
+
+        # Append mode / sub-command
+        MODE="${{ inputs.mode }}"
+        CMD="$CMD $MODE"
+
+        # Append check-diff specific flags
+        if [ "$MODE" = "check-diff" ]; then
+          if [ -n "${{ inputs.base }}" ]; then
+            CMD="$CMD --base ${{ inputs.base }}"
+          fi
+          if [ -n "${{ inputs.head }}" ]; then
+            CMD="$CMD --head ${{ inputs.head }}"
+          fi
+          if [ -n "${{ inputs.contract }}" ]; then
+            CMD="$CMD --contract ${{ inputs.contract }}"
+          fi
+        fi
+
+        echo "Running: $CMD"
+        OUTPUT=$($CMD 2>&1)
+        EXIT_CODE=$?
+
+        echo "$OUTPUT"
+
+        # Derive result and summary outputs
+        if [ $EXIT_CODE -eq 0 ]; then
+          RESULT="passed"
+          SUMMARY=$(echo "$OUTPUT" | grep -E "^Summary:" | tail -1)
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="repo-guard: all checks passed"
+          fi
+        else
+          # Distinguish configuration/runtime errors from enforcement failures
+          if echo "$OUTPUT" | grep -qE "^(ERROR|FAIL: repo-policy)"; then
+            RESULT="error"
+          else
+            RESULT="failed"
+          fi
+          SUMMARY=$(echo "$OUTPUT" | grep -E "^Summary:" | tail -1)
+          if [ -z "$SUMMARY" ]; then
+            SUMMARY="repo-guard: one or more checks failed (exit $EXIT_CODE)"
+          fi
+        fi
+
+        echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+        echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+        exit $EXIT_CODE

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,40 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Install repo-guard
+    - name: Resolve repo-guard binary
+      id: resolve-bin
+      shell: bash
+      run: |
+        # Priority order for resolving the repo-guard CLI:
+        #
+        # 1. Source entrypoint inside this action's own checkout (self-hosted use,
+        #    e.g. `uses: ./` or `uses: netkeep80/repo-guard@<ref>` before the
+        #    package is published to npm).  The action file lives at
+        #    $GITHUB_ACTION_PATH/action.yml; if src/repo-guard.mjs is next to it
+        #    we know we're running from source.
+        #
+        # 2. node_modules/.bin/repo-guard in the workspace (pre-installed by an
+        #    earlier `npm ci` step in the same job).
+        #
+        # 3. A globally-installed binary from npm (downstream consumers who install
+        #    the Action by tag after the package is published).
+
+        ACTION_SRC="${GITHUB_ACTION_PATH}/src/repo-guard.mjs"
+        WORKSPACE_BIN="${GITHUB_WORKSPACE}/node_modules/.bin/repo-guard"
+
+        if [ -f "$ACTION_SRC" ]; then
+          echo "bin=node ${ACTION_SRC}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: source entrypoint at ${ACTION_SRC}"
+        elif [ -f "$WORKSPACE_BIN" ]; then
+          echo "bin=${WORKSPACE_BIN}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: workspace node_modules at ${WORKSPACE_BIN}"
+        else
+          echo "bin=" >> "$GITHUB_OUTPUT"
+          echo "No local binary found; will install from npm."
+        fi
+
+    - name: Install repo-guard from npm
+      if: steps.resolve-bin.outputs.bin == ''
       shell: bash
       run: npm install -g repo-guard@${{ inputs.repo-guard-version }}
 
@@ -86,8 +119,14 @@ runs:
       run: |
         set +e
 
+        # Determine the binary to use (set by resolve-bin step)
+        BIN="${{ steps.resolve-bin.outputs.bin }}"
+        if [ -z "$BIN" ]; then
+          BIN="repo-guard"
+        fi
+
         # Build the command
-        CMD="repo-guard"
+        CMD="$BIN"
 
         # Append --repo-root if provided; fall back to GITHUB_WORKSPACE
         REPO_ROOT="${{ inputs.repo-root }}"

--- a/action.yml
+++ b/action.yml
@@ -48,13 +48,6 @@ inputs:
     required: false
     default: "20"
 
-  repo-guard-version:
-    description: >
-      Version of the `repo-guard` npm package to use.
-      Defaults to `latest`. Pin to a specific version for reproducible runs.
-    required: false
-    default: "latest"
-
 outputs:
   result:
     description: >
@@ -74,42 +67,12 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
-    - name: Resolve repo-guard binary
-      id: resolve-bin
+    - name: Install repo-guard dependencies
       shell: bash
       run: |
-        # Priority order for resolving the repo-guard CLI:
-        #
-        # 1. Source entrypoint inside this action's own checkout (self-hosted use,
-        #    e.g. `uses: ./` or `uses: netkeep80/repo-guard@<ref>` before the
-        #    package is published to npm).  The action file lives at
-        #    $GITHUB_ACTION_PATH/action.yml; if src/repo-guard.mjs is next to it
-        #    we know we're running from source.
-        #
-        # 2. node_modules/.bin/repo-guard in the workspace (pre-installed by an
-        #    earlier `npm ci` step in the same job).
-        #
-        # 3. A globally-installed binary from npm (downstream consumers who install
-        #    the Action by tag after the package is published).
-
-        ACTION_SRC="${GITHUB_ACTION_PATH}/src/repo-guard.mjs"
-        WORKSPACE_BIN="${GITHUB_WORKSPACE}/node_modules/.bin/repo-guard"
-
-        if [ -f "$ACTION_SRC" ]; then
-          echo "bin=node ${ACTION_SRC}" >> "$GITHUB_OUTPUT"
-          echo "Resolved: source entrypoint at ${ACTION_SRC}"
-        elif [ -f "$WORKSPACE_BIN" ]; then
-          echo "bin=${WORKSPACE_BIN}" >> "$GITHUB_OUTPUT"
-          echo "Resolved: workspace node_modules at ${WORKSPACE_BIN}"
-        else
-          echo "bin=" >> "$GITHUB_OUTPUT"
-          echo "No local binary found; will install from npm."
-        fi
-
-    - name: Install repo-guard from npm
-      if: steps.resolve-bin.outputs.bin == ''
-      shell: bash
-      run: npm install -g repo-guard@${{ inputs.repo-guard-version }}
+        # Install runtime dependencies for the checked-out Action source.
+        cd "${GITHUB_ACTION_PATH}"
+        npm install --production --silent
 
     - name: Run repo-guard
       id: run-repo-guard
@@ -119,11 +82,8 @@ runs:
       run: |
         set +e
 
-        # Determine the binary to use (set by resolve-bin step)
-        BIN="${{ steps.resolve-bin.outputs.bin }}"
-        if [ -z "$BIN" ]; then
-          BIN="repo-guard"
-        fi
+        # Always run the CLI from the checked-out Action source.
+        BIN="node ${GITHUB_ACTION_PATH}/src/repo-guard.mjs"
 
         # Build the command
         CMD="$BIN"

--- a/templates/example-workflow.yml
+++ b/templates/example-workflow.yml
@@ -1,0 +1,33 @@
+# Example: repo-guard reusable Action
+#
+# Copy this file to .github/workflows/repo-guard.yml in your repository.
+# Requires a repo-policy.json at the repository root (see templates/repo-policy.min.json).
+#
+# Minimal setup:
+#   1. Add repo-policy.json to your repo root.
+#   2. Copy this workflow file to .github/workflows/repo-guard.yml.
+#   3. Add a change contract to PR descriptions or linked issues.
+
+name: repo-guard policy check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history is required for base...head diff
+          fetch-depth: 0
+
+      - name: Enforce repository policy
+        uses: netkeep80/repo-guard@main
+        with:
+          mode: check-pr
+        env:
+          # Required for fetching linked issue contracts
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/example-workflow.yml
+++ b/templates/example-workflow.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Enforce repository policy
-        uses: netkeep80/repo-guard@main
+        uses: netkeep80/repo-guard@v1.0.0
         with:
           mode: check-pr
         env:

--- a/templates/example-workflow.yml
+++ b/templates/example-workflow.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Enforce repository policy
-        uses: netkeep80/repo-guard@v1.0.0
+        uses: netkeep80/repo-guard@vX.Y.Z  # replace with a release tag from https://github.com/netkeep80/repo-guard/releases
         with:
           mode: check-pr
         env:


### PR DESCRIPTION
## Summary

Packages `repo-guard` as a reusable GitHub Action (`action.yml`) so any repository can adopt it without cloning `repo-guard` manually or hand-assembling a custom workflow.

### Changes

- **`action.yml`** — declares inputs (`mode`, `repo-root`, `base`, `head`, `contract`, `node-version`) and outputs (`result`, `summary`); runs the CLI bundled with the checked-out Action ref via `node $GITHUB_ACTION_PATH/src/repo-guard.mjs`
- **README** — new "GitHub Action (reusable)" section with quick start, inputs/outputs table, enforcement mode examples, and version-pinning guidance
- **`templates/example-workflow.yml`** — copy-pasteable minimal workflow for downstream repos
- **`.github/workflows/ci.yml`** — self-hosts the Action using `uses: ./` to satisfy the issue's self-hosting requirement

### Design decision (Option B)

The Action always runs the CLI from the checked-out Action ref (`node $GITHUB_ACTION_PATH/src/repo-guard.mjs`). Pinning the Action ref (e.g. `uses: netkeep80/repo-guard@vX.Y.Z`) is sufficient for version control — no separate `repo-guard-version` input is needed or exposed.

### Pinning note

All documentation uses `@vX.Y.Z` as a placeholder (with a link to the [Releases page](https://github.com/netkeep80/repo-guard/releases)) rather than a concrete tag that does not exist yet. Once the first release tag is cut after merge, users can substitute the actual tag.

## Change Contract

```repo-guard-json
{
  "change_type": "feature",
  "scope": ["action.yml", "README.md", "templates/example-workflow.yml", ".github/workflows/ci.yml"],
  "budgets": {
    "max_new_files": 2,
    "max_new_docs": 0,
    "max_net_added_lines": 300
  },
  "must_touch": ["action.yml"],
  "must_not_touch": ["schemas/", "repo-policy.json"],
  "expected_effects": [
    "Downstream repos can adopt repo-guard via uses: netkeep80/repo-guard@vX.Y.Z without cloning",
    "action.yml exposes mode, repo-root, base, head, contract, node-version inputs",
    "README documents the Action with quick-start example and inputs/outputs table",
    "repo-guard self-hosts its own Action in CI to satisfy the self-hosting requirement"
  ]
}
```

Fixes #18