### PR TITLE
Add structured repo-guard output formats

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-16T07:08:28.401Z for PR creation at branch issue-23-25619ffda52a for issue https://github.com/netkeep80/repo-guard/issues/23

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-16T07:08:28.401Z for PR creation at branch issue-23-25619ffda52a for issue https://github.com/netkeep80/repo-guard/issues/23

--- a/README.md
+++ b/README.md
@@ -190,6 +190,75 @@ repo-guard --enforcement advisory check-diff --base main --head feature
 
 # Явно включить blocking mode (default)
 repo-guard --enforcement blocking check-diff --base main --head feature
+
+# Машиночитаемый результат для CI tooling
+repo-guard check-diff --format json --base main --head feature
+
+# Краткий Markdown summary для GitHub job summary
+repo-guard check-diff --format summary --base main --head feature
+```
+
+#### Structured output
+
+`check-diff` supports three output formats:
+
+| Format | Purpose |
+|---|---|
+| `text` | Default human-readable CLI logs. |
+| `json` | Stable machine-readable result for CI pipelines and higher-level tooling. Stdout contains only JSON. |
+| `summary` | Concise GitHub-flavored Markdown suitable for `$GITHUB_STEP_SUMMARY`. |
+
+The JSON result is intended as an API surface. Field names are stable and intentionally boring:
+
+```json
+{
+  "mode": "blocking",
+  "ok": false,
+  "result": "failed",
+  "passed": 4,
+  "violations": [
+    {
+      "rule": "max-new-files",
+      "actual": 2,
+      "limit": 0,
+      "files": ["src/feature.mjs", "tests/feature.test.mjs"],
+      "touched": [],
+      "must_touch": [],
+      "must_not_touch": [],
+      "details": [],
+      "errors": []
+    }
+  ],
+  "violationCount": 1,
+  "failed": 1,
+  "exitCode": 1,
+  "ruleResults": [
+    {
+      "rule": "max-new-files",
+      "ok": false,
+      "details": ["actual: 2, limit: 0", "file: src/feature.mjs", "file: tests/feature.test.mjs"]
+    }
+  ],
+  "hints": [],
+  "repositoryRoot": "/path/to/repo",
+  "diff": {
+    "changedFiles": 2,
+    "checkedFiles": 2,
+    "skippedOperationalFiles": 0
+  }
+}
+```
+
+Exit behavior is unchanged: in `blocking` mode violations exit `1`; in `advisory` mode violations are reported but the command exits `0`. Consumers should read both `ok` and `exitCode`: `ok` describes policy result, while `exitCode` describes command exit semantics for the active enforcement mode.
+
+Example GitHub Actions usage:
+
+```yaml
+- name: repo-guard JSON
+  run: repo-guard check-diff --format json --base "$BASE_SHA" --head "$HEAD_SHA" > repo-guard-result.json
+
+- name: repo-guard summary
+  run: repo-guard check-diff --format summary --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
 ```
 
 ### Проверка PR (в GitHub Actions)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
@@ -25,7 +25,8 @@
     "test:github-pr": "node tests/test-github-pr.mjs",
     "test:init": "node tests/test-init.mjs",
     "test:doctor": "node tests/test-doctor.mjs",
-    "test:enforcement": "node tests/test-enforcement-mode.mjs"
+    "test:enforcement": "node tests/test-enforcement-mode.mjs",
+    "test:structured-output": "node tests/test-structured-output.mjs"
   },
   "keywords": [
     "repo-policy",

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -74,41 +74,135 @@ function printCheckDetails(mode, check) {
   }
 }
 
-export function createCheckReporter(mode) {
+function detailFromCheck(check) {
+  const details = [];
+  if (check.message) details.push(check.message);
+  if (check.actual !== undefined) details.push(`actual: ${check.actual}, limit: ${check.limit}`);
+  if (check.files) details.push(...check.files.map((f) => `file: ${f}`));
+  if (check.touched) details.push(...check.touched.map((f) => `touched: ${f}`));
+  if (check.must_touch) details.push(`must_touch: ${check.must_touch.join(", ")}`);
+  if (check.must_not_touch) details.push(`must_not_touch: ${check.must_not_touch.join(", ")}`);
+  if (check.details) details.push(...check.details);
+  if (check.errors) details.push(...check.errors);
+  if (check.hint) details.push(`hint: ${check.hint}`);
+  return details;
+}
+
+function violationFromCheck(name, check) {
+  return {
+    rule: name,
+    message: check.message,
+    actual: check.actual,
+    limit: check.limit,
+    files: check.files || [],
+    touched: check.touched || [],
+    must_touch: check.must_touch || [],
+    must_not_touch: check.must_not_touch || [],
+    details: check.details || [],
+    errors: check.errors || [],
+    hint: check.hint,
+  };
+}
+
+function renderMarkdownTableCell(value) {
+  return String(value || "")
+    .replaceAll("|", "\\|")
+    .replaceAll("\n", "<br>");
+}
+
+export function createCheckReporter(mode, options = {}) {
   let passed = 0;
   let violations = 0;
+  const quiet = options.quiet || false;
+  const ruleResults = [];
+  const violationDetails = [];
+  const hints = [];
 
   return {
     report(name, check) {
+      const normalized = { rule: name, ok: Boolean(check.ok), details: detailFromCheck(check) };
+      ruleResults.push(normalized);
+
       if (check.ok) {
         passed++;
-        console.log(`  PASS: ${name}`);
+        if (!quiet) console.log(`  PASS: ${name}`);
         return;
       }
 
       violations++;
+      const violation = violationFromCheck(name, check);
+      violationDetails.push(violation);
+      if (check.hint) hints.push({ rule: name, message: check.hint });
       const label = mode === "advisory" ? "WARN" : "FAIL";
-      writeViolation(mode, `  ${label}: ${name}`);
-      printCheckDetails(mode, check);
+      if (!quiet) {
+        writeViolation(mode, `  ${label}: ${name}`);
+        printCheckDetails(mode, check);
+      }
     },
 
-    finish() {
+    finish(extra = {}) {
       const enforcedFailures = mode === "blocking" ? violations : 0;
       const advisoryPart = mode === "advisory" ? `, ${violations} advisory violation(s)` : "";
       const modePart = mode === "advisory" ? "violations reported as warnings" : "violations enforced";
       const exitCode = enforcedFailures > 0 ? 1 : 0;
       const result = violations > 0 ? "failed" : "passed";
 
-      console.log(`\nSummary: ${passed} passed, ${enforcedFailures} failed${advisoryPart} (mode: ${mode}; ${modePart})`);
-      console.log(`Result: ${result} (mode: ${mode}; exit code ${exitCode})`);
+      if (!quiet) {
+        console.log(`\nSummary: ${passed} passed, ${enforcedFailures} failed${advisoryPart} (mode: ${mode}; ${modePart})`);
+        console.log(`Result: ${result} (mode: ${mode}; exit code ${exitCode})`);
+      }
 
-      return { passed, violations, failed: enforcedFailures, exitCode };
+      return {
+        mode,
+        ok: violations === 0,
+        result,
+        passed,
+        violations: violationDetails,
+        violationCount: violations,
+        failed: enforcedFailures,
+        exitCode,
+        ruleResults,
+        hints,
+        ...extra,
+      };
     },
 
     get violations() {
       return violations;
     },
   };
+}
+
+export function renderCheckSummary(result) {
+  const lines = [
+    "## repo-guard summary",
+    "",
+    `- Result: ${result.result}`,
+    `- Mode: ${result.mode}`,
+    `- Repository root: \`${result.repositoryRoot}\``,
+    `- Checks: ${result.passed} passed, ${result.failed} failed${result.mode === "advisory" ? `, ${result.violationCount} advisory violation(s)` : ""}`,
+  ];
+
+  if (result.diff) {
+    lines.push(`- Diff: ${result.diff.changedFiles} file(s) changed${result.diff.skippedOperationalFiles ? `, ${result.diff.skippedOperationalFiles} operational skipped` : ""}`);
+  }
+
+  if (result.violations.length > 0) {
+    lines.push("", "| Rule | Details |", "|---|---|");
+    for (const violation of result.violations) {
+      const details = detailFromCheck(violation).join("<br>") || "Violation reported";
+      lines.push(`| ${renderMarkdownTableCell(violation.rule)} | ${renderMarkdownTableCell(details)} |`);
+    }
+  }
+
+  if (result.hints.length > 0) {
+    lines.push("", "### Hints");
+    for (const hint of result.hints) {
+      lines.push(`- ${hint.rule}: ${hint.message}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
 }
 
 export function ajvErrors(errors) {

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -26,6 +26,7 @@ import {
   ajvErrors,
   createCheckReporter,
   printEnforcementMode,
+  renderCheckSummary,
   resolveEnforcementMode,
 } from "./enforcement.mjs";
 
@@ -64,16 +65,18 @@ function loadJSON(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
 }
 
-function validate(ajv, schema, data, label) {
+function validate(ajv, schema, data, label, options = {}) {
   const valid = ajv.validate(schema, data);
   if (!valid) {
-    console.error(`FAIL: ${label}`);
-    for (const err of ajv.errors) {
-      console.error(`  ${err.instancePath || "/"} ${err.message}`);
+    if (!options.quiet) {
+      console.error(`FAIL: ${label}`);
+      for (const err of ajv.errors) {
+        console.error(`  ${err.instancePath || "/"} ${err.message}`);
+      }
     }
     return false;
   }
-  console.log(`OK: ${label}`);
+  if (!options.quiet) console.log(`OK: ${label}`);
   return true;
 }
 
@@ -103,6 +106,34 @@ function runCheckDiff(roots, args) {
   const contractSchemaPath = resolve(roots.packageRoot, "schemas/change-contract.schema.json");
   const policyPath = resolve(roots.repoRoot, "repo-policy.json");
 
+  let base = null;
+  let head = null;
+  let contractPath = null;
+  let format = "text";
+  const KNOWN_DIFF_OPTS = new Set(["--base", "--head", "--contract", "--format"]);
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--base" && args[i + 1]) base = args[++i];
+    else if (args[i] === "--head" && args[i + 1]) head = args[++i];
+    else if (args[i] === "--contract" && args[i + 1]) {
+      contractPath = resolve(roots.repoRoot, args[++i]);
+    } else if (args[i] === "--format" && args[i + 1]) {
+      format = args[++i];
+    } else if (args[i].startsWith("-") && !KNOWN_DIFF_OPTS.has(args[i])) {
+      console.error(`Unknown option for check-diff: ${args[i]}`);
+      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
+      process.exit(1);
+    }
+  }
+
+  if (!["text", "json", "summary"].includes(format)) {
+    console.error(`Unknown check-diff format: ${format}`);
+    console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
+    process.exit(1);
+  }
+
+  const quiet = format === "json";
+
   const policySchema = loadJSON(policySchemaPath);
   const contractSchema = loadJSON(contractSchemaPath);
   const policy = loadJSON(policyPath);
@@ -110,40 +141,27 @@ function runCheckDiff(roots, args) {
   const ajv = new Ajv({ allErrors: true });
 
   let ok = true;
-  ok = validate(ajv, policySchema, policy, "repo-policy.json") && ok;
+  ok = validate(ajv, policySchema, policy, "repo-policy.json", { quiet }) && ok;
 
   const regexErrors = compileForbidRegex(policy.content_rules);
   if (regexErrors.length > 0) {
     ok = false;
-    console.error("FAIL: forbid_regex compilation");
-    for (const e of regexErrors) {
-      console.error(`  [${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`);
+    if (!quiet) {
+      console.error("FAIL: forbid_regex compilation");
+      for (const e of regexErrors) {
+        console.error(`  [${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`);
+      }
     }
   }
 
-  for (const w of warnReservedPolicyFields(policy)) {
-    console.warn(`WARN: ${w}`);
-  }
-
-  let base = null;
-  let head = null;
-  let contractPath = null;
-  const KNOWN_DIFF_OPTS = new Set(["--base", "--head", "--contract"]);
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--base" && args[i + 1]) base = args[++i];
-    else if (args[i] === "--head" && args[i + 1]) head = args[++i];
-    else if (args[i] === "--contract" && args[i + 1]) {
-      contractPath = resolve(roots.repoRoot, args[++i]);
-    } else if (args[i].startsWith("-") && !KNOWN_DIFF_OPTS.has(args[i])) {
-      console.error(`Unknown option for check-diff: ${args[i]}`);
-      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--enforcement <advisory|blocking>]");
-      process.exit(1);
+  if (!quiet) {
+    for (const w of warnReservedPolicyFields(policy)) {
+      console.warn(`WARN: ${w}`);
     }
   }
 
   if (!ok) {
-    console.error("\nPolicy compilation failed; aborting enforcement.");
+    if (!quiet) console.error("\nPolicy compilation failed; aborting enforcement.");
     process.exit(1);
   }
 
@@ -152,8 +170,8 @@ function runCheckDiff(roots, args) {
     console.error(`ERROR: ${enforcement.message}`);
     process.exit(1);
   }
-  printEnforcementMode(enforcement);
-  const reporter = createCheckReporter(enforcement.mode);
+  if (!quiet) printEnforcementMode(enforcement);
+  const reporter = createCheckReporter(enforcement.mode, { quiet });
 
   let contract = null;
   if (contractPath) {
@@ -163,8 +181,10 @@ function runCheckDiff(roots, args) {
       reporter.report("change-contract", contractCheck);
       if (contractCheck.ok) {
         contract = loadedContract;
-        for (const w of warnReservedContractFields(contract)) {
-          console.warn(`WARN: ${w}`);
+        if (!quiet) {
+          for (const w of warnReservedContractFields(contract)) {
+            console.warn(`WARN: ${w}`);
+          }
         }
       }
     } catch (e) {
@@ -180,7 +200,7 @@ function runCheckDiff(roots, args) {
   const files = filterOperationalPaths(allFiles, policy.paths.operational_paths);
 
   const skipped = allFiles.length - files.length;
-  console.log(`\nDiff analysis: ${allFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
+  if (!quiet) console.log(`\nDiff analysis: ${allFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
 
   const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
   reporter.report("forbidden-paths", {
@@ -224,7 +244,19 @@ function runCheckDiff(roots, args) {
     reporter.report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
   }
 
-  const summary = reporter.finish();
+  const summary = reporter.finish({
+    repositoryRoot: roots.repoRoot,
+    diff: {
+      changedFiles: allFiles.length,
+      checkedFiles: files.length,
+      skippedOperationalFiles: skipped,
+    },
+  });
+  if (format === "json") {
+    console.log(JSON.stringify(summary, null, 2));
+  } else if (format === "summary") {
+    console.log(renderCheckSummary(summary));
+  }
   process.exit(summary.exitCode);
 }
 

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -1,0 +1,145 @@
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { execSync, spawnSync } from "node:child_process";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+const projectRoot = resolve(__dirname, "..");
+const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, str, substring) {
+  const passed = str.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected to include: ${JSON.stringify(substring)}`);
+    console.error(`  output: ${JSON.stringify(str.slice(0, 1000))}`);
+  }
+}
+
+function runGuard(args, opts = {}) {
+  const result = spawnSync(process.execPath, [repoGuard, ...args], {
+    cwd: opts.cwd || projectRoot,
+    env: { ...process.env, ...(opts.env || {}) },
+    encoding: "utf-8",
+  });
+  return {
+    code: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    output: `${result.stdout || ""}${result.stderr || ""}`,
+  };
+}
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-format-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: ["secrets/**"],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 0,
+      max_net_added_lines: 500,
+    },
+    content_rules: [],
+    cochange_rules: [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  execSync("mkdir -p src secrets", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "src", "feature.mjs"), "export const value = 1;\n");
+  writeFileSync(join(dir, "secrets", "token.txt"), "token\n");
+  execSync("git add -A && git commit -m feature", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
+console.log("\n--- check-diff --format json emits stable machine-readable result ---");
+{
+  const repo = makeRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("json exit code follows blocking failures", result.code, 1);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("stdout is valid json", true, true);
+  } catch (e) {
+    expect("stdout is valid json", e.message, "valid json");
+  }
+  expect("stderr is empty for json output", result.stderr, "");
+  expect("mode is blocking", parsed?.mode, "blocking");
+  expect("repositoryRoot is absolute", parsed?.repositoryRoot, repo.dir);
+  expect("ok is false", parsed?.ok, false);
+  expect("exitCode is 1", parsed?.exitCode, 1);
+  expect("changed file count", parsed?.diff?.changedFiles, 2);
+  expect("result array is stable", Array.isArray(parsed?.ruleResults), true);
+  expect("violations array is stable", Array.isArray(parsed?.violations), true);
+  expect("hints array is stable", Array.isArray(parsed?.hints), true);
+  expect("forbidden violation is detailed",
+    parsed?.violations.some((v) => v.rule === "forbidden-paths" && v.files.includes("secrets/token.txt")),
+    true);
+  expect("cochange violation is detailed",
+    parsed?.violations.some((v) => v.rule.startsWith("cochange:") && v.must_touch.includes("tests/**")),
+    true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff --format summary emits GitHub-friendly concise summary ---");
+{
+  const repo = makeRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "--enforcement", "advisory",
+    "check-diff",
+    "--format", "summary",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("summary advisory exit code", result.code, 0);
+  expectIncludes("summary has heading", result.output, "## repo-guard summary");
+  expectIncludes("summary has result", result.output, "- Result: failed");
+  expectIncludes("summary has mode", result.output, "- Mode: advisory");
+  expectIncludes("summary has violation table", result.output, "| Rule | Details |");
+  expectIncludes("summary includes forbidden path", result.output, "secrets/token.txt");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log(`\n${failures === 0 ? "All structured output tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#23.

Adds structured output for `repo-guard check-diff`:

- `--format json` emits stdout-only JSON with stable fields for mode, repository root, policy result, exit code, rule results, violations, hints, and diff metadata.
- `--format summary` emits concise GitHub-flavored Markdown suitable for `$GITHUB_STEP_SUMMARY`.
- Default `text` output remains the existing human CLI output.

## repo-guard change contract

```repo-guard-json
{
  "change_type": "feature",
  "scope": [
    "src/**",
    "tests/**",
    "README.md",
    "package.json"
  ],
  "budgets": {
    "max_new_files": 1,
    "max_net_added_lines": 500,
    "max_new_docs": 0
  },
  "must_touch": [
    "src/**",
    "tests/**",
    "README.md"
  ],
  "must_not_touch": [
    "schemas/**",
    "templates/**"
  ],
  "expected_effects": [
    "check-diff supports --format json for machine-readable output",
    "check-diff supports --format summary for GitHub job summaries",
    "structured output behavior is covered by automated tests and README documentation"
  ]
}
```

## JSON contract

The JSON result includes:

- `mode`, `ok`, `result`, `exitCode`
- `repositoryRoot`
- `diff.changedFiles`, `diff.checkedFiles`, `diff.skippedOperationalFiles`
- `ruleResults[]`
- `violations[]`
- `hints[]`

In advisory mode, `ok` still reflects policy violations while `exitCode` reflects non-blocking command semantics.

## Tests

- Added `tests/test-structured-output.mjs` covering JSON shape, stdout cleanliness, violation detail, summary rendering, and advisory exit behavior.
- Added `npm run test:structured-output`.
- Ran `npm test` locally.

## Documentation

README now documents `--format json`, `--format summary`, the JSON schema shape, exit behavior, and GitHub Actions examples.
