### PR TITLE
Add ownership-aware surface matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-contract.yml
+++ b/.github/ISSUE_TEMPLATE/change-contract.yml
@@ -21,6 +21,7 @@ body:
       value: |
         ```repo-guard-yaml
         change_type: feature
+        change_class: kernel-hardening
         scope:
           - src/
         budgets: {}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 
 ```repo-guard-yaml
 change_type: feature
+change_class: kernel-hardening
 scope:
   - src/
 budgets: {}

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T23:25:48.742Z for PR creation at branch issue-33-6a34bc6bebc8 for issue https://github.com/netkeep80/repo-guard/issues/33

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T23:25:48.742Z for PR creation at branch issue-33-6a34bc6bebc8 for issue https://github.com/netkeep80/repo-guard/issues/33

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Result: passed (mode: blocking; exit code 0)
     "docs-cleanup",
     "generated-refresh"
   ],
+  "allow_unclassified_files": false,
   "surface_matrix": {
     "kernel-hardening": {
       "allow": ["kernel", "tests"],
@@ -562,7 +563,19 @@ repo-guard check-diff --base main --head feature --change-class generated-refres
     surface kernel matched: src/core.mjs
 ```
 
-Файл может совпасть с несколькими surfaces; repo-guard считает все совпадения. Для catch-all поведения можно объявить явную surface вроде `"other": ["**"]` и включить её в матрицу там, где это допустимо.
+Файл может совпасть с несколькими surfaces; repo-guard считает все совпадения. Когда `surface_matrix` включён, changed file, который не совпал ни с одной surface, по умолчанию считается нарушением:
+
+```text
+  FAIL: surface-matrix
+    surface_matrix found changed files that match no declared surface: scripts/tool.mjs
+    change_class: docs-cleanup
+    touched_surfaces: (none)
+    unclassified_files: scripts/tool.mjs
+    changed files matched no declared surface: scripts/tool.mjs
+    hint: Add matching surface globs or set allow_unclassified_files: true if unclassified files are intentional.
+```
+
+Если policy намеренно описывает только часть репозитория, можно явно включить `"allow_unclassified_files": true`. По умолчанию это `false`, чтобы matrix-проверку нельзя было обойти файлами вне объявленных surfaces.
 
 ## GitHub Action (reusable)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Policy engine для репозитория: формализует правил
 | Max new files | Ограничивает общее количество новых файлов |
 | Max net added lines | Ограничивает `added − deleted` строк |
 | Co-change rules | Если изменён X, должен быть изменён и Y |
+| Surface matrix | Проверяет, что объявленный `change_class` трогает только разрешённые surface-классы |
 | Content rules | Запрещает regex-паттерны в добавленных строках |
 | must_touch | Хотя бы один из указанных паттернов должен совпасть с изменённым файлом (из contract) |
 | must_not_touch | Ни один из указанных паттернов не должен совпасть с изменённым файлом (из contract) |
@@ -184,6 +185,9 @@ repo-guard check-diff --base main --head feature
 
 # Проверить diff с change contract
 repo-guard check-diff --contract path/to/contract.json
+
+# Проверить diff с явным change class для surface_matrix
+repo-guard check-diff --change-class docs-cleanup
 
 # Наблюдать нарушения без падения job
 repo-guard --enforcement advisory check-diff --base main --head feature
@@ -425,6 +429,7 @@ node src/repo-guard.mjs
 ````markdown
 ```repo-guard-yaml
 change_type: bugfix
+change_class: kernel-hardening
 scope:
   - src/pagination.mjs
 budgets:
@@ -443,6 +448,8 @@ expected_effects:
 Contract говорит: это bugfix, который должен затронуть `src/pagination.mjs`, не должен трогать схемы и policy, и не должен создавать новых файлов.
 
 Для существующих PR сохраняется совместимость с JSON-блоком ` ```repo-guard-json `; оба формата дают одну и ту же нормализованную модель contract перед schema validation.
+
+`change_class` опционален для обычных policy. Он становится обязательным для diff, который трогает объявленные surfaces, если в policy включён `surface_matrix`.
 
 ### 3. Что проверяет repo-guard
 
@@ -482,6 +489,80 @@ Result: passed (mode: blocking; exit code 0)
   FAIL: cochange: src/** -> tests/**
     must_touch: tests/**
 ```
+
+## Ownership-aware surfaces
+
+Глобальный `paths.forbidden` хорошо работает для файлов, которые нельзя трогать никогда. Но generated, release или governance surfaces часто нельзя запрещать глобально: regeneration PR должен иметь право менять generated-файлы, а обычный docs PR — нет.
+
+Для этого policy может объявить named surfaces, named change classes и матрицу допустимых сочетаний:
+
+```json
+{
+  "surfaces": {
+    "kernel": ["src/**", "include/**"],
+    "tests": ["tests/**"],
+    "docs": ["docs/**", "README.md"],
+    "governance": ["repo-policy.json", ".github/**"],
+    "release": ["CHANGELOG.md", "package.json"],
+    "generated": ["single_include/**"]
+  },
+  "change_classes": [
+    "kernel-hardening",
+    "docs-cleanup",
+    "generated-refresh"
+  ],
+  "surface_matrix": {
+    "kernel-hardening": {
+      "allow": ["kernel", "tests"],
+      "forbid": ["generated", "release"]
+    },
+    "docs-cleanup": {
+      "allow": ["docs", "governance"],
+      "forbid": ["kernel", "tests", "generated", "release"]
+    },
+    "generated-refresh": {
+      "allow": ["generated", "release"],
+      "forbid": ["kernel", "docs", "governance"]
+    }
+  }
+}
+```
+
+Затем intent задаётся в contract:
+
+```yaml
+change_type: chore
+change_class: generated-refresh
+scope:
+  - single_include/
+budgets: {}
+must_touch:
+  - single_include/
+must_not_touch: []
+expected_effects:
+  - Regenerated bundled artifact
+```
+
+Для local/CI `check-diff` без contract можно передать тот же intent флагом:
+
+```bash
+repo-guard check-diff --base main --head feature --change-class generated-refresh
+```
+
+Если `docs-cleanup` PR затронет `src/core.mjs`, output явно покажет объявленный class, detected surfaces и нарушившую комбинацию:
+
+```text
+  FAIL: surface-matrix
+    change_class "docs-cleanup" cannot touch surfaces: kernel
+    change_class: docs-cleanup
+    touched_surfaces: docs, kernel
+    allowed_surfaces: docs, governance
+    forbidden_surfaces: generated, kernel, release, tests
+    violating_surfaces: kernel
+    surface kernel matched: src/core.mjs
+```
+
+Файл может совпасть с несколькими surfaces; repo-guard считает все совпадения. Для catch-all поведения можно объявить явную surface вроде `"other": ["**"]` и включить её в матрицу там, где это допустимо.
 
 ## GitHub Action (reusable)
 
@@ -531,6 +612,7 @@ A copy-pasteable version of this workflow is also available at [`templates/examp
 | `base` | no | _(empty)_ | Base git ref for diff (`check-diff` only). |
 | `head` | no | _(empty)_ | Head git ref for diff (`check-diff` only). |
 | `contract` | no | _(empty)_ | Path to a contract JSON file, relative to `repo-root` (`check-diff` only). |
+| `change-class` | no | _(empty)_ | Named change class for `surface_matrix` enforcement (`check-diff` only). Overrides contract `change_class` when set. |
 | `node-version` | no | `20` | Node.js version used to run repo-guard. |
 
 ### Outputs
@@ -595,6 +677,7 @@ Pin to a release tag to get reproducible runs. The Action always executes the CL
     base: main
     head: ${{ github.sha }}
     contract: path/to/contract.json
+    change-class: docs-cleanup
 ```
 
 ## Использование в GitHub PR workflow

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,13 @@ inputs:
     required: false
     default: ""
 
+  change-class:
+    description: >
+      Named change class for surface_matrix enforcement (used with
+      `mode: check-diff`). Overrides change_class from a contract file when set.
+    required: false
+    default: ""
+
   node-version:
     description: "Node.js version to use when running repo-guard."
     required: false
@@ -123,6 +130,9 @@ runs:
           fi
           if [ -n "${{ inputs.contract }}" ]; then
             CMD="$CMD --contract ${{ inputs.contract }}"
+          fi
+          if [ -n "${{ inputs.change-class }}" ]; then
+            CMD="$CMD --change-class ${{ inputs.change-class }}"
           fi
         fi
 

--- a/schemas/change-contract.schema.json
+++ b/schemas/change-contract.schema.json
@@ -17,6 +17,11 @@
       "type": "string",
       "enum": ["feature", "bugfix", "refactor", "docs", "chore"]
     },
+    "change_class": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Optional named policy change class used by surface_matrix enforcement."
+    },
     "scope": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 },

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -103,6 +103,10 @@
       "minItems": 1,
       "uniqueItems": true
     },
+    "allow_unclassified_files": {
+      "type": "boolean",
+      "description": "When surface_matrix is enabled, changed files that match no declared surface fail by default. Set this true only when partial surface coverage is intentional."
+    },
     "surface_matrix": {
       "type": "object",
       "description": "Allowed repository surface combinations for each named change class.",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -12,6 +12,9 @@
     "cochange_rules"
   ],
   "additionalProperties": false,
+  "dependencies": {
+    "surface_matrix": ["surfaces", "change_classes"]
+  },
   "properties": {
     "policy_format_version": {
       "type": "string",
@@ -80,6 +83,46 @@
         "max_net_added_lines": {
           "type": "integer",
           "minimum": 0
+        }
+      }
+    },
+    "surfaces": {
+      "type": "object",
+      "description": "Named repository surfaces mapped to one or more path globs. A changed file can match multiple surfaces.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string", "minLength": 1 },
+        "minItems": 1
+      }
+    },
+    "change_classes": {
+      "type": "array",
+      "description": "Named change classes that can be declared by a change contract or check-diff --change-class.",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "surface_matrix": {
+      "type": "object",
+      "description": "Allowed repository surface combinations for each named change class.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["allow"],
+        "additionalProperties": false,
+        "properties": {
+          "allow": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "minItems": 1,
+            "uniqueItems": true
+          },
+          "forbid": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          }
         }
       }
     },

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -114,6 +114,103 @@ export function checkCochangeRules(files, rules) {
   return violations;
 }
 
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function formatList(values) {
+  return values && values.length > 0 ? values.join(", ") : "(none)";
+}
+
+export function detectTouchedSurfaces(files, surfaces = {}) {
+  const filesBySurface = {};
+
+  for (const [surface, patterns] of Object.entries(surfaces || {})) {
+    const matchedFiles = uniqueSorted(
+      files
+        .filter((f) => matchesAny(f.path, patterns || []))
+        .map((f) => f.path)
+    );
+
+    if (matchedFiles.length > 0) {
+      filesBySurface[surface] = matchedFiles;
+    }
+  }
+
+  return {
+    touched_surfaces: Object.keys(filesBySurface).sort(),
+    files_by_surface: filesBySurface,
+  };
+}
+
+export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass) {
+  if (!surfaceMatrix || Object.keys(surfaceMatrix).length === 0) return { ok: true };
+
+  const detected = detectTouchedSurfaces(files, surfaces);
+  const touchedSurfaces = detected.touched_surfaces;
+  const changeClassValue = changeClass || null;
+
+  if (touchedSurfaces.length === 0) {
+    return {
+      ok: true,
+      change_class: changeClassValue,
+      touched_surfaces: touchedSurfaces,
+      files_by_surface: detected.files_by_surface,
+    };
+  }
+
+  if (!changeClassValue) {
+    return {
+      ok: false,
+      message: "surface_matrix requires a declared change_class",
+      change_class: null,
+      touched_surfaces: touchedSurfaces,
+      files_by_surface: detected.files_by_surface,
+      hint: "Set change_class in the contract or pass --change-class <name>.",
+    };
+  }
+
+  const matrixEntry = surfaceMatrix[changeClassValue];
+  if (!matrixEntry) {
+    return {
+      ok: false,
+      message: `change_class "${changeClassValue}" is not defined in surface_matrix`,
+      change_class: changeClassValue,
+      touched_surfaces: touchedSurfaces,
+      files_by_surface: detected.files_by_surface,
+      details: [`known change classes: ${formatList(Object.keys(surfaceMatrix).sort())}`],
+      hint: "Define the change class in surface_matrix or use one of the configured classes.",
+    };
+  }
+
+  const allowedSurfaces = uniqueSorted(matrixEntry.allow || []);
+  const forbiddenSurfaces = uniqueSorted(matrixEntry.forbid || []);
+  const allowedSet = new Set(allowedSurfaces);
+  const forbiddenSet = new Set(forbiddenSurfaces);
+
+  const notAllowed = allowedSurfaces.length > 0
+    ? touchedSurfaces.filter((surface) => !allowedSet.has(surface))
+    : [];
+  const explicitlyForbidden = touchedSurfaces.filter((surface) => forbiddenSet.has(surface));
+  const violatingSurfaces = uniqueSorted([...notAllowed, ...explicitlyForbidden]);
+
+  return {
+    ok: violatingSurfaces.length === 0,
+    message: violatingSurfaces.length === 0
+      ? undefined
+      : `change_class "${changeClassValue}" cannot touch surfaces: ${violatingSurfaces.join(", ")}`,
+    change_class: changeClassValue,
+    touched_surfaces: touchedSurfaces,
+    allowed_surfaces: allowedSurfaces,
+    forbidden_surfaces: forbiddenSurfaces,
+    violating_surfaces: violatingSurfaces,
+    files_by_surface: detected.files_by_surface,
+    details: violatingSurfaces.map(
+      (surface) => `surface ${surface} matched: ${detected.files_by_surface[surface].join(", ")}`
+    ),
+  };
+}
+
 export function checkContentRules(files, rules) {
   const violations = [];
 

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -124,6 +124,7 @@ function formatList(values) {
 
 export function detectTouchedSurfaces(files, surfaces = {}) {
   const filesBySurface = {};
+  const classifiedFiles = new Set();
 
   for (const [surface, patterns] of Object.entries(surfaces || {})) {
     const matchedFiles = uniqueSorted(
@@ -134,28 +135,64 @@ export function detectTouchedSurfaces(files, surfaces = {}) {
 
     if (matchedFiles.length > 0) {
       filesBySurface[surface] = matchedFiles;
+      for (const file of matchedFiles) {
+        classifiedFiles.add(file);
+      }
     }
   }
+
+  const changedFiles = uniqueSorted(files.map((f) => f.path));
 
   return {
     touched_surfaces: Object.keys(filesBySurface).sort(),
     files_by_surface: filesBySurface,
+    unclassified_files: changedFiles.filter((file) => !classifiedFiles.has(file)),
   };
 }
 
-export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass) {
+function unclassifiedFilesMessage(unclassifiedFiles) {
+  return `surface_matrix found changed files that match no declared surface: ${unclassifiedFiles.join(", ")}`;
+}
+
+function unclassifiedFilesHint() {
+  return "Add matching surface globs or set allow_unclassified_files: true if unclassified files are intentional.";
+}
+
+export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass, options = {}) {
   if (!surfaceMatrix || Object.keys(surfaceMatrix).length === 0) return { ok: true };
 
   const detected = detectTouchedSurfaces(files, surfaces);
   const touchedSurfaces = detected.touched_surfaces;
+  const unclassifiedFiles = detected.unclassified_files;
   const changeClassValue = changeClass || null;
+  const allowUnclassifiedFiles = Boolean(
+    options.allow_unclassified_files || options.allowUnclassifiedFiles
+  );
+  const hasUnclassifiedViolation = unclassifiedFiles.length > 0 && !allowUnclassifiedFiles;
+  const unclassifiedDetails = hasUnclassifiedViolation
+    ? [`changed files matched no declared surface: ${unclassifiedFiles.join(", ")}`]
+    : [];
 
-  if (touchedSurfaces.length === 0) {
+  if (touchedSurfaces.length === 0 && !hasUnclassifiedViolation) {
     return {
       ok: true,
       change_class: changeClassValue,
       touched_surfaces: touchedSurfaces,
       files_by_surface: detected.files_by_surface,
+      unclassified_files: unclassifiedFiles,
+    };
+  }
+
+  if (touchedSurfaces.length === 0 && hasUnclassifiedViolation) {
+    return {
+      ok: false,
+      message: unclassifiedFilesMessage(unclassifiedFiles),
+      change_class: changeClassValue,
+      touched_surfaces: touchedSurfaces,
+      files_by_surface: detected.files_by_surface,
+      unclassified_files: unclassifiedFiles,
+      details: unclassifiedDetails,
+      hint: unclassifiedFilesHint(),
     };
   }
 
@@ -166,7 +203,11 @@ export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass) 
       change_class: null,
       touched_surfaces: touchedSurfaces,
       files_by_surface: detected.files_by_surface,
-      hint: "Set change_class in the contract or pass --change-class <name>.",
+      unclassified_files: unclassifiedFiles,
+      details: unclassifiedDetails,
+      hint: hasUnclassifiedViolation
+        ? `Set change_class in the contract or pass --change-class <name>. ${unclassifiedFilesHint()}`
+        : "Set change_class in the contract or pass --change-class <name>.",
     };
   }
 
@@ -178,8 +219,14 @@ export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass) 
       change_class: changeClassValue,
       touched_surfaces: touchedSurfaces,
       files_by_surface: detected.files_by_surface,
-      details: [`known change classes: ${formatList(Object.keys(surfaceMatrix).sort())}`],
-      hint: "Define the change class in surface_matrix or use one of the configured classes.",
+      unclassified_files: unclassifiedFiles,
+      details: [
+        `known change classes: ${formatList(Object.keys(surfaceMatrix).sort())}`,
+        ...unclassifiedDetails,
+      ],
+      hint: hasUnclassifiedViolation
+        ? `Define the change class in surface_matrix or use one of the configured classes. ${unclassifiedFilesHint()}`
+        : "Define the change class in surface_matrix or use one of the configured classes.",
     };
   }
 
@@ -193,21 +240,33 @@ export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass) 
     : [];
   const explicitlyForbidden = touchedSurfaces.filter((surface) => forbiddenSet.has(surface));
   const violatingSurfaces = uniqueSorted([...notAllowed, ...explicitlyForbidden]);
+  const details = [
+    ...violatingSurfaces.map(
+      (surface) => `surface ${surface} matched: ${detected.files_by_surface[surface].join(", ")}`
+    ),
+    ...unclassifiedDetails,
+  ];
+  let message;
+  if (violatingSurfaces.length > 0 && hasUnclassifiedViolation) {
+    message = `change_class "${changeClassValue}" cannot touch surfaces: ${violatingSurfaces.join(", ")}; unclassified files: ${unclassifiedFiles.join(", ")}`;
+  } else if (violatingSurfaces.length > 0) {
+    message = `change_class "${changeClassValue}" cannot touch surfaces: ${violatingSurfaces.join(", ")}`;
+  } else if (hasUnclassifiedViolation) {
+    message = unclassifiedFilesMessage(unclassifiedFiles);
+  }
 
   return {
-    ok: violatingSurfaces.length === 0,
-    message: violatingSurfaces.length === 0
-      ? undefined
-      : `change_class "${changeClassValue}" cannot touch surfaces: ${violatingSurfaces.join(", ")}`,
+    ok: violatingSurfaces.length === 0 && !hasUnclassifiedViolation,
+    message,
     change_class: changeClassValue,
     touched_surfaces: touchedSurfaces,
     allowed_surfaces: allowedSurfaces,
     forbidden_surfaces: forbiddenSurfaces,
     violating_surfaces: violatingSurfaces,
     files_by_surface: detected.files_by_surface,
-    details: violatingSurfaces.map(
-      (surface) => `surface ${surface} matched: ${detected.files_by_surface[surface].join(", ")}`
-    ),
+    unclassified_files: unclassifiedFiles,
+    details,
+    hint: hasUnclassifiedViolation ? unclassifiedFilesHint() : undefined,
   };
 }
 

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -86,6 +86,9 @@ function printCheckDetails(mode, check) {
   if (check.violating_surfaces) {
     write(`    violating_surfaces: ${formatList(check.violating_surfaces)}`);
   }
+  if (check.unclassified_files && check.unclassified_files.length > 0) {
+    write(`    unclassified_files: ${formatList(check.unclassified_files)}`);
+  }
   if (check.details) {
     for (const detail of check.details) write(`    ${detail}`);
   }
@@ -110,6 +113,9 @@ function detailFromCheck(check) {
   if (check.allowed_surfaces) details.push(`allowed_surfaces: ${formatList(check.allowed_surfaces)}`);
   if (check.forbidden_surfaces) details.push(`forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
   if (check.violating_surfaces) details.push(`violating_surfaces: ${formatList(check.violating_surfaces)}`);
+  if (check.unclassified_files && check.unclassified_files.length > 0) {
+    details.push(`unclassified_files: ${formatList(check.unclassified_files)}`);
+  }
   if (check.details) details.push(...check.details);
   if (check.errors) details.push(...check.errors);
   if (check.hint) details.push(`hint: ${check.hint}`);
@@ -137,6 +143,9 @@ function violationFromCheck(name, check) {
   if (check.forbidden_surfaces) violation.forbidden_surfaces = check.forbidden_surfaces;
   if (check.violating_surfaces) violation.violating_surfaces = check.violating_surfaces;
   if (check.files_by_surface) violation.files_by_surface = check.files_by_surface;
+  if (check.unclassified_files && check.unclassified_files.length > 0) {
+    violation.unclassified_files = check.unclassified_files;
+  }
 
   return violation;
 }

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -42,6 +42,14 @@ function writeViolation(mode, message) {
   }
 }
 
+function formatList(values) {
+  return values && values.length > 0 ? values.join(", ") : "(none)";
+}
+
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
 function printCheckDetails(mode, check) {
   const write = (message) => writeViolation(mode, message);
 
@@ -63,6 +71,21 @@ function printCheckDetails(mode, check) {
   if (check.must_not_touch) {
     write(`    must_not_touch: ${check.must_not_touch.join(", ")}`);
   }
+  if (hasOwn(check, "change_class")) {
+    write(`    change_class: ${check.change_class || "(missing)"}`);
+  }
+  if (check.touched_surfaces) {
+    write(`    touched_surfaces: ${formatList(check.touched_surfaces)}`);
+  }
+  if (check.allowed_surfaces) {
+    write(`    allowed_surfaces: ${formatList(check.allowed_surfaces)}`);
+  }
+  if (check.forbidden_surfaces) {
+    write(`    forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
+  }
+  if (check.violating_surfaces) {
+    write(`    violating_surfaces: ${formatList(check.violating_surfaces)}`);
+  }
   if (check.details) {
     for (const detail of check.details) write(`    ${detail}`);
   }
@@ -82,6 +105,11 @@ function detailFromCheck(check) {
   if (check.touched) details.push(...check.touched.map((f) => `touched: ${f}`));
   if (check.must_touch) details.push(`must_touch: ${check.must_touch.join(", ")}`);
   if (check.must_not_touch) details.push(`must_not_touch: ${check.must_not_touch.join(", ")}`);
+  if (hasOwn(check, "change_class")) details.push(`change_class: ${check.change_class || "(missing)"}`);
+  if (check.touched_surfaces) details.push(`touched_surfaces: ${formatList(check.touched_surfaces)}`);
+  if (check.allowed_surfaces) details.push(`allowed_surfaces: ${formatList(check.allowed_surfaces)}`);
+  if (check.forbidden_surfaces) details.push(`forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
+  if (check.violating_surfaces) details.push(`violating_surfaces: ${formatList(check.violating_surfaces)}`);
   if (check.details) details.push(...check.details);
   if (check.errors) details.push(...check.errors);
   if (check.hint) details.push(`hint: ${check.hint}`);
@@ -89,7 +117,7 @@ function detailFromCheck(check) {
 }
 
 function violationFromCheck(name, check) {
-  return {
+  const violation = {
     rule: name,
     message: check.message,
     actual: check.actual,
@@ -102,6 +130,15 @@ function violationFromCheck(name, check) {
     errors: check.errors || [],
     hint: check.hint,
   };
+
+  if (hasOwn(check, "change_class")) violation.change_class = check.change_class;
+  if (check.touched_surfaces) violation.touched_surfaces = check.touched_surfaces;
+  if (check.allowed_surfaces) violation.allowed_surfaces = check.allowed_surfaces;
+  if (check.forbidden_surfaces) violation.forbidden_surfaces = check.forbidden_surfaces;
+  if (check.violating_surfaces) violation.violating_surfaces = check.violating_surfaces;
+  if (check.files_by_surface) violation.files_by_surface = check.files_by_surface;
+
+  return violation;
 }
 
 function renderMarkdownTableCell(value) {

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -5,6 +5,7 @@ import Ajv from "ajv";
 import { extractContract, extractLinkedIssueNumbers, resolveContract } from "./markdown-contract.mjs";
 import {
   compileForbidRegex,
+  compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
 } from "./policy-compiler.mjs";
@@ -22,6 +23,7 @@ import {
   checkNewFilesBudget,
   checkNetAddedLinesBudget,
   checkCochangeRules,
+  checkSurfaceMatrix,
   checkContentRules,
   checkMustTouch,
   checkMustNotTouch,
@@ -159,6 +161,15 @@ export function runCheckPR(roots, args = []) {
     }
   }
 
+  const surfaceErrors = compileSurfacePolicy(policy);
+  if (surfaceErrors.length > 0) {
+    ok = false;
+    console.error("FAIL: surface policy compilation");
+    for (const e of surfaceErrors) {
+      console.error(`  ${e.message}`);
+    }
+  }
+
   for (const w of warnReservedPolicyFields(policy)) {
     console.warn(`WARN: ${w}`);
   }
@@ -237,6 +248,10 @@ export function runCheckPR(roots, args = []) {
   reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+
+  if (policy.surface_matrix) {
+    reporter.report("surface-matrix", checkSurfaceMatrix(files, policy.surfaces, policy.surface_matrix, contract?.change_class || null));
+  }
 
   const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
   if (cochangeViolations.length > 0) {

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -250,7 +250,16 @@ export function runCheckPR(roots, args = []) {
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
 
   if (policy.surface_matrix) {
-    reporter.report("surface-matrix", checkSurfaceMatrix(files, policy.surfaces, policy.surface_matrix, contract?.change_class || null));
+    reporter.report(
+      "surface-matrix",
+      checkSurfaceMatrix(
+        files,
+        policy.surfaces,
+        policy.surface_matrix,
+        contract?.change_class || null,
+        { allow_unclassified_files: policy.allow_unclassified_files }
+      )
+    );
   }
 
   const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -100,6 +100,7 @@ function buildPRTemplate() {
 
 \`\`\`repo-guard-yaml
 change_type: feature
+change_class: kernel-hardening
 scope:
   - src/
 budgets: {}
@@ -135,6 +136,7 @@ body:
       value: |
         \`\`\`repo-guard-yaml
         change_type: feature
+        change_class: kernel-hardening
         scope:
           - src/
         budgets: {}

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -17,6 +17,57 @@ export function compileForbidRegex(contentRules) {
   return errors;
 }
 
+export function compileSurfacePolicy(policy) {
+  const errors = [];
+  const surfaces = policy.surfaces || {};
+  const surfaceNames = new Set(Object.keys(surfaces));
+  const changeClasses = new Set(policy.change_classes || []);
+  const surfaceMatrix = policy.surface_matrix || {};
+
+  if (!policy.surface_matrix) return errors;
+
+  if (surfaceNames.size === 0) {
+    errors.push({ message: "surface_matrix requires at least one named surface in surfaces" });
+  }
+  if (changeClasses.size === 0) {
+    errors.push({ message: "surface_matrix requires at least one named change class in change_classes" });
+  }
+
+  for (const [changeClass, rule] of Object.entries(surfaceMatrix)) {
+    if (changeClasses.size > 0 && !changeClasses.has(changeClass)) {
+      errors.push({
+        change_class: changeClass,
+        message: `surface_matrix entry "${changeClass}" is not listed in change_classes`,
+      });
+    }
+
+    const allowed = new Set(rule.allow || []);
+    for (const field of ["allow", "forbid"]) {
+      for (const surface of rule[field] || []) {
+        if (!surfaceNames.has(surface)) {
+          errors.push({
+            change_class: changeClass,
+            surface,
+            message: `surface_matrix["${changeClass}"].${field} references unknown surface "${surface}"`,
+          });
+        }
+      }
+    }
+
+    for (const surface of rule.forbid || []) {
+      if (allowed.has(surface)) {
+        errors.push({
+          change_class: changeClass,
+          surface,
+          message: `surface_matrix["${changeClass}"] lists surface "${surface}" in both allow and forbid`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function warnReservedContractFields(contract) {
   const warnings = [];
   if (contract.overrides && contract.overrides.length > 0) {

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -13,12 +13,14 @@ import {
   checkNewFilesBudget,
   checkNetAddedLinesBudget,
   checkCochangeRules,
+  checkSurfaceMatrix,
   checkContentRules,
   checkMustTouch,
   checkMustNotTouch,
 } from "./diff-checker.mjs";
 import {
   compileForbidRegex,
+  compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
 } from "./policy-compiler.mjs";
@@ -109,8 +111,9 @@ function runCheckDiff(roots, args) {
   let base = null;
   let head = null;
   let contractPath = null;
+  let cliChangeClass = null;
   let format = "text";
-  const KNOWN_DIFF_OPTS = new Set(["--base", "--head", "--contract", "--format"]);
+  const KNOWN_DIFF_OPTS = new Set(["--base", "--head", "--contract", "--format", "--change-class"]);
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--base" && args[i + 1]) base = args[++i];
@@ -119,16 +122,25 @@ function runCheckDiff(roots, args) {
       contractPath = resolve(roots.repoRoot, args[++i]);
     } else if (args[i] === "--format" && args[i + 1]) {
       format = args[++i];
+    } else if (args[i] === "--change-class") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        console.error("Error: --change-class requires a name argument");
+        console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--change-class <name>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
+        process.exit(1);
+      }
+      cliChangeClass = next;
+      i++;
     } else if (args[i].startsWith("-") && !KNOWN_DIFF_OPTS.has(args[i])) {
       console.error(`Unknown option for check-diff: ${args[i]}`);
-      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
+      console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--change-class <name>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
       process.exit(1);
     }
   }
 
   if (!["text", "json", "summary"].includes(format)) {
     console.error(`Unknown check-diff format: ${format}`);
-    console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
+    console.error("Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--change-class <name>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]");
     process.exit(1);
   }
 
@@ -150,6 +162,17 @@ function runCheckDiff(roots, args) {
       console.error("FAIL: forbid_regex compilation");
       for (const e of regexErrors) {
         console.error(`  [${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`);
+      }
+    }
+  }
+
+  const surfaceErrors = compileSurfacePolicy(policy);
+  if (surfaceErrors.length > 0) {
+    ok = false;
+    if (!quiet) {
+      console.error("FAIL: surface policy compilation");
+      for (const e of surfaceErrors) {
+        console.error(`  ${e.message}`);
       }
     }
   }
@@ -216,6 +239,11 @@ function runCheckDiff(roots, args) {
   reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+
+  if (policy.surface_matrix) {
+    const declaredChangeClass = cliChangeClass || contract?.change_class || null;
+    reporter.report("surface-matrix", checkSurfaceMatrix(files, policy.surfaces, policy.surface_matrix, declaredChangeClass));
+  }
 
   const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
   if (cochangeViolations.length > 0) {

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -242,7 +242,16 @@ function runCheckDiff(roots, args) {
 
   if (policy.surface_matrix) {
     const declaredChangeClass = cliChangeClass || contract?.change_class || null;
-    reporter.report("surface-matrix", checkSurfaceMatrix(files, policy.surfaces, policy.surface_matrix, declaredChangeClass));
+    reporter.report(
+      "surface-matrix",
+      checkSurfaceMatrix(
+        files,
+        policy.surfaces,
+        policy.surface_matrix,
+        declaredChangeClass,
+        { allow_unclassified_files: policy.allow_unclassified_files }
+      )
+    );
   }
 
   const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);

--- a/templates/issue-contract-example.md
+++ b/templates/issue-contract-example.md
@@ -5,6 +5,7 @@ as a YAML code block so `repo-guard` can validate it:
 
 ```repo-guard-yaml
 change_type: feature
+change_class: kernel-hardening
 scope:
   - src/auth.mjs
   - src/middleware/**

--- a/templates/pr-contract-example.md
+++ b/templates/pr-contract-example.md
@@ -5,6 +5,7 @@ validate the proposed changes against the repository policy:
 
 ```repo-guard-yaml
 change_type: bugfix
+change_class: kernel-hardening
 scope:
   - src/pagination.mjs
 budgets:

--- a/tests/fixtures/diff-contract.json
+++ b/tests/fixtures/diff-contract.json
@@ -1,5 +1,6 @@
 {
   "change_type": "feature",
+  "change_class": "kernel-hardening",
   "scope": ["src/**"],
   "budgets": {
     "max_new_files": 3,

--- a/tests/fixtures/valid-contract.json
+++ b/tests/fixtures/valid-contract.json
@@ -1,5 +1,6 @@
 {
   "change_type": "feature",
+  "change_class": "kernel-hardening",
   "scope": ["src/**", "schemas/**", "tests/**"],
   "budgets": {
     "max_new_files": 15,

--- a/tests/fixtures/valid-policy.json
+++ b/tests/fixtures/valid-policy.json
@@ -15,6 +15,27 @@
     "max_new_files": 20,
     "max_net_added_lines": 500
   },
+  "surfaces": {
+    "kernel": ["include/**", "src/**"],
+    "tests": ["tests/**"],
+    "docs": ["docs/**", "README.md"],
+    "generated": ["single_include/**"]
+  },
+  "change_classes": ["kernel-hardening", "docs-cleanup", "generated-refresh"],
+  "surface_matrix": {
+    "kernel-hardening": {
+      "allow": ["kernel", "tests"],
+      "forbid": ["generated"]
+    },
+    "docs-cleanup": {
+      "allow": ["docs"],
+      "forbid": ["kernel", "tests", "generated"]
+    },
+    "generated-refresh": {
+      "allow": ["generated"],
+      "forbid": ["kernel", "docs", "tests"]
+    }
+  },
   "content_rules": [
     {
       "id": "forbid_doxygen_tags_in_headers",

--- a/tests/fixtures/valid-policy.json
+++ b/tests/fixtures/valid-policy.json
@@ -22,6 +22,7 @@
     "generated": ["single_include/**"]
   },
   "change_classes": ["kernel-hardening", "docs-cleanup", "generated-refresh"],
+  "allow_unclassified_files": false,
   "surface_matrix": {
     "kernel-hardening": {
       "allow": ["kernel", "tests"],

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -314,6 +314,7 @@ const touchedSurfaces = detectTouchedSurfaces(surfaceFiles, surfaces);
 expect("10. detects touched surface count", touchedSurfaces.touched_surfaces.length, 3);
 expect("10. detects docs surface", touchedSurfaces.touched_surfaces.includes("docs"), true);
 expect("10. maps files by surface", touchedSurfaces.files_by_surface.kernel[0], "src/core.mjs");
+expect("10. reports no unclassified files for fully classified diff", touchedSurfaces.unclassified_files.length, 0);
 
 const surfaceMatrix = {
   "kernel-hardening": {
@@ -334,6 +335,27 @@ const kernelOnlyFiles = [
 const kernelSurfaceResult = checkSurfaceMatrix(kernelOnlyFiles, surfaces, surfaceMatrix, "kernel-hardening");
 expect("10. allowed kernel/test surface combination passes", kernelSurfaceResult.ok, true);
 expect("10. allowed combination reports change_class", kernelSurfaceResult.change_class, "kernel-hardening");
+
+const unclassifiedOnlyFiles = [
+  { path: "scripts/tool.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+];
+
+const unclassifiedSurfaces = detectTouchedSurfaces(unclassifiedOnlyFiles, surfaces);
+expect("10. detects unclassified changed file", unclassifiedSurfaces.unclassified_files[0], "scripts/tool.mjs");
+
+const unclassifiedResult = checkSurfaceMatrix(unclassifiedOnlyFiles, surfaces, surfaceMatrix, "docs-cleanup");
+expect("10. surface matrix rejects unclassified files by default", unclassifiedResult.ok, false);
+expect("10. reports unclassified files", unclassifiedResult.unclassified_files[0], "scripts/tool.mjs");
+expect("10. unclassified failure message names file", unclassifiedResult.message.includes("scripts/tool.mjs"), true);
+
+const allowedUnclassifiedResult = checkSurfaceMatrix(
+  unclassifiedOnlyFiles,
+  surfaces,
+  surfaceMatrix,
+  "docs-cleanup",
+  { allow_unclassified_files: true }
+);
+expect("10. policy can explicitly allow unclassified files", allowedUnclassifiedResult.ok, true);
 
 const docsSurfaceResult = checkSurfaceMatrix(surfaceFiles, surfaces, surfaceMatrix, "docs-cleanup");
 expect("10. docs class rejects kernel/test surfaces", docsSurfaceResult.ok, false);

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -9,6 +9,8 @@ import {
   checkContentRules,
   checkMustTouch,
   checkMustNotTouch,
+  detectTouchedSurfaces,
+  checkSurfaceMatrix,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -291,6 +293,61 @@ const gitkeepFiles = [
 const gitkeepFiltered = filterOperationalPaths(gitkeepFiles, [".claude/**", ".gitkeep"]);
 expect("9. .gitkeep filtered as operational", gitkeepFiltered.length, 1);
 expect("9. .gitkeep: only src file remains", gitkeepFiltered[0].path, "src/app.mjs");
+
+// --- 10. surface matrix ---
+
+const surfaceFiles = [
+  { path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+  { path: "tests/core.test.mjs", addedLines: ["test"], deletedLines: [], status: "modified" },
+  { path: "docs/guide.md", addedLines: ["docs"], deletedLines: [], status: "modified" },
+];
+
+const surfaces = {
+  kernel: ["src/**"],
+  tests: ["tests/**"],
+  docs: ["docs/**", "README.md"],
+  generated: ["single_include/**"],
+  release: ["CHANGELOG.md", "package.json"],
+};
+
+const touchedSurfaces = detectTouchedSurfaces(surfaceFiles, surfaces);
+expect("10. detects touched surface count", touchedSurfaces.touched_surfaces.length, 3);
+expect("10. detects docs surface", touchedSurfaces.touched_surfaces.includes("docs"), true);
+expect("10. maps files by surface", touchedSurfaces.files_by_surface.kernel[0], "src/core.mjs");
+
+const surfaceMatrix = {
+  "kernel-hardening": {
+    allow: ["kernel", "tests"],
+    forbid: ["generated", "release"],
+  },
+  "docs-cleanup": {
+    allow: ["docs", "governance"],
+    forbid: ["kernel", "tests", "generated", "release"],
+  },
+};
+
+const kernelOnlyFiles = [
+  { path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+  { path: "tests/core.test.mjs", addedLines: ["test"], deletedLines: [], status: "modified" },
+];
+
+const kernelSurfaceResult = checkSurfaceMatrix(kernelOnlyFiles, surfaces, surfaceMatrix, "kernel-hardening");
+expect("10. allowed kernel/test surface combination passes", kernelSurfaceResult.ok, true);
+expect("10. allowed combination reports change_class", kernelSurfaceResult.change_class, "kernel-hardening");
+
+const docsSurfaceResult = checkSurfaceMatrix(surfaceFiles, surfaces, surfaceMatrix, "docs-cleanup");
+expect("10. docs class rejects kernel/test surfaces", docsSurfaceResult.ok, false);
+expect("10. reports declared change_class", docsSurfaceResult.change_class, "docs-cleanup");
+expect("10. reports touched surfaces", docsSurfaceResult.touched_surfaces.join(","), "docs,kernel,tests");
+expect("10. reports violating surfaces", docsSurfaceResult.violating_surfaces.join(","), "kernel,tests");
+
+const missingClassResult = checkSurfaceMatrix(surfaceFiles, surfaces, surfaceMatrix, null);
+expect("10. surface matrix requires change_class", missingClassResult.ok, false);
+expect("10. missing change_class message", missingClassResult.message, "surface_matrix requires a declared change_class");
+
+const unknownClassResult = checkSurfaceMatrix(surfaceFiles, surfaces, surfaceMatrix, "release");
+expect("10. undefined change_class fails", unknownClassResult.ok, false);
+expect("10. undefined change_class is reported", unknownClassResult.change_class, "release");
 
 // --- Summary ---
 

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   compileForbidRegex,
+  compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
 } from "../src/policy-compiler.mjs";
@@ -54,6 +55,60 @@ describe("forbid_regex eager validation", () => {
     ];
     const errors = compileForbidRegex(rules);
     assert.equal(errors.length, 0);
+  });
+});
+
+describe("surface policy compilation", () => {
+  it("accepts matrix references to declared surfaces and change classes", () => {
+    const errors = compileSurfacePolicy({
+      surfaces: {
+        kernel: ["src/**"],
+        tests: ["tests/**"],
+      },
+      change_classes: ["kernel-hardening"],
+      surface_matrix: {
+        "kernel-hardening": {
+          allow: ["kernel", "tests"],
+          forbid: [],
+        },
+      },
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it("rejects matrix entries that reference unknown surfaces", () => {
+    const errors = compileSurfacePolicy({
+      surfaces: {
+        docs: ["docs/**"],
+      },
+      change_classes: ["docs-cleanup"],
+      surface_matrix: {
+        "docs-cleanup": {
+          allow: ["docs", "kernel"],
+          forbid: ["generated"],
+        },
+      },
+    });
+    assert.equal(errors.length, 2);
+    assert.ok(errors.some((e) => e.message.includes("kernel")));
+    assert.ok(errors.some((e) => e.message.includes("generated")));
+  });
+
+  it("rejects matrix entries that are not declared change classes", () => {
+    const errors = compileSurfacePolicy({
+      surfaces: {
+        docs: ["docs/**"],
+      },
+      change_classes: ["docs-cleanup"],
+      surface_matrix: {
+        release: {
+          allow: ["docs"],
+          forbid: [],
+        },
+      },
+    });
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("change_classes"));
   });
 });
 

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -132,9 +132,60 @@ function makeSurfaceRepo() {
   execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
 
   execSync("mkdir -p docs src", { cwd: dir, stdio: "pipe" });
+  execSync("mkdir -p scripts", { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "docs", "guide.md"), "# Guide\n");
   writeFileSync(join(dir, "src", "feature.mjs"), "export const value = 1;\n");
+  writeFileSync(join(dir, "scripts", "tool.mjs"), "export const tool = true;\n");
   execSync("git add -A && git commit -m docs-plus-kernel", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
+function makeUnclassifiedOnlySurfaceRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-unclassified-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    surfaces: {
+      docs: ["docs/**", "README.md"],
+    },
+    change_classes: ["docs-cleanup"],
+    allow_unclassified_files: true,
+    surface_matrix: {
+      "docs-cleanup": {
+        allow: ["docs"],
+        forbid: [],
+      },
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  execSync("mkdir -p scripts", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "scripts", "tool.mjs"), "export const tool = true;\n");
+  execSync("git add -A && git commit -m script", { cwd: dir, stdio: "pipe" });
 
   return {
     dir,
@@ -207,9 +258,36 @@ console.log("\n--- check-diff --change-class enforces surface_matrix ---");
       v.change_class === "docs-cleanup" &&
       v.touched_surfaces.includes("docs") &&
       v.touched_surfaces.includes("kernel") &&
-      v.violating_surfaces.includes("kernel")
+      v.violating_surfaces.includes("kernel") &&
+      v.unclassified_files.includes("scripts/tool.mjs")
     ),
     true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff honors allow_unclassified_files policy switch ---");
+{
+  const repo = makeUnclassifiedOnlySurfaceRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+    "--change-class", "docs-cleanup",
+  ]);
+
+  expect("allow_unclassified_files keeps unclassified-only diff passing", result.code, 0);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("allow_unclassified_files stdout is valid json", true, true);
+  } catch (e) {
+    expect("allow_unclassified_files stdout is valid json", e.message, "valid json");
+  }
+  expect("allow_unclassified_files result is ok", parsed?.ok, true);
+  expect("allow_unclassified_files has no violations", parsed?.violations.length, 0);
 
   rmSync(repo.dir, { recursive: true });
 }

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -81,6 +81,68 @@ function makeRepo() {
   };
 }
 
+function makeSurfaceRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-surfaces-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    surfaces: {
+      kernel: ["src/**"],
+      tests: ["tests/**"],
+      docs: ["docs/**", "README.md"],
+      governance: ["repo-policy.json", ".github/**"],
+      generated: ["single_include/**"],
+      release: ["CHANGELOG.md", "package.json"],
+    },
+    change_classes: ["docs-cleanup", "kernel-hardening", "generated-refresh"],
+    surface_matrix: {
+      "docs-cleanup": {
+        allow: ["docs", "governance"],
+        forbid: ["kernel", "tests", "generated", "release"],
+      },
+      "kernel-hardening": {
+        allow: ["kernel", "tests"],
+        forbid: ["generated", "release"],
+      },
+      "generated-refresh": {
+        allow: ["generated", "release"],
+        forbid: ["kernel", "docs", "governance"],
+      },
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  execSync("mkdir -p docs src", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "docs", "guide.md"), "# Guide\n");
+  writeFileSync(join(dir, "src", "feature.mjs"), "export const value = 1;\n");
+  execSync("git add -A && git commit -m docs-plus-kernel", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
 console.log("\n--- check-diff --format json emits stable machine-readable result ---");
 {
   const repo = makeRepo();
@@ -114,6 +176,39 @@ console.log("\n--- check-diff --format json emits stable machine-readable result
     true);
   expect("cochange violation is detailed",
     parsed?.violations.some((v) => v.rule.startsWith("cochange:") && v.must_touch.includes("tests/**")),
+    true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff --change-class enforces surface_matrix ---");
+{
+  const repo = makeSurfaceRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+    "--change-class", "docs-cleanup",
+  ]);
+
+  expect("surface matrix exit code follows blocking failure", result.code, 1);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("surface matrix stdout is valid json", true, true);
+  } catch (e) {
+    expect("surface matrix stdout is valid json", e.message, "valid json");
+  }
+  expect("surface matrix violation is detailed",
+    parsed?.violations.some((v) =>
+      v.rule === "surface-matrix" &&
+      v.change_class === "docs-cleanup" &&
+      v.touched_surfaces.includes("docs") &&
+      v.touched_surfaces.includes("kernel") &&
+      v.violating_surfaces.includes("kernel")
+    ),
     true);
 
   rmSync(repo.dir, { recursive: true });


### PR DESCRIPTION
## Summary

- Add `surfaces`, `change_classes`, and `surface_matrix` policy fields for ownership-aware diff validation.
- Add optional contract `change_class`, plus `check-diff --change-class` and a reusable Action `change-class` input.
- Reject unclassified changed files by default when `surface_matrix` is enabled, and report them as `unclassified_files` so matrix coverage cannot be silently bypassed.
- Add explicit `allow_unclassified_files: true` policy opt-out for repositories that intentionally define partial surface coverage.
- Report matrix failures with the declared change class, detected touched surfaces, allowed/forbidden surfaces, violating surfaces, matched files, and unclassified files.
- Update templates and README with a realistic generated-refresh example that avoids a global generated-file ban.

Fixes netkeep80/repo-guard#33

## Reproduction / Verification

The owner-requested bypass reproduced before the latest fix with a changed file like `scripts/tool.mjs` matching no declared surface: `checkSurfaceMatrix(...)` returned `ok: true` with `touched_surfaces: []`. It now returns `ok: false`, names `scripts/tool.mjs` in `unclassified_files`, and includes a hint to add a surface glob or explicitly set `allow_unclassified_files: true`.

Automated coverage now includes:

- `tests/test-diff-rules.mjs` covers surface detection, missing/unknown `change_class`, allowed combinations, surface violations, default rejection of unclassified changed files, and explicit opt-out with `allow_unclassified_files: true`.
- `tests/test-structured-output.mjs` creates a temporary repo where `docs-cleanup` touches docs, kernel, and an unclassified script, then verifies `check-diff --change-class docs-cleanup --format json` rejects the diff with structured surface and unclassified-file details.
- `tests/test-structured-output.mjs` also verifies the policy-level `allow_unclassified_files: true` switch lets an intentionally unclassified-only diff pass.
- `tests/test-hardening.mjs` verifies bad matrix references are rejected during policy compilation.
- `tests/fixtures/valid-policy.json` and `tests/fixtures/valid-contract.json` validate the new schema fields.

Local checks run:

- `npm run test:diff`
- `npm run test:structured-output`
- `npm run test:schemas`
- `npm test`
- `node src/repo-guard.mjs`
- `node src/repo-guard.mjs check-diff`
- `git diff --check`
- `npm pack --pack-destination /tmp/repo-guard-pack-smoke`
- `npm install /tmp/repo-guard-pack-smoke/repo-guard-1.0.0.tgz --prefix /tmp/repo-guard-pack-smoke/install`
- `node /tmp/repo-guard-pack-smoke/install/node_modules/repo-guard/src/repo-guard.mjs`

## Change Contract

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - src/
  - schemas/
  - tests/
  - README.md
  - action.yml
  - templates/
  - .github/
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 1000
must_touch:
  - src/diff-checker.mjs
  - schemas/repo-policy.schema.json
  - tests/test-diff-rules.mjs
must_not_touch:
  - LICENSE
expected_effects:
  - repo-guard can validate ownership-aware surface matrices from a declared change class
  - surface_matrix fails closed on changed files that match no declared surface unless policy explicitly allows them
```
