### PR TITLE
Add advisory enforcement mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   validate:
+    # repo-guard's own CI is intentionally blocking: this job protects the
+    # package, schemas, and reusable Action behavior before changes can merge.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,14 +53,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run PR policy check
+        # Self-host repo-guard in blocking mode once a PR is ready for review.
+        # Draft PRs stay unblocked so work-in-progress branches can iterate.
         if: github.event_name == 'pull_request' && !github.event.pull_request.draft
         uses: ./
         with:
           mode: check-pr
+          enforcement: blocking
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   smoke-pack:
+    # Packaging smoke tests are blocking because downstream users pin released
+    # artifacts and need the installable tarball to match the source tree.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-16T06:30:38.265Z for PR creation at branch issue-21-9eb157b625b9 for issue https://github.com/netkeep80/repo-guard/issues/21

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-16T06:30:38.265Z for PR creation at branch issue-21-9eb157b625b9 for issue https://github.com/netkeep80/repo-guard/issues/21

--- a/README.md
+++ b/README.md
@@ -122,11 +122,13 @@ repo-guard init --preset documentation
 #### Режим enforcement
 
 ```bash
-repo-guard init --mode enforce    # по умолчанию — строгие бюджеты
-repo-guard init --mode advisory   # ослабленные бюджеты (50 файлов, 10 docs, 5000 строк)
+repo-guard init --mode enforce    # по умолчанию — blocking enforcement
+repo-guard init --mode advisory   # non-blocking advisory enforcement
 ```
 
-Режим `advisory` удобен для начала: бюджеты значительно расширены (50 файлов, 10 docs, 5000 строк), что снижает вероятность блокировки PR. Workflow по-прежнему запускается и сообщает о нарушениях, но широкие лимиты позволяют освоиться с repo-guard до перехода на строгий `enforce`.
+Режим `advisory` удобен для начала: `repo-guard` по-прежнему запускает все проверки и сообщает о нарушениях, но завершает policy run с exit code `0`, чтобы CI не блокировал PR из-за policy violations. Режим `enforce` является alias для `blocking`: нарушения policy приводят к exit code `1`.
+
+Бюджеты policy одинаково применяются в обоих режимах. Разница только в exit semantics и summary messaging.
 
 #### Использование с --repo-root
 
@@ -182,6 +184,12 @@ repo-guard check-diff --base main --head feature
 
 # Проверить diff с change contract
 repo-guard check-diff --contract path/to/contract.json
+
+# Наблюдать нарушения без падения job
+repo-guard --enforcement advisory check-diff --base main --head feature
+
+# Явно включить blocking mode (default)
+repo-guard --enforcement blocking check-diff --base main --head feature
 ```
 
 ### Проверка PR (в GitHub Actions)
@@ -195,6 +203,34 @@ repo-guard check-pr
 - `git` CLI с достаточной глубиной fetch для base...head diff;
 - `gh` CLI с авторизацией (для fallback на linked issue);
 - event payload типа `pull_request` с base/head SHA.
+
+### Advisory vs blocking
+
+`repo-guard` separates command mode (`check-pr`, `check-diff`) from enforcement behavior:
+
+| Enforcement | Aliases | Exit behavior |
+|---|---|---|
+| `advisory` | `warn` | Policy violations are printed as `WARN` and the command exits `0`. |
+| `blocking` | `enforce` | Policy violations are printed as `FAIL` and the command exits `1`. |
+
+Set the behavior in invocation:
+
+```bash
+repo-guard --enforcement advisory check-pr
+repo-guard --enforcement blocking check-diff --base main --head feature
+```
+
+Or set a default in `repo-policy.json`:
+
+```json
+{
+  "enforcement": {
+    "mode": "advisory"
+  }
+}
+```
+
+CLI invocation wins over policy config. Advisory mode only makes policy violations non-blocking; setup/configuration errors such as invalid policy JSON, missing `git`, or missing GitHub Actions event context still fail.
 
 ### Диагностика окружения
 
@@ -294,6 +330,9 @@ node src/repo-guard.mjs
 {
   "policy_format_version": "0.1.0",
   "repository_kind": "application",
+  "enforcement": {
+    "mode": "blocking"
+  },
   "paths": {
     "forbidden": [],
     "canonical_docs": ["README.md"],
@@ -338,6 +377,8 @@ Contract говорит: это bugfix, который должен затрон
 
 ```
 OK: repo-policy.json
+Enforcement mode: blocking (policy violations are enforced; exit code is 1 when violations exist)
+  PASS: change-contract
 
 Diff analysis: 3 file(s) changed
   PASS: forbidden-paths
@@ -349,7 +390,8 @@ Diff analysis: 3 file(s) changed
   PASS: must-touch
   PASS: must-not-touch
 
-Summary: 8 passed, 0 failed
+Summary: 9 passed, 0 failed (mode: blocking; violations enforced)
+Result: passed (mode: blocking; exit code 0)
 ```
 
 ### 4. Пример failure
@@ -397,6 +439,7 @@ jobs:
         uses: netkeep80/repo-guard@vX.Y.Z  # replace with latest release tag
         with:
           mode: check-pr
+          enforcement: blocking
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -410,6 +453,7 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `mode` | no | `check-pr` | `check-pr` — validate a PR in GitHub Actions context. `check-diff` — validate a local diff between two refs. |
+| `enforcement` | no | `blocking` | `blocking`/`enforce` fails the job on policy violations. `advisory`/`warn` reports violations but exits successfully. |
 | `repo-root` | no | `$GITHUB_WORKSPACE` | Path to the directory containing `repo-policy.json`. |
 | `base` | no | _(empty)_ | Base git ref for diff (`check-diff` only). |
 | `head` | no | _(empty)_ | Head git ref for diff (`check-diff` only). |
@@ -431,9 +475,9 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 - name: repo-guard (advisory)
   id: guard
   uses: netkeep80/repo-guard@vX.Y.Z  # replace with latest release tag
-  continue-on-error: true
   with:
     mode: check-pr
+    enforcement: advisory
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -441,7 +485,19 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
   run: echo "repo-guard result: ${{ steps.guard.outputs.result }}"
 ```
 
-**Blocking** — the step fails the job if any check fails (default behaviour; no extra config needed).
+In advisory mode, the Action step exits successfully for policy violations, but `steps.guard.outputs.result` is still `failed` when checks found violations. Configuration/runtime errors still fail the step.
+
+**Blocking** — the step fails the job if any policy check fails (default behaviour):
+
+```yaml
+- name: repo-guard (blocking)
+  uses: netkeep80/repo-guard@vX.Y.Z
+  with:
+    mode: check-pr
+    enforcement: blocking
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
 
 ### Pinning the version
 
@@ -451,6 +507,7 @@ Pin to a release tag to get reproducible runs. The Action always executes the CL
 - uses: netkeep80/repo-guard@vX.Y.Z   # replace with a release tag, e.g. v1.2.3
   with:
     mode: check-pr
+    enforcement: blocking
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -461,6 +518,7 @@ Pin to a release tag to get reproducible runs. The Action always executes the CL
 - uses: netkeep80/repo-guard@vX.Y.Z  # replace with latest release tag
   with:
     mode: check-diff
+    enforcement: advisory
     base: main
     head: ${{ github.sha }}
     contract: path/to/contract.json
@@ -481,7 +539,7 @@ Pin to a release tag to get reproducible runs. The Action always executes the CL
 ```yaml
 - name: Run PR policy check
   if: github.event_name == 'pull_request' && !github.event.pull_request.draft
-  run: npx repo-guard check-pr
+  run: npx repo-guard --enforcement blocking check-pr
   env:
     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,19 @@ branding:
 inputs:
   mode:
     description: >
-      Enforcement mode. Use `check-pr` to validate a pull request against policy
+      Command mode. Use `check-pr` to validate a pull request against policy
       and change contract (requires GitHub Actions PR event context). Use `check-diff`
       to validate a local diff between two refs.
     required: false
     default: "check-pr"
+
+  enforcement:
+    description: >
+      Policy enforcement behavior. `blocking`/`enforce` fails the job when
+      policy violations are found. `advisory`/`warn` reports violations but
+      exits successfully so teams can observe noise before enforcing.
+    required: false
+    default: "blocking"
 
   repo-root:
     description: >
@@ -52,7 +60,8 @@ outputs:
   result:
     description: >
       Enforcement result: `passed` if all checks passed, `failed` if any check
-      failed, or `error` if repo-guard could not run (e.g. missing policy file).
+      failed (including advisory violations), or `error` if repo-guard could not
+      run (e.g. missing policy file).
     value: ${{ steps.run-repo-guard.outputs.result }}
 
   summary:
@@ -95,7 +104,12 @@ runs:
         fi
         CMD="$CMD --repo-root $REPO_ROOT"
 
-        # Append mode / sub-command
+        # Append enforcement behavior and command mode / sub-command
+        ENFORCEMENT="${{ inputs.enforcement }}"
+        if [ -n "$ENFORCEMENT" ]; then
+          CMD="$CMD --enforcement $ENFORCEMENT"
+        fi
+
         MODE="${{ inputs.mode }}"
         CMD="$CMD $MODE"
 
@@ -118,10 +132,13 @@ runs:
 
         echo "$OUTPUT"
 
-        # Derive result and summary outputs
+        # Derive result and summary outputs. Advisory mode can exit 0 while
+        # still reporting policy violations, so prefer the CLI Result line.
+        CLI_RESULT=$(echo "$OUTPUT" | sed -nE 's/^Result: ([a-z]+).*/\1/p' | tail -1)
+        SUMMARY=$(echo "$OUTPUT" | grep -E "^Summary:" | tail -1)
+
         if [ $EXIT_CODE -eq 0 ]; then
-          RESULT="passed"
-          SUMMARY=$(echo "$OUTPUT" | grep -E "^Summary:" | tail -1)
+          RESULT="${CLI_RESULT:-passed}"
           if [ -z "$SUMMARY" ]; then
             SUMMARY="repo-guard: all checks passed"
           fi
@@ -130,9 +147,8 @@ runs:
           if echo "$OUTPUT" | grep -qE "^(ERROR|FAIL: repo-policy)"; then
             RESULT="error"
           else
-            RESULT="failed"
+            RESULT="${CLI_RESULT:-failed}"
           fi
-          SUMMARY=$(echo "$OUTPUT" | grep -E "^Summary:" | tail -1)
           if [ -z "$SUMMARY" ]; then
             SUMMARY="repo-guard: one or more checks failed (exit $EXIT_CODE)"
           fi

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
@@ -24,7 +24,8 @@
     "test:contract": "node tests/test-markdown-contract.mjs",
     "test:github-pr": "node tests/test-github-pr.mjs",
     "test:init": "node tests/test-init.mjs",
-    "test:doctor": "node tests/test-doctor.mjs"
+    "test:doctor": "node tests/test-doctor.mjs",
+    "test:enforcement": "node tests/test-enforcement-mode.mjs"
   },
   "keywords": [
     "repo-policy",

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -1,6 +1,9 @@
 {
   "policy_format_version": "0.3.0",
   "repository_kind": "tooling",
+  "enforcement": {
+    "mode": "blocking"
+  },
   "paths": {
     "forbidden": [
       "docs/phase-*",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -21,6 +21,19 @@
       "type": "string",
       "enum": ["library", "application", "tooling", "documentation"]
     },
+    "enforcement": {
+      "type": "object",
+      "required": ["mode"],
+      "additionalProperties": false,
+      "description": "Optional default enforcement behavior. CLI or Action invocation can override it.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["advisory", "blocking"],
+          "description": "advisory reports policy violations as warnings and exits 0; blocking enforces violations with exit 1."
+        }
+      }
+    },
     "paths": {
       "type": "object",
       "required": ["forbidden", "canonical_docs", "governance_paths"],

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -1,0 +1,116 @@
+const MODE_ALIASES = new Map([
+  ["advisory", "advisory"],
+  ["warn", "advisory"],
+  ["blocking", "blocking"],
+  ["enforce", "blocking"],
+]);
+
+export function normalizeEnforcementMode(value, label = "enforcement") {
+  const raw = String(value || "").trim().toLowerCase();
+  const mode = MODE_ALIASES.get(raw);
+  if (!mode) {
+    return {
+      ok: false,
+      message: `Unknown ${label}: ${value}. Must be one of: advisory, warn, blocking, enforce.`,
+    };
+  }
+  return { ok: true, mode };
+}
+
+export function resolveEnforcementMode({ cliValue, policy }) {
+  const policyValue = policy?.enforcement?.mode;
+  const raw = cliValue || policyValue || "blocking";
+  const source = cliValue ? "cli" : policyValue ? "policy" : "default";
+  const result = normalizeEnforcementMode(raw, "enforcement mode");
+  if (!result.ok) return result;
+  return { ok: true, mode: result.mode, source, requested: raw };
+}
+
+export function printEnforcementMode(enforcement) {
+  if (enforcement.mode === "advisory") {
+    console.log("Enforcement mode: advisory (policy violations are reported as warnings; exit code remains 0)");
+  } else {
+    console.log("Enforcement mode: blocking (policy violations are enforced; exit code is 1 when violations exist)");
+  }
+}
+
+function writeViolation(mode, message) {
+  if (mode === "advisory") {
+    console.warn(message);
+  } else {
+    console.error(message);
+  }
+}
+
+function printCheckDetails(mode, check) {
+  const write = (message) => writeViolation(mode, message);
+
+  if (check.message) {
+    write(`    ${check.message}`);
+  }
+  if (check.actual !== undefined) {
+    write(`    actual: ${check.actual}, limit: ${check.limit}`);
+  }
+  if (check.files) {
+    for (const f of check.files) write(`    - ${f}`);
+  }
+  if (check.touched) {
+    for (const f of check.touched) write(`    - ${f}`);
+  }
+  if (check.must_touch) {
+    write(`    must_touch: ${check.must_touch.join(", ")}`);
+  }
+  if (check.must_not_touch) {
+    write(`    must_not_touch: ${check.must_not_touch.join(", ")}`);
+  }
+  if (check.details) {
+    for (const detail of check.details) write(`    ${detail}`);
+  }
+  if (check.errors) {
+    for (const error of check.errors) write(`    ${error}`);
+  }
+  if (check.hint) {
+    write(`    hint: ${check.hint}`);
+  }
+}
+
+export function createCheckReporter(mode) {
+  let passed = 0;
+  let violations = 0;
+
+  return {
+    report(name, check) {
+      if (check.ok) {
+        passed++;
+        console.log(`  PASS: ${name}`);
+        return;
+      }
+
+      violations++;
+      const label = mode === "advisory" ? "WARN" : "FAIL";
+      writeViolation(mode, `  ${label}: ${name}`);
+      printCheckDetails(mode, check);
+    },
+
+    finish() {
+      const enforcedFailures = mode === "blocking" ? violations : 0;
+      const advisoryPart = mode === "advisory" ? `, ${violations} advisory violation(s)` : "";
+      const modePart = mode === "advisory" ? "violations reported as warnings" : "violations enforced";
+      const exitCode = enforcedFailures > 0 ? 1 : 0;
+      const result = violations > 0 ? "failed" : "passed";
+
+      console.log(`\nSummary: ${passed} passed, ${enforcedFailures} failed${advisoryPart} (mode: ${mode}; ${modePart})`);
+      console.log(`Result: ${result} (mode: ${mode}; exit code ${exitCode})`);
+
+      return { passed, violations, failed: enforcedFailures, exitCode };
+    },
+
+    get violations() {
+      return violations;
+    },
+  };
+}
+
+export function ajvErrors(errors) {
+  return (errors || []).map((err) => `${err.instancePath || "/"} ${err.message}`);
+}

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -9,6 +9,12 @@ import {
   warnReservedPolicyFields,
 } from "./policy-compiler.mjs";
 import {
+  ajvErrors,
+  createCheckReporter,
+  printEnforcementMode,
+  resolveEnforcementMode,
+} from "./enforcement.mjs";
+import {
   parseDiff,
   filterOperationalPaths,
   checkForbiddenPaths,
@@ -36,6 +42,18 @@ function validate(ajv, schema, data, label) {
   }
   console.log(`OK: ${label}`);
   return true;
+}
+
+function validationCheck(ajv, schema, data, label) {
+  const valid = ajv.validate(schema, data);
+  if (valid) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    message: `${label} failed schema validation`,
+    errors: ajvErrors(ajv.errors),
+  };
 }
 
 export function loadGitHubEvent() {
@@ -96,7 +114,15 @@ export function checkPrerequisites() {
   return missing;
 }
 
-export function runCheckPR(roots) {
+export function runCheckPR(roots, args = []) {
+  for (const arg of args) {
+    if (arg.startsWith("-")) {
+      console.error(`Unknown option for check-pr: ${arg}`);
+      console.error("Usage: repo-guard check-pr [--enforcement <advisory|blocking>]");
+      process.exit(1);
+    }
+  }
+
   const prereqs = checkPrerequisites();
   if (prereqs.length > 0) {
     console.error("ERROR: check-pr prerequisites not met:");
@@ -115,32 +141,6 @@ export function runCheckPR(roots) {
   const { base, head, prBody, prNumber, repoFullName } = eventInfo;
   console.log(`PR #${prNumber}: checking contract and diff (${base?.slice(0, 7)}..${head?.slice(0, 7)})`);
 
-  let issueBody = null;
-  const prResult = extractContract(prBody);
-  if (!prResult.ok && prResult.error === "contract_not_found") {
-    const linkedIssues = extractLinkedIssueNumbers(prBody);
-    if (linkedIssues.length > 1) {
-      console.error(`ERROR [issue_link_ambiguous]: PR body references ${linkedIssues.length} issues (${linkedIssues.map(n => `#${n}`).join(", ")}); expected exactly one`);
-      process.exit(1);
-    }
-    if (linkedIssues.length === 1) {
-      console.log(`No contract in PR body; trying linked issue #${linkedIssues[0]}...`);
-      issueBody = fetchIssueBody(repoFullName, linkedIssues[0]);
-      if (!issueBody) {
-        console.error(`ERROR: Could not fetch issue #${linkedIssues[0]} body`);
-      }
-    }
-  }
-
-  const contractResult = resolveContract(prBody, issueBody);
-  if (!contractResult.ok) {
-    console.error(`ERROR [${contractResult.error}]: ${contractResult.message}`);
-    process.exit(1);
-  }
-
-  const contract = contractResult.contract;
-  console.log("OK: change-contract extracted");
-
   const policySchema = loadJSON(resolve(roots.packageRoot, "schemas/repo-policy.schema.json"));
   const contractSchema = loadJSON(resolve(roots.packageRoot, "schemas/change-contract.schema.json"));
   const policy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
@@ -149,7 +149,6 @@ export function runCheckPR(roots) {
 
   let ok = true;
   ok = validate(ajv, policySchema, policy, "repo-policy.json") && ok;
-  ok = validate(ajv, contractSchema, contract, "change-contract (from markdown)") && ok;
 
   const regexErrors = compileForbidRegex(policy.content_rules);
   if (regexErrors.length > 0) {
@@ -163,13 +162,58 @@ export function runCheckPR(roots) {
   for (const w of warnReservedPolicyFields(policy)) {
     console.warn(`WARN: ${w}`);
   }
-  for (const w of warnReservedContractFields(contract)) {
-    console.warn(`WARN: ${w}`);
-  }
 
   if (!ok) {
     console.error("\nPolicy compilation failed");
     process.exit(1);
+  }
+
+  const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
+  if (!enforcement.ok) {
+    console.error(`ERROR: ${enforcement.message}`);
+    process.exit(1);
+  }
+  printEnforcementMode(enforcement);
+  const reporter = createCheckReporter(enforcement.mode);
+
+  let issueBody = null;
+  let contractFailure = null;
+  const prResult = extractContract(prBody);
+  if (!prResult.ok && prResult.error === "contract_not_found") {
+    const linkedIssues = extractLinkedIssueNumbers(prBody);
+    if (linkedIssues.length > 1) {
+      contractFailure = {
+        error: "issue_link_ambiguous",
+        message: `PR body references ${linkedIssues.length} issues (${linkedIssues.map(n => `#${n}`).join(", ")}); expected exactly one`,
+      };
+    } else if (linkedIssues.length === 1) {
+      console.log(`No contract in PR body; trying linked issue #${linkedIssues[0]}...`);
+      issueBody = fetchIssueBody(repoFullName, linkedIssues[0]);
+      if (!issueBody) {
+        contractFailure = {
+          error: "issue_fetch_failed",
+          message: `Could not fetch issue #${linkedIssues[0]} body`,
+        };
+      }
+    }
+  }
+
+  const contractResult = contractFailure || resolveContract(prBody, issueBody);
+  let contract = null;
+  if (!contractResult.ok) {
+    reporter.report("change-contract", {
+      ok: false,
+      message: `[${contractResult.error}]: ${contractResult.message}`,
+    });
+  } else {
+    const contractCheck = validationCheck(ajv, contractSchema, contractResult.contract, "change-contract (from markdown)");
+    reporter.report("change-contract", contractCheck);
+    if (contractCheck.ok) {
+      contract = contractResult.contract;
+      for (const w of warnReservedContractFields(contract)) {
+        console.warn(`WARN: ${w}`);
+      }
+    }
   }
 
   const diffText = execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: roots.repoRoot });
@@ -179,78 +223,48 @@ export function runCheckPR(roots) {
   const skipped = allFiles.length - files.length;
   console.log(`\nDiff analysis: ${allFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
 
-  let passed = 0;
-  let failed = 0;
-
-  function report(name, check) {
-    if (check.ok) {
-      passed++;
-      console.log(`  PASS: ${name}`);
-    } else {
-      failed++;
-      ok = false;
-      console.error(`  FAIL: ${name}`);
-      if (check.actual !== undefined) {
-        console.error(`    actual: ${check.actual}, limit: ${check.limit}`);
-      }
-      if (check.files) {
-        for (const f of check.files) console.error(`    - ${f}`);
-      }
-      if (check.touched) {
-        for (const f of check.touched) console.error(`    - ${f}`);
-      }
-      if (check.must_touch) {
-        console.error(`    must_touch: ${check.must_touch.join(", ")}`);
-      }
-      if (check.hint) {
-        console.error(`    hint: ${check.hint}`);
-      }
-    }
-  }
-
   const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
-  report("forbidden-paths", {
+  reporter.report("forbidden-paths", {
     ok: forbiddenViolations.length === 0,
     files: forbiddenViolations,
   });
 
-  const budgets = contract.budgets || {};
+  const budgets = contract?.budgets || {};
   const maxNewDocs = budgets.max_new_docs ?? policy.diff_rules.max_new_docs;
   const maxNewFiles = budgets.max_new_files ?? policy.diff_rules.max_new_files;
   const maxNetAddedLines = budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines;
 
-  report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
-  report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
-  report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+  reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
+  reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
+  reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
 
   const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
   if (cochangeViolations.length > 0) {
     for (const v of cochangeViolations) {
-      report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
+      reporter.report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
         ok: false,
         must_touch: v.must_change_any,
       });
     }
   } else {
-    report("cochange-rules", { ok: true });
+    reporter.report("cochange-rules", { ok: true });
   }
 
   const contentViolations = checkContentRules(files, policy.content_rules);
   if (contentViolations.length > 0) {
-    ok = false;
-    failed++;
-    console.error("  FAIL: content-rules");
-    for (const v of contentViolations) {
-      console.error(`    [${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`);
-    }
+    reporter.report("content-rules", {
+      ok: false,
+      details: contentViolations.map((v) => `[${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`),
+    });
   } else {
-    passed++;
-    console.log("  PASS: content-rules");
+    reporter.report("content-rules", { ok: true });
   }
 
-  report("must-touch", checkMustTouch(files, contract.must_touch));
-  report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
+  if (contract) {
+    reporter.report("must-touch", checkMustTouch(files, contract.must_touch));
+    reporter.report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
+  }
 
-  console.log(`\nSummary: ${passed} passed, ${failed} failed`);
-  process.exit(ok ? 0 : 1);
+  const summary = reporter.finish();
+  process.exit(summary.exitCode);
 }

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { resolve, relative, dirname } from "node:path";
+import { normalizeEnforcementMode } from "./enforcement.mjs";
 
 const PRESETS = {
   application: {
@@ -48,20 +49,20 @@ const PRESETS = {
   },
 };
 
-const ADVISORY_OVERRIDES = {
-  diff_rules: { max_new_docs: 10, max_new_files: 50, max_net_added_lines: 5000 },
-};
-
-function buildPolicy(preset, mode) {
+function buildPolicy(preset, enforcementMode) {
   const base = JSON.parse(JSON.stringify(PRESETS[preset]));
-  const policy = { policy_format_version: "0.3.0", ...base };
-  if (mode === "advisory") {
-    Object.assign(policy.diff_rules, ADVISORY_OVERRIDES.diff_rules);
-  }
-  return policy;
+  return {
+    policy_format_version: "0.3.0",
+    repository_kind: base.repository_kind,
+    enforcement: { mode: enforcementMode },
+    paths: base.paths,
+    diff_rules: base.diff_rules,
+    content_rules: base.content_rules,
+    cochange_rules: base.cochange_rules,
+  };
 }
 
-function buildWorkflow() {
+function buildWorkflow(enforcementMode) {
   return `name: repo-guard policy check
 
 on:
@@ -81,6 +82,7 @@ jobs:
         uses: netkeep80/repo-guard@main
         with:
           mode: check-pr
+          enforcement: ${enforcementMode}
         env:
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 `;
@@ -158,12 +160,14 @@ function writeIfAbsent(filePath, content, created, skipped) {
 
 export function runInit(roots, args) {
   let preset = "application";
-  let mode = "enforce";
+  let mode = roots.enforcementMode || "enforce";
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--preset" && args[i + 1]) {
       preset = args[++i];
     } else if (args[i] === "--mode" && args[i + 1]) {
+      mode = args[++i];
+    } else if (args[i] === "--enforcement" && args[i + 1]) {
       mode = args[++i];
     } else if (args[i] === "--help") {
       printUsage();
@@ -181,21 +185,23 @@ export function runInit(roots, args) {
     process.exit(1);
   }
 
-  if (mode !== "advisory" && mode !== "enforce") {
-    console.error(`Unknown mode: ${mode}. Must be "advisory" or "enforce".`);
+  const enforcement = normalizeEnforcementMode(mode, "mode");
+  if (!enforcement.ok) {
+    console.error(enforcement.message);
     process.exit(1);
   }
+  const enforcementMode = enforcement.mode;
 
   const repoRoot = roots.repoRoot;
   const created = [];
   const skipped = [];
 
   const policyPath = resolve(repoRoot, "repo-policy.json");
-  const policyContent = JSON.stringify(buildPolicy(preset, mode), null, 2) + "\n";
+  const policyContent = JSON.stringify(buildPolicy(preset, enforcementMode), null, 2) + "\n";
   writeIfAbsent(policyPath, policyContent, created, skipped);
 
   const workflowPath = resolve(repoRoot, ".github/workflows/repo-guard.yml");
-  writeIfAbsent(workflowPath, buildWorkflow(), created, skipped);
+  writeIfAbsent(workflowPath, buildWorkflow(enforcementMode), created, skipped);
 
   const prTemplatePath = resolve(repoRoot, ".github/PULL_REQUEST_TEMPLATE.md");
   writeIfAbsent(prTemplatePath, buildPRTemplate(), created, skipped);
@@ -203,7 +209,7 @@ export function runInit(roots, args) {
   const issueTemplatePath = resolve(repoRoot, ".github/ISSUE_TEMPLATE/change-contract.yml");
   writeIfAbsent(issueTemplatePath, buildIssueTemplate(), created, skipped);
 
-  console.log(`repo-guard init (preset: ${preset}, mode: ${mode})\n`);
+  console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcementMode})\n`);
 
   if (created.length > 0) {
     console.log("Created:");
@@ -232,8 +238,10 @@ Scaffold a repo-guard setup in the current repository.
 Options:
   --preset <preset>  Repository preset (default: application)
                      Presets: application, library, tooling, documentation
-  --mode <mode>      Default enforcement mode (default: enforce)
-                     Modes: advisory (relaxed budgets), enforce (strict budgets)
+  --mode <mode>      Default enforcement behavior (default: enforce)
+                     Modes: advisory/warn (non-blocking), enforce/blocking (blocking)
+  --enforcement <mode>
+                     Alias for --mode
   --help             Show this help message
 
 Files created:

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -22,27 +22,42 @@ import {
   warnReservedContractFields,
   warnReservedPolicyFields,
 } from "./policy-compiler.mjs";
+import {
+  ajvErrors,
+  createCheckReporter,
+  printEnforcementMode,
+  resolveEnforcementMode,
+} from "./enforcement.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
 
 export function resolveRoots(args) {
   let repoRoot = process.cwd();
+  let enforcementMode = null;
   const filtered = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--repo-root") {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
         console.error("Error: --repo-root requires a path argument");
-        console.error("Usage: repo-guard [--repo-root <path>] [check-diff|check-pr|init|doctor] [options]");
+        console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor] [options]");
         process.exit(1);
       }
       repoRoot = resolve(args[++i]);
+    } else if (args[i] === "--enforcement" || args[i] === "--enforcement-mode") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error(`Error: ${args[i]} requires a mode argument`);
+        console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor] [options]");
+        process.exit(1);
+      }
+      enforcementMode = args[++i];
     } else {
       filtered.push(args[i]);
     }
   }
-  return { packageRoot, repoRoot, args: filtered };
+  return { packageRoot, repoRoot, enforcementMode, args: filtered };
 }
 
 function loadJSON(path) {
@@ -60,6 +75,18 @@ function validate(ajv, schema, data, label) {
   }
   console.log(`OK: ${label}`);
   return true;
+}
+
+function validationCheck(ajv, schema, data, label) {
+  const valid = ajv.validate(schema, data);
+  if (valid) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    message: `${label} failed schema validation`,
+    errors: ajvErrors(ajv.errors),
+  };
 }
 
 function getDiff(base, head, cwd) {
@@ -98,24 +125,19 @@ function runCheckDiff(roots, args) {
     console.warn(`WARN: ${w}`);
   }
 
-  let contract = null;
   let base = null;
   let head = null;
+  let contractPath = null;
   const KNOWN_DIFF_OPTS = new Set(["--base", "--head", "--contract"]);
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--base" && args[i + 1]) base = args[++i];
     else if (args[i] === "--head" && args[i + 1]) head = args[++i];
     else if (args[i] === "--contract" && args[i + 1]) {
-      const contractPath = resolve(roots.repoRoot, args[++i]);
-      contract = loadJSON(contractPath);
-      ok = validate(ajv, contractSchema, contract, contractPath) && ok;
-      for (const w of warnReservedContractFields(contract)) {
-        console.warn(`WARN: ${w}`);
-      }
+      contractPath = resolve(roots.repoRoot, args[++i]);
     } else if (args[i].startsWith("-") && !KNOWN_DIFF_OPTS.has(args[i])) {
       console.error(`Unknown option for check-diff: ${args[i]}`);
-      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>]");
+      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--enforcement <advisory|blocking>]");
       process.exit(1);
     }
   }
@@ -125,6 +147,34 @@ function runCheckDiff(roots, args) {
     process.exit(1);
   }
 
+  const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
+  if (!enforcement.ok) {
+    console.error(`ERROR: ${enforcement.message}`);
+    process.exit(1);
+  }
+  printEnforcementMode(enforcement);
+  const reporter = createCheckReporter(enforcement.mode);
+
+  let contract = null;
+  if (contractPath) {
+    try {
+      const loadedContract = loadJSON(contractPath);
+      const contractCheck = validationCheck(ajv, contractSchema, loadedContract, contractPath);
+      reporter.report("change-contract", contractCheck);
+      if (contractCheck.ok) {
+        contract = loadedContract;
+        for (const w of warnReservedContractFields(contract)) {
+          console.warn(`WARN: ${w}`);
+        }
+      }
+    } catch (e) {
+      reporter.report("change-contract", {
+        ok: false,
+        message: `Cannot read ${contractPath}: ${e.message}`,
+      });
+    }
+  }
+
   const diffText = getDiff(base, head, roots.repoRoot);
   const allFiles = parseDiff(diffText);
   const files = filterOperationalPaths(allFiles, policy.paths.operational_paths);
@@ -132,37 +182,8 @@ function runCheckDiff(roots, args) {
   const skipped = allFiles.length - files.length;
   console.log(`\nDiff analysis: ${allFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
 
-  let passed = 0;
-  let failed = 0;
-
-  function report(name, check) {
-    if (check.ok) {
-      passed++;
-      console.log(`  PASS: ${name}`);
-    } else {
-      failed++;
-      ok = false;
-      console.error(`  FAIL: ${name}`);
-      if (check.actual !== undefined) {
-        console.error(`    actual: ${check.actual}, limit: ${check.limit}`);
-      }
-      if (check.files) {
-        for (const f of check.files) console.error(`    - ${f}`);
-      }
-      if (check.touched) {
-        for (const f of check.touched) console.error(`    - ${f}`);
-      }
-      if (check.must_touch) {
-        console.error(`    must_touch: ${check.must_touch.join(", ")}`);
-      }
-      if (check.hint) {
-        console.error(`    hint: ${check.hint}`);
-      }
-    }
-  }
-
   const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
-  report("forbidden-paths", {
+  reporter.report("forbidden-paths", {
     ok: forbiddenViolations.length === 0,
     files: forbiddenViolations,
   });
@@ -172,42 +193,39 @@ function runCheckDiff(roots, args) {
   const maxNewFiles = budgets.max_new_files ?? policy.diff_rules.max_new_files;
   const maxNetAddedLines = budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines;
 
-  report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
-  report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
-  report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+  reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
+  reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
+  reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
 
   const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
   if (cochangeViolations.length > 0) {
     for (const v of cochangeViolations) {
-      report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
+      reporter.report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
         ok: false,
         must_touch: v.must_change_any,
       });
     }
   } else {
-    report("cochange-rules", { ok: true });
+    reporter.report("cochange-rules", { ok: true });
   }
 
   const contentViolations = checkContentRules(files, policy.content_rules);
   if (contentViolations.length > 0) {
-    ok = false;
-    failed++;
-    console.error(`  FAIL: content-rules`);
-    for (const v of contentViolations) {
-      console.error(`    [${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`);
-    }
+    reporter.report("content-rules", {
+      ok: false,
+      details: contentViolations.map((v) => `[${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`),
+    });
   } else {
-    passed++;
-    console.log(`  PASS: content-rules`);
+    reporter.report("content-rules", { ok: true });
   }
 
   if (contract) {
-    report("must-touch", checkMustTouch(files, contract.must_touch));
-    report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
+    reporter.report("must-touch", checkMustTouch(files, contract.must_touch));
+    reporter.report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
   }
 
-  console.log(`\nSummary: ${passed} passed, ${failed} failed`);
-  process.exit(ok ? 0 : 1);
+  const summary = reporter.finish();
+  process.exit(summary.exitCode);
 }
 
 function runValidate(roots, args) {
@@ -258,7 +276,7 @@ if (isMain) {
 
   if (command && !MODES.has(command) && command.startsWith("-")) {
     console.error(`Unknown option: ${command}`);
-    console.error("Usage: repo-guard [--repo-root <path>] [check-diff|check-pr|init|doctor] [options]");
+    console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor] [options]");
     process.exit(1);
   }
 
@@ -268,7 +286,7 @@ if (isMain) {
   } else if (command === "check-pr") {
     roots.args = roots.args.slice(1);
     const { runCheckPR } = await import("./github-pr.mjs");
-    runCheckPR(roots);
+    runCheckPR(roots, roots.args);
   } else if (command === "init") {
     roots.args = roots.args.slice(1);
     const { runInit } = await import("./init.mjs");

--- a/templates/example-workflow.yml
+++ b/templates/example-workflow.yml
@@ -28,6 +28,7 @@ jobs:
         uses: netkeep80/repo-guard@vX.Y.Z  # replace with a release tag from https://github.com/netkeep80/repo-guard/releases
         with:
           mode: check-pr
+          enforcement: blocking  # use advisory while observing violations before rollout
         env:
           # Required for fetching linked issue contracts
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/repo-policy.min.json
+++ b/templates/repo-policy.min.json
@@ -1,6 +1,9 @@
 {
   "policy_format_version": "0.1.0",
   "repository_kind": "application",
+  "enforcement": {
+    "mode": "blocking"
+  },
   "paths": {
     "forbidden": [],
     "canonical_docs": ["README.md"],

--- a/tests/fixtures/valid-policy.json
+++ b/tests/fixtures/valid-policy.json
@@ -1,6 +1,9 @@
 {
   "policy_format_version": "0.1.0",
   "repository_kind": "library",
+  "enforcement": {
+    "mode": "blocking"
+  },
   "paths": {
     "forbidden": ["*.bak"],
     "canonical_docs": ["README.md"],

--- a/tests/test-enforcement-mode.mjs
+++ b/tests/test-enforcement-mode.mjs
@@ -1,0 +1,206 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { execSync, spawnSync } from "node:child_process";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+const projectRoot = resolve(__dirname, "..");
+const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, str, substring) {
+  const passed = str.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected to include: ${JSON.stringify(substring)}`);
+    console.error(`  output: ${JSON.stringify(str.slice(0, 1000))}`);
+  }
+}
+
+function runGuard(args, opts = {}) {
+  const result = spawnSync(process.execPath, [repoGuard, ...args], {
+    cwd: opts.cwd || projectRoot,
+    env: { ...process.env, ...(opts.env || {}) },
+    encoding: "utf-8",
+  });
+  return {
+    code: result.status,
+    output: `${result.stdout || ""}${result.stderr || ""}`,
+  };
+}
+
+function makePolicy(enforcementMode) {
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 0,
+      max_net_added_lines: 500,
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  if (enforcementMode) {
+    policy.enforcement = { mode: enforcementMode };
+  }
+
+  return policy;
+}
+
+function makeRepo(enforcementMode) {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-enforcement-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(makePolicy(enforcementMode), null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  writeFileSync(join(dir, "new-file.txt"), "new\n");
+  execSync("git add -A && git commit -m add-file", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
+console.log("\n--- blocking check-diff fails on policy violation ---");
+{
+  const repo = makeRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("blocking exit code", result.code, 1);
+  expectIncludes("blocking reports FAIL", result.output, "FAIL: max-new-files");
+  expectIncludes("blocking summary names mode", result.output, "mode: blocking");
+  expectIncludes("blocking result failed", result.output, "Result: failed");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- advisory check-diff reports but does not fail ---");
+{
+  const repo = makeRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "--enforcement", "advisory",
+    "check-diff",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("advisory exit code", result.code, 0);
+  expectIncludes("advisory reports WARN", result.output, "WARN: max-new-files");
+  expectIncludes("advisory summary has zero enforced failures", result.output, "0 failed");
+  expectIncludes("advisory summary names advisory violations", result.output, "advisory violation");
+  expectIncludes("advisory result still records failed checks", result.output, "Result: failed");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- warn alias can be supplied after the command ---");
+{
+  const repo = makeRepo();
+  const result = runGuard([
+    "check-diff",
+    "--repo-root", repo.dir,
+    "--base", repo.base,
+    "--head", repo.head,
+    "--enforcement", "warn",
+  ]);
+
+  expect("warn alias exit code", result.code, 0);
+  expectIncludes("warn alias resolves to advisory", result.output, "mode: advisory");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- policy config can opt into advisory mode ---");
+{
+  const repo = makeRepo("advisory");
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("policy advisory exit code", result.code, 0);
+  expectIncludes("policy advisory mode", result.output, "mode: advisory");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- CLI enforcement overrides policy config ---");
+{
+  const repo = makeRepo("advisory");
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "--enforcement", "blocking",
+    "check-diff",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("CLI blocking override exit code", result.code, 1);
+  expectIncludes("CLI blocking override mode", result.output, "mode: blocking");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-pr missing contract is advisory when requested ---");
+{
+  const repo = makeRepo();
+  const eventPath = join(repo.dir, "event.json");
+  writeFileSync(eventPath, JSON.stringify({
+    pull_request: {
+      number: 123,
+      base: { sha: repo.base },
+      head: { sha: repo.head },
+      body: "No contract here.",
+    },
+    repository: { full_name: "owner/repo" },
+  }));
+
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "--enforcement", "advisory",
+    "check-pr",
+  ], {
+    env: { GITHUB_EVENT_PATH: eventPath },
+  });
+
+  expect("check-pr advisory missing contract exit code", result.code, 0);
+  expectIncludes("check-pr missing contract warning", result.output, "WARN: change-contract");
+  expectIncludes("check-pr advisory summary", result.output, "advisory violation");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log(`\n${failures === 0 ? "All enforcement mode tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-init.mjs
+++ b/tests/test-init.mjs
@@ -47,7 +47,7 @@ console.log("\n--- default init (application + enforce) ---");
   const dir = makeTmpDir();
   const out = runInit(`--repo-root ${dir} init`);
   expectIncludes("default output mentions preset", out, "preset: application");
-  expectIncludes("default output mentions mode", out, "mode: enforce");
+  expectIncludes("default output mentions enforcement", out, "enforcement: blocking");
 
   expect("creates repo-policy.json", existsSync(join(dir, "repo-policy.json")), true);
   expect("creates workflow", existsSync(join(dir, ".github/workflows/repo-guard.yml")), true);
@@ -77,16 +77,17 @@ for (const preset of ["application", "library", "tooling", "documentation"]) {
   }
 }
 
-// --- advisory mode relaxes budgets ---
+// --- advisory mode sets non-blocking enforcement without changing budgets ---
 
-console.log("\n--- advisory mode budgets ---");
+console.log("\n--- advisory mode enforcement ---");
 {
   const dir = makeTmpDir();
   runInit(`--repo-root ${dir} init --preset library --mode advisory`);
   const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
-  expect("advisory max_new_files", policy.diff_rules.max_new_files, 50);
-  expect("advisory max_new_docs", policy.diff_rules.max_new_docs, 10);
-  expect("advisory max_net_added_lines", policy.diff_rules.max_net_added_lines, 5000);
+  expect("advisory enforcement mode", policy.enforcement.mode, "advisory");
+  expect("advisory preserves preset max_new_files", policy.diff_rules.max_new_files, 15);
+  expect("advisory preserves preset max_new_docs", policy.diff_rules.max_new_docs, 2);
+  expect("advisory preserves preset max_net_added_lines", policy.diff_rules.max_net_added_lines, 1000);
 }
 
 // --- enforce mode uses preset budgets ---
@@ -96,9 +97,22 @@ console.log("\n--- enforce mode budgets ---");
   const dir = makeTmpDir();
   runInit(`--repo-root ${dir} init --preset library --mode enforce`);
   const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
+  expect("enforce maps to blocking enforcement", policy.enforcement.mode, "blocking");
   expect("enforce max_new_files", policy.diff_rules.max_new_files, 15);
   expect("enforce max_new_docs", policy.diff_rules.max_new_docs, 2);
   expect("enforce max_net_added_lines", policy.diff_rules.max_net_added_lines, 1000);
+}
+
+// --- --enforcement alias works with init ---
+
+console.log("\n--- enforcement alias ---");
+{
+  const dir = makeTmpDir();
+  runInit(`--repo-root ${dir} --enforcement warn init --preset tooling`);
+  const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
+  const workflow = readFileSync(join(dir, ".github/workflows/repo-guard.yml"), "utf-8");
+  expect("warn alias maps to advisory policy", policy.enforcement.mode, "advisory");
+  expectIncludes("warn alias maps to advisory workflow", workflow, "enforcement: advisory");
 }
 
 // --- idempotency: skips existing files ---
@@ -133,6 +147,7 @@ console.log("\n--- workflow content ---");
   const workflow = readFileSync(join(dir, ".github/workflows/repo-guard.yml"), "utf-8");
   expectIncludes("workflow uses repo-guard action", workflow, "netkeep80/repo-guard@main");
   expectIncludes("workflow uses check-pr", workflow, "mode: check-pr");
+  expectIncludes("workflow uses blocking enforcement", workflow, "enforcement: blocking");
   expectIncludes("workflow has fetch-depth 0", workflow, "fetch-depth: 0");
   expectIncludes("workflow has GH_TOKEN", workflow, "GH_TOKEN");
 }


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#21.

This adds explicit advisory vs blocking enforcement behavior for `check-diff`, `check-pr`, generated init scaffolding, and the reusable Action.

## Changes

- Added `--enforcement advisory|blocking` with aliases `warn` and `enforce`.
- Added optional `repo-policy.json` config: `"enforcement": { "mode": "advisory" | "blocking" }`.
- Made advisory mode report policy violations as `WARN` while returning exit code `0`.
- Kept configuration/runtime failures blocking in advisory mode.
- Added Action input `enforcement` and made Action outputs preserve `failed` for advisory violations.
- Updated init scaffolding, templates, README, schema, and self-hosted workflow comments.
- Added integration coverage for CLI exit semantics, aliases, policy config, CLI override, and `check-pr` missing-contract advisory behavior.

## Verification

- `npm test`
- `node src/repo-guard.mjs --enforcement blocking check-diff --base upstream/main --head HEAD`
- Pack/install smoke check matching the existing `smoke-pack` workflow command

## Change Contract

```repo-guard-json
{
  "change_type": "feature",
  "scope": [
    "src/",
    "schemas/",
    "tests/",
    "templates/",
    ".github/workflows/",
    "action.yml",
    "README.md",
    "repo-policy.json",
    "package.json"
  ],
  "budgets": {
    "max_new_files": 2,
    "max_new_docs": 0,
    "max_net_added_lines": 1200
  },
  "must_touch": [
    "src/**",
    "tests/**",
    "README.md",
    "action.yml"
  ],
  "must_not_touch": [],
  "expected_effects": [
    "Downstream workflows can run repo-guard in advisory mode without failing jobs for policy violations.",
    "Blocking mode continues to fail predictably for policy violations.",
    "Summaries identify the active enforcement behavior and resulting exit semantics."
  ]
}
```
