### PR TITLE
Add surface debt validation to change contracts

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-18T23:58:45.653Z for PR creation at branch issue-35-6c0751591e4c for issue https://github.com/netkeep80/repo-guard/issues/35

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-18T23:58:45.653Z for PR creation at branch issue-35-6c0751591e4c for issue https://github.com/netkeep80/repo-guard/issues/35

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Policy engine для репозитория: формализует правил
 | Canonical docs budget | Ограничивает количество новых `.md` файлов |
 | Max new files | Ограничивает общее количество новых файлов |
 | Max net added lines | Ограничивает `added − deleted` строк |
+| Surface debt | Требует явный `surface_debt`, если diff временно увеличивает поверхность репозитория |
 | Co-change rules | Если изменён X, должен быть изменён и Y |
 | Surface matrix | Проверяет, что объявленный `change_class` трогает только разрешённые surface-классы |
 | Content rules | Запрещает regex-паттерны в добавленных строках |
@@ -229,6 +230,12 @@ The JSON result is intended as an API surface. Field names are stable and intent
       "touched": [],
       "must_touch": [],
       "must_not_touch": [],
+      "status": "undeclared_growth",
+      "growth": {
+        "new_files": 2,
+        "new_files_list": ["src/feature.mjs", "tests/feature.test.mjs"],
+        "net_added_lines": 42
+      },
       "details": [],
       "errors": []
     }
@@ -435,6 +442,13 @@ scope:
 budgets:
   max_new_files: 0
   max_new_docs: 0
+surface_debt:
+  kind: temporary_growth
+  reason: Introduce extraction path before removing duplicated code
+  expected_delta:
+    max_new_files: 1
+    max_net_added_lines: 60
+  repayment_issue: 123
 must_touch:
   - src/pagination.mjs
 must_not_touch:
@@ -445,7 +459,9 @@ expected_effects:
 ```
 ````
 
-Contract говорит: это bugfix, который должен затронуть `src/pagination.mjs`, не должен трогать схемы и policy, и не должен создавать новых файлов.
+Contract говорит: это bugfix, который должен затронуть `src/pagination.mjs`, не должен трогать схемы и policy, и не должен создавать новых файлов. Если diff всё же временно увеличивает поверхность репозитория, `surface_debt` фиксирует причину, ожидаемый рост и issue, где долг будет погашен.
+
+`surface_debt` проверяется только по фактическому росту diff: количеству новых файлов и `added - deleted` строк. Без debt рост получает статус `undeclared_growth`; если фактический рост больше `expected_delta`, статус будет `declared_debt_exceeded`; если нет `repayment_issue`, статус будет `missing_repayment_target`.
 
 Для существующих PR сохраняется совместимость с JSON-блоком ` ```repo-guard-json `; оба формата дают одну и ту же нормализованную модель contract перед schema validation.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Policy engine для репозитория: формализует правил
 | Canonical docs budget | Ограничивает количество новых `.md` файлов |
 | Max new files | Ограничивает общее количество новых файлов |
 | Max net added lines | Ограничивает `added − deleted` строк |
-| Surface debt | Требует явный `surface_debt`, если diff временно увеличивает поверхность репозитория |
+| Surface debt | Проверяет объявленный `surface_debt`, если contract явно описывает временный рост |
 | Co-change rules | Если изменён X, должен быть изменён и Y |
 | Surface matrix | Проверяет, что объявленный `change_class` трогает только разрешённые surface-классы |
 | Content rules | Запрещает regex-паттерны в добавленных строках |
@@ -230,12 +230,6 @@ The JSON result is intended as an API surface. Field names are stable and intent
       "touched": [],
       "must_touch": [],
       "must_not_touch": [],
-      "status": "undeclared_growth",
-      "growth": {
-        "new_files": 2,
-        "new_files_list": ["src/feature.mjs", "tests/feature.test.mjs"],
-        "net_added_lines": 42
-      },
       "details": [],
       "errors": []
     }
@@ -461,7 +455,7 @@ expected_effects:
 
 Contract говорит: это bugfix, который должен затронуть `src/pagination.mjs`, не должен трогать схемы и policy, и не должен создавать новых файлов. Если diff всё же временно увеличивает поверхность репозитория, `surface_debt` фиксирует причину, ожидаемый рост и issue, где долг будет погашен.
 
-`surface_debt` проверяется только по фактическому росту diff: количеству новых файлов и `added - deleted` строк. Без debt рост получает статус `undeclared_growth`; если фактический рост больше `expected_delta`, статус будет `declared_debt_exceeded`; если нет `repayment_issue`, статус будет `missing_repayment_target`.
+`surface_debt` проверяется только когда contract явно его объявляет. Проверка сравнивает declaration с фактическим ростом diff: количеством новых файлов и `added - deleted` строк. Если рост есть, но `surface_debt` не объявлен, repo-guard сообщает не блокирующий статус `undeclared`; если фактический рост больше `expected_delta`, статус будет `declared_debt_exceeded`; если нет `repayment_issue`, статус будет `missing_repayment_target`.
 
 Для существующих PR сохраняется совместимость с JSON-блоком ` ```repo-guard-json `; оба формата дают одну и ту же нормализованную модель contract перед schema validation.
 

--- a/schemas/change-contract.schema.json
+++ b/schemas/change-contract.schema.json
@@ -45,6 +45,41 @@
         }
       }
     },
+    "surface_debt": {
+      "type": "object",
+      "description": "Explicit temporary repository surface growth declaration.",
+      "required": ["kind", "reason", "expected_delta", "repayment_issue"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["temporary_growth"]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "expected_delta": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": false,
+          "properties": {
+            "max_new_files": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "max_net_added_lines": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "repayment_issue": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
     "must_touch": {
       "type": "array",
       "items": { "type": "string" },

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -122,15 +122,13 @@ export function checkSurfaceDebt(files, surfaceDebt) {
 
   if (!surfaceDebt) {
     return {
-      ok: false,
-      status: "undeclared_growth",
-      message: "diff grows repository surface but no surface_debt is declared",
+      ok: true,
+      status: "undeclared",
       growth,
       details: [
         `new files: ${growth.new_files}`,
         `net added lines: ${growth.net_added_lines}`,
       ],
-      hint: "Declare surface_debt with kind, reason, expected_delta, and repayment_issue when temporary growth is intentional.",
     };
   }
 

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -94,6 +94,89 @@ export function checkNetAddedLinesBudget(files, maxNetAddedLines) {
   };
 }
 
+export function calculateDiffGrowth(files) {
+  const newFiles = files.filter((f) => f.status === "added").map((f) => f.path);
+  let netAddedLines = 0;
+  for (const f of files) {
+    netAddedLines += f.addedLines.length - (f.deletedLines ? f.deletedLines.length : 0);
+  }
+
+  return {
+    new_files: newFiles.length,
+    new_files_list: newFiles,
+    net_added_lines: netAddedLines,
+  };
+}
+
+export function checkSurfaceDebt(files, surfaceDebt) {
+  const growth = calculateDiffGrowth(files);
+  const hasGrowth = growth.new_files > 0 || growth.net_added_lines > 0;
+
+  if (!hasGrowth) {
+    return {
+      ok: true,
+      status: "not_needed",
+      growth,
+    };
+  }
+
+  if (!surfaceDebt) {
+    return {
+      ok: false,
+      status: "undeclared_growth",
+      message: "diff grows repository surface but no surface_debt is declared",
+      growth,
+      details: [
+        `new files: ${growth.new_files}`,
+        `net added lines: ${growth.net_added_lines}`,
+      ],
+      hint: "Declare surface_debt with kind, reason, expected_delta, and repayment_issue when temporary growth is intentional.",
+    };
+  }
+
+  const missing = [];
+  if (!surfaceDebt.repayment_issue) missing.push("repayment_issue");
+
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      status: "missing_repayment_target",
+      message: `declared surface debt is missing repayment target: ${missing.join(", ")}`,
+      growth,
+      surface_debt: surfaceDebt,
+      details: missing.map((field) => `missing ${field}`),
+      hint: "Set repayment_issue to the issue number where the temporary growth will be repaid.",
+    };
+  }
+
+  const expectedDelta = surfaceDebt.expected_delta || {};
+  const exceeded = [];
+  if (
+    expectedDelta.max_new_files !== undefined &&
+    growth.new_files > expectedDelta.max_new_files
+  ) {
+    exceeded.push(`new files ${growth.new_files} exceeds declared debt ${expectedDelta.max_new_files}`);
+  }
+  if (
+    expectedDelta.max_net_added_lines !== undefined &&
+    growth.net_added_lines > expectedDelta.max_net_added_lines
+  ) {
+    exceeded.push(`net added lines ${growth.net_added_lines} exceeds declared debt ${expectedDelta.max_net_added_lines}`);
+  }
+
+  return {
+    ok: exceeded.length === 0,
+    status: exceeded.length === 0 ? "declared" : "declared_debt_exceeded",
+    message: exceeded.length > 0 ? "declared surface debt is smaller than actual diff growth" : undefined,
+    growth,
+    surface_debt: surfaceDebt,
+    details: exceeded,
+    hint: exceeded.length > 0
+      ? "Update expected_delta to match intentional temporary growth or reduce the diff."
+      : undefined,
+  };
+}
+
 export function checkCochangeRules(files, rules) {
   const changedPaths = files.map((f) => f.path);
   const violations = [];

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -59,6 +59,12 @@ function printCheckDetails(mode, check) {
   if (check.actual !== undefined) {
     write(`    actual: ${check.actual}, limit: ${check.limit}`);
   }
+  if (check.status) {
+    write(`    status: ${check.status}`);
+  }
+  if (check.growth) {
+    write(`    growth: new_files=${check.growth.new_files}, net_added_lines=${check.growth.net_added_lines}`);
+  }
   if (check.files) {
     for (const f of check.files) write(`    - ${f}`);
   }
@@ -104,6 +110,10 @@ function detailFromCheck(check) {
   const details = [];
   if (check.message) details.push(check.message);
   if (check.actual !== undefined) details.push(`actual: ${check.actual}, limit: ${check.limit}`);
+  if (check.status) details.push(`status: ${check.status}`);
+  if (check.growth) {
+    details.push(`growth: new_files=${check.growth.new_files}, net_added_lines=${check.growth.net_added_lines}`);
+  }
   if (check.files) details.push(...check.files.map((f) => `file: ${f}`));
   if (check.touched) details.push(...check.touched.map((f) => `touched: ${f}`));
   if (check.must_touch) details.push(`must_touch: ${check.must_touch.join(", ")}`);
@@ -137,6 +147,9 @@ function violationFromCheck(name, check) {
     hint: check.hint,
   };
 
+  if (check.status) violation.status = check.status;
+  if (check.growth) violation.growth = check.growth;
+  if (check.surface_debt) violation.surface_debt = check.surface_debt;
   if (hasOwn(check, "change_class")) violation.change_class = check.change_class;
   if (check.touched_surfaces) violation.touched_surfaces = check.touched_surfaces;
   if (check.allowed_surfaces) violation.allowed_surfaces = check.allowed_surfaces;

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -22,6 +22,7 @@ import {
   checkCanonicalDocsBudget,
   checkNewFilesBudget,
   checkNetAddedLinesBudget,
+  checkSurfaceDebt,
   checkCochangeRules,
   checkSurfaceMatrix,
   checkContentRules,
@@ -248,6 +249,7 @@ export function runCheckPR(roots, args = []) {
   reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+  reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
 
   if (policy.surface_matrix) {
     reporter.report(

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -12,6 +12,7 @@ import {
   checkCanonicalDocsBudget,
   checkNewFilesBudget,
   checkNetAddedLinesBudget,
+  checkSurfaceDebt,
   checkCochangeRules,
   checkSurfaceMatrix,
   checkContentRules,
@@ -239,6 +240,7 @@ function runCheckDiff(roots, args) {
   reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
+  reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
 
   if (policy.surface_matrix) {
     const declaredChangeClass = cliChangeClass || contract?.change_class || null;

--- a/templates/issue-contract-example.md
+++ b/templates/issue-contract-example.md
@@ -12,6 +12,13 @@ scope:
 budgets:
   max_new_files: 5
   max_new_docs: 1
+surface_debt:
+  kind: temporary_growth
+  reason: Add temporary adapter before deleting the old middleware path
+  expected_delta:
+    max_new_files: 1
+    max_net_added_lines: 80
+  repayment_issue: 456
 must_touch:
   - src/auth.mjs
 must_not_touch:

--- a/templates/pr-contract-example.md
+++ b/templates/pr-contract-example.md
@@ -11,6 +11,13 @@ scope:
 budgets:
   max_new_files: 0
   max_new_docs: 0
+surface_debt:
+  kind: temporary_growth
+  reason: Introduce extraction path before removing duplicated code
+  expected_delta:
+    max_new_files: 1
+    max_net_added_lines: 60
+  repayment_issue: 123
 must_touch:
   - src/pagination.mjs
 must_not_touch:

--- a/tests/fixtures/valid-contract.json
+++ b/tests/fixtures/valid-contract.json
@@ -7,6 +7,15 @@
     "max_new_docs": 2,
     "max_net_added_lines": 1000
   },
+  "surface_debt": {
+    "kind": "temporary_growth",
+    "reason": "Introduce extraction seam before removing duplicated path",
+    "expected_delta": {
+      "max_new_files": 1,
+      "max_net_added_lines": 60
+    },
+    "repayment_issue": 123
+  },
   "must_touch": ["package.json", "src/repo-guard.mjs"],
   "must_not_touch": ["LICENSE"],
   "expected_effects": ["CLI runner validates policy and contracts"],

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -162,8 +162,8 @@ const growthFiles = [
   { path: "src/extract.mjs", addedLines: new Array(50).fill("new"), deletedLines: [], status: "added" },
 ];
 
-expect("4b. undeclared surface growth fails", checkSurfaceDebt(growthFiles, null).ok, false);
-expect("4b. undeclared surface growth status", checkSurfaceDebt(growthFiles, null).status, "undeclared_growth");
+expect("4b. undeclared surface growth passes by default", checkSurfaceDebt(growthFiles, null).ok, true);
+expect("4b. undeclared surface growth status", checkSurfaceDebt(growthFiles, null).status, "undeclared");
 expect("4b. declared surface debt passes", checkSurfaceDebt(growthFiles, growthDebt).ok, true);
 expect("4b. declared surface debt status", checkSurfaceDebt(growthFiles, growthDebt).status, "declared");
 expect(

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -5,6 +5,7 @@ import {
   checkCanonicalDocsBudget,
   checkNewFilesBudget,
   checkNetAddedLinesBudget,
+  checkSurfaceDebt,
   checkCochangeRules,
   checkContentRules,
   checkMustTouch,
@@ -144,6 +145,39 @@ const shrinkFiles = [
 ];
 expect("4. negative net always passes", checkNetAddedLinesBudget(shrinkFiles, 0).ok, true);
 expect("4. negative net actual", checkNetAddedLinesBudget(shrinkFiles, 0).actual, -15);
+
+// --- 4b. Surface debt validates temporary growth declarations ---
+
+const growthDebt = {
+  kind: "temporary_growth",
+  reason: "Introduce extraction seam before removing duplicate path",
+  expected_delta: {
+    max_new_files: 1,
+    max_net_added_lines: 60,
+  },
+  repayment_issue: 123,
+};
+
+const growthFiles = [
+  { path: "src/extract.mjs", addedLines: new Array(50).fill("new"), deletedLines: [], status: "added" },
+];
+
+expect("4b. undeclared surface growth fails", checkSurfaceDebt(growthFiles, null).ok, false);
+expect("4b. undeclared surface growth status", checkSurfaceDebt(growthFiles, null).status, "undeclared_growth");
+expect("4b. declared surface debt passes", checkSurfaceDebt(growthFiles, growthDebt).ok, true);
+expect("4b. declared surface debt status", checkSurfaceDebt(growthFiles, growthDebt).status, "declared");
+expect(
+  "4b. declared debt exceeded fails",
+  checkSurfaceDebt(growthFiles, { ...growthDebt, expected_delta: { max_new_files: 0, max_net_added_lines: 10 } }).status,
+  "declared_debt_exceeded"
+);
+expect(
+  "4b. declared debt missing repayment fails",
+  checkSurfaceDebt(growthFiles, { ...growthDebt, repayment_issue: undefined }).status,
+  "missing_repayment_target"
+);
+expect("4b. shrink needs no surface debt", checkSurfaceDebt(shrinkFiles, null).ok, true);
+expect("4b. shrink surface debt status", checkSurfaceDebt(shrinkFiles, null).status, "not_needed");
 
 // --- 5. Co-change rule violation ---
 

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -153,10 +153,10 @@ function expect(label, actual, expected) {
     cochange_rules: [],
   };
   writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
-  writeFileSync(join(tmp, "hello.txt"), "hello");
+  writeFileSync(join(tmp, "hello.txt"), "hello\nworld\n");
   execSync("git add -A && git commit -m init", { cwd: tmp });
 
-  writeFileSync(join(tmp, "world.txt"), "world");
+  writeFileSync(join(tmp, "hello.txt"), "hello\n");
   execSync("git add -A && git commit -m second", { cwd: tmp });
 
   try {
@@ -334,10 +334,10 @@ function expect(label, actual, expected) {
     cochange_rules: [],
   };
   writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
-  writeFileSync(join(tmp, "hello.txt"), "hello");
+  writeFileSync(join(tmp, "hello.txt"), "hello\nworld\n");
   execSync("git add -A && git commit -m init", { cwd: tmp });
 
-  writeFileSync(join(tmp, "world.txt"), "world");
+  writeFileSync(join(tmp, "hello.txt"), "hello\n");
   execSync("git add -A && git commit -m second", { cwd: tmp });
 
   try {
@@ -435,10 +435,10 @@ function expect(label, actual, expected) {
     cochange_rules: [],
   };
   writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
-  writeFileSync(join(tmp, "a.txt"), "a");
+  writeFileSync(join(tmp, "a.txt"), "a\nb\n");
   execSync("git add -A && git commit -m init", { cwd: tmp });
 
-  writeFileSync(join(tmp, "b.txt"), "b");
+  writeFileSync(join(tmp, "a.txt"), "a\n");
   execSync("git add -A && git commit -m second", { cwd: tmp });
 
   try {
@@ -521,10 +521,10 @@ function expect(label, actual, expected) {
     cochange_rules: [],
   };
   writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(policy));
-  writeFileSync(join(tmp, "a.txt"), "a");
+  writeFileSync(join(tmp, "a.txt"), "a\nb\n");
   execSync("git add -A && git commit -m init", { cwd: tmp });
 
-  writeFileSync(join(tmp, "b.txt"), "b");
+  writeFileSync(join(tmp, "a.txt"), "a\n");
   execSync("git add -A && git commit -m second", { cwd: tmp });
 
   try {

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -379,7 +379,7 @@ console.log("\n--- check-diff reports surface debt status in JSON output ---");
   rmSync(repo.dir, { recursive: true });
 }
 
-console.log("\n--- check-diff distinguishes undeclared growth and exceeded debt ---");
+console.log("\n--- check-diff treats undeclared growth as non-blocking and enforces declared debt ---");
 {
   const undeclaredRepo = makeSurfaceDebtRepo(null);
   const undeclared = runGuard([
@@ -389,11 +389,15 @@ console.log("\n--- check-diff distinguishes undeclared growth and exceeded debt 
     "--base", undeclaredRepo.base,
     "--head", undeclaredRepo.head,
   ]);
-  expect("undeclared growth exit code", undeclared.code, 1);
+  expect("undeclared growth exit code", undeclared.code, 0);
   const undeclaredParsed = JSON.parse(undeclared.stdout);
+  expect("undeclared growth result passes", undeclaredParsed.ok, true);
   expect("undeclared growth status",
-    undeclaredParsed.violations.find((v) => v.rule === "surface-debt")?.status,
-    "undeclared_growth");
+    undeclaredParsed.ruleResults.find((r) => r.rule === "surface-debt")?.details.includes("status: undeclared"),
+    true);
+  expect("undeclared growth has no violation",
+    undeclaredParsed.violations.some((v) => v.rule === "surface-debt"),
+    false);
   rmSync(undeclaredRepo.dir, { recursive: true });
 
   const exceededContract = {

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -145,6 +145,46 @@ function makeSurfaceRepo() {
   };
 }
 
+function makeSurfaceDebtRepo(contract) {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-debt-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  if (contract) writeFileSync(join(dir, "contract.json"), JSON.stringify(contract, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  execSync("mkdir -p src", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "src", "growth.mjs"), `${new Array(12).fill("export const value = 1;").join("\n")}\n`);
+  execSync("git add -A && git commit -m growth", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    contractPath: contract ? "contract.json" : null,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
 function makeUnclassifiedOnlySurfaceRepo() {
   const dir = mkdtempSync(join(tmpdir(), "repo-guard-unclassified-"));
   execSync("git init", { cwd: dir, stdio: "pipe" });
@@ -181,9 +221,10 @@ function makeUnclassifiedOnlySurfaceRepo() {
 
   writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
   writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("mkdir -p scripts", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "scripts", "tool.mjs"), "export const oldTool = true;\nexport const removed = true;\n");
   execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
 
-  execSync("mkdir -p scripts", { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "scripts", "tool.mjs"), "export const tool = true;\n");
   execSync("git add -A && git commit -m script", { cwd: dir, stdio: "pipe" });
 
@@ -290,6 +331,103 @@ console.log("\n--- check-diff honors allow_unclassified_files policy switch ---"
   expect("allow_unclassified_files has no violations", parsed?.violations.length, 0);
 
   rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff reports surface debt status in JSON output ---");
+{
+  const contract = {
+    change_type: "feature",
+    scope: ["src/**"],
+    budgets: {},
+    surface_debt: {
+      kind: "temporary_growth",
+      reason: "Introduce extraction seam before removing duplicated path",
+      expected_delta: {
+        max_new_files: 1,
+        max_net_added_lines: 20,
+      },
+      repayment_issue: 123,
+    },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["Temporary growth is explicit and repayable"],
+  };
+  const repo = makeSurfaceDebtRepo(contract);
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+    "--contract", repo.contractPath,
+  ]);
+
+  expect("declared surface debt exit code", result.code, 0);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("surface debt stdout is valid json", true, true);
+  } catch (e) {
+    expect("surface debt stdout is valid json", e.message, "valid json");
+  }
+  const debtResult = parsed?.ruleResults.find((r) => r.rule === "surface-debt");
+  expect("surface debt rule passes", debtResult?.ok, true);
+  expect("surface debt rule exposes declared status",
+    debtResult?.details.includes("status: declared"),
+    true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff distinguishes undeclared growth and exceeded debt ---");
+{
+  const undeclaredRepo = makeSurfaceDebtRepo(null);
+  const undeclared = runGuard([
+    "--repo-root", undeclaredRepo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", undeclaredRepo.base,
+    "--head", undeclaredRepo.head,
+  ]);
+  expect("undeclared growth exit code", undeclared.code, 1);
+  const undeclaredParsed = JSON.parse(undeclared.stdout);
+  expect("undeclared growth status",
+    undeclaredParsed.violations.find((v) => v.rule === "surface-debt")?.status,
+    "undeclared_growth");
+  rmSync(undeclaredRepo.dir, { recursive: true });
+
+  const exceededContract = {
+    change_type: "feature",
+    scope: ["src/**"],
+    budgets: {},
+    surface_debt: {
+      kind: "temporary_growth",
+      reason: "Introduce extraction seam before removing duplicated path",
+      expected_delta: {
+        max_new_files: 0,
+        max_net_added_lines: 1,
+      },
+      repayment_issue: 123,
+    },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["Temporary growth is explicit and repayable"],
+  };
+  const exceededRepo = makeSurfaceDebtRepo(exceededContract);
+  const exceeded = runGuard([
+    "--repo-root", exceededRepo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", exceededRepo.base,
+    "--head", exceededRepo.head,
+    "--contract", exceededRepo.contractPath,
+  ]);
+  expect("declared debt exceeded exit code", exceeded.code, 1);
+  const exceededParsed = JSON.parse(exceeded.stdout);
+  expect("declared debt exceeded status",
+    exceededParsed.violations.find((v) => v.rule === "surface-debt")?.status,
+    "declared_debt_exceeded");
+  rmSync(exceededRepo.dir, { recursive: true });
 }
 
 console.log("\n--- check-diff --format summary emits GitHub-friendly concise summary ---");


### PR DESCRIPTION
Fixes netkeep80/repo-guard#35

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - README.md
  - schemas/change-contract.schema.json
  - src/**
  - templates/**
  - tests/**
budgets:
  max_new_files: 15
  max_new_docs: 2
  max_net_added_lines: 2000
surface_debt:
  kind: temporary_growth
  reason: Add first-class surface debt schema and enforcement before future cleanup can tighten growth policy defaults
  expected_delta:
    max_new_files: 0
    max_net_added_lines: 400
  repayment_issue: 35
must_touch:
  - schemas/change-contract.schema.json
  - src/diff-checker.mjs
must_not_touch:
  - LICENSE
expected_effects:
  - Change contracts accept explicit temporary surface debt
  - check-diff and check-pr validate declared debt against actual growth
  - Structured output reports surface debt status
  - Repository growth without surface_debt remains non-blocking by default
```

## Summary
- Add optional `surface_debt` to the change contract schema.
- Validate declared surface debt during `check-diff` and `check-pr`, distinguishing `declared`, `declared_debt_exceeded`, and `missing_repayment_target`.
- Keep undeclared growth non-blocking by default and report it as `status: undeclared` in rule results.
- Include debt status and growth details in structured JSON output and human-readable summaries.
- Document realistic YAML examples and update fixtures/tests.

## Review Feedback Addressed
- Updated semantics after owner review so repo-guard does not require `surface_debt` for every growing diff.
- `surface_debt` is now opt-in unless a future policy switch explicitly requires it.
- Existing declared-debt validation remains enforced: exceeded expected deltas and missing repayment targets still fail.

## Reproduction / Verification
- `node tests/validate-schemas.mjs` validates that contracts now accept `surface_debt`.
- `node tests/test-diff-rules.mjs` covers non-blocking undeclared growth, declared debt, exceeded debt, missing repayment target, and shrink-only diffs.
- `node tests/test-structured-output.mjs` verifies JSON output exposes debt status and that undeclared growth is not a violation by default.
- `npm test` passes locally.

## CI Investigation
- Downloaded failed run log to `ci-logs/ci-24616859153.log`.
- Root cause: PR policy gate could not find a repo-guard contract in the PR body or linked issue, then also flagged this implementation growth under the earlier unconditional semantics.
- Fix: added the required `repo-guard-yaml` contract block above and later adjusted surface debt semantics to be opt-in by default.

## Notes
- No automatic debt tracking or GitHub issue-state validation is added; `repayment_issue` is schema/runtime presence validation only, matching the issue non-goals.
