### PR TITLE
Add typed new-file classification rules

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T00:18:01.048Z for PR creation at branch issue-36-50a4e1699bbc for issue https://github.com/netkeep80/repo-guard/issues/36

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T00:18:01.048Z for PR creation at branch issue-36-50a4e1699bbc for issue https://github.com/netkeep80/repo-guard/issues/36

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Result: passed (mode: blocking; exit code 0)
 }
 ```
 
-`new_file_rules` проверяет только файлы со статусом `added`; изменения существующих файлов остаются за `surface_matrix`, `cochange_rules` и другими проверками. Если policy включает `new_file_rules`, diff с новыми файлами должен иметь `change_class` в contract или через `--change-class`.
+`new_file_rules` проверяет только файлы со статусом `added`; изменения существующих файлов остаются за `surface_matrix`, `cochange_rules` и другими проверками. Если policy включает `new_file_rules`, diff с новыми файлами должен иметь `change_class` в contract или через `--change-class`. Каждая запись `new_file_rules` должна явно задавать `allow_classes`; пустой список `[]` означает намеренный запрет всех классов новых файлов.
 
 Пример: `kernel-hardening` может добавить до двух test files и один changelog fragment, но не может незаметно добавить generated artifact или новый design document. Это точнее, чем плоский `max_new_files: 3`: лимит допускает полезные тесты, но всё ещё блокирует неожиданные классы файлов.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Policy engine для репозитория: формализует правил
 | Max new files | Ограничивает общее количество новых файлов |
 | Max net added lines | Ограничивает `added − deleted` строк |
 | Surface debt | Проверяет объявленный `surface_debt`, если contract явно описывает временный рост |
+| New file rules | Проверяет классы новых файлов и per-class бюджеты для объявленного `change_class` |
 | Co-change rules | Если изменён X, должен быть изменён и Y |
 | Surface matrix | Проверяет, что объявленный `change_class` трогает только разрешённые surface-классы |
 | Content rules | Запрещает regex-паттерны в добавленных строках |
@@ -475,6 +476,7 @@ Diff analysis: 3 file(s) changed
   PASS: canonical-docs-budget
   PASS: max-new-files
   PASS: max-net-added-lines
+  PASS: new-file-rules
   PASS: cochange-rules
   PASS: content-rules
   PASS: must-touch
@@ -499,6 +501,61 @@ Result: passed (mode: blocking; exit code 0)
   FAIL: cochange: src/** -> tests/**
     must_touch: tests/**
 ```
+
+## Typed New File Classes
+
+Глобальный `diff_rules.max_new_files` остаётся полезным верхним лимитом, но он не различает смысл новых файлов. Для многих репозиториев новый test file, generated artifact, canonical doc и changelog fragment имеют разный риск. `new_file_classes` и `new_file_rules` позволяют описать это явно:
+
+```json
+{
+  "new_file_classes": {
+    "test": ["tests/**"],
+    "canonical_doc": ["docs/**", "README.md"],
+    "generated": ["single_include/**"],
+    "changelog_fragment": ["changelog.d/*.md"],
+    "script": ["scripts/**"]
+  },
+  "new_file_rules": {
+    "docs-cleanup": {
+      "allow_classes": [],
+      "max_new_files": 0
+    },
+    "kernel-hardening": {
+      "allow_classes": ["test", "changelog_fragment"],
+      "max_per_class": {
+        "test": 2,
+        "changelog_fragment": 1
+      }
+    },
+    "generated-refresh": {
+      "allow_classes": ["generated", "changelog_fragment"],
+      "max_per_class": {
+        "generated": 20,
+        "changelog_fragment": 1
+      }
+    }
+  }
+}
+```
+
+`new_file_rules` проверяет только файлы со статусом `added`; изменения существующих файлов остаются за `surface_matrix`, `cochange_rules` и другими проверками. Если policy включает `new_file_rules`, diff с новыми файлами должен иметь `change_class` в contract или через `--change-class`.
+
+Пример: `kernel-hardening` может добавить до двух test files и один changelog fragment, но не может незаметно добавить generated artifact или новый design document. Это точнее, чем плоский `max_new_files: 3`: лимит допускает полезные тесты, но всё ещё блокирует неожиданные классы файлов.
+
+При нарушении output называет offending file, detected class и нарушенное правило:
+
+```text
+  FAIL: new-file-rules
+    change_class "kernel-hardening" cannot add new-file classes: generated
+    change_class: kernel-hardening
+    new_files: changelog.d/core.md, single_include/core.h, tests/core.test.mjs
+    allowed_classes: changelog_fragment, test
+    touched_classes: changelog_fragment, generated, test
+    violating_classes: generated
+    class generated is not allowed by new_file_rules["kernel-hardening"].allow_classes; files: single_include/core.h
+```
+
+Файлы, которые не совпали ни с одним glob из `new_file_classes`, считаются unclassified и тоже fail, когда `new_file_rules` активны. Старое поведение `max_new_files` не меняется: если `new_file_classes` и `new_file_rules` отсутствуют, repo-guard продолжает применять только плоские budgets.
 
 ## Ownership-aware surfaces
 

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -130,6 +130,43 @@
         }
       }
     },
+    "new_file_classes": {
+      "type": "object",
+      "description": "Named classes for newly added files mapped to one or more path globs. A new file can match multiple classes.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "array",
+        "items": { "type": "string", "minLength": 1 },
+        "minItems": 1
+      }
+    },
+    "new_file_rules": {
+      "type": "object",
+      "description": "Allowed new-file classes and per-class budgets for each named change class.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allow_classes": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "max_per_class": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            }
+          },
+          "max_new_files": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
     "content_rules": {
       "type": "array",
       "items": {

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -146,6 +146,7 @@
       "minProperties": 1,
       "additionalProperties": {
         "type": "object",
+        "required": ["allow_classes"],
         "additionalProperties": false,
         "properties": {
           "allow_classes": {

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -239,6 +239,157 @@ function unclassifiedFilesHint() {
   return "Add matching surface globs or set allow_unclassified_files: true if unclassified files are intentional.";
 }
 
+export function classifyNewFiles(files, newFileClasses = {}) {
+  const filesByClass = {};
+  const classByFile = {};
+  const classifiedFiles = new Set();
+  const newFiles = uniqueSorted(files.filter((f) => f.status === "added").map((f) => f.path));
+
+  for (const [fileClass, patterns] of Object.entries(newFileClasses || {})) {
+    const matchedFiles = newFiles.filter((file) => matchesAny(file, patterns || []));
+
+    if (matchedFiles.length > 0) {
+      filesByClass[fileClass] = matchedFiles;
+      for (const file of matchedFiles) {
+        classifiedFiles.add(file);
+        if (!classByFile[file]) classByFile[file] = [];
+        classByFile[file].push(fileClass);
+      }
+    }
+  }
+
+  for (const classes of Object.values(classByFile)) {
+    classes.sort();
+  }
+
+  return {
+    new_files: newFiles,
+    files_by_class: filesByClass,
+    class_by_file: classByFile,
+    unclassified_files: newFiles.filter((file) => !classifiedFiles.has(file)),
+  };
+}
+
+function unclassifiedNewFilesMessage(unclassifiedFiles) {
+  return `new_file_rules found added files that match no declared new_file_class: ${unclassifiedFiles.join(", ")}`;
+}
+
+function unclassifiedNewFilesHint() {
+  return "Add matching new_file_classes globs or update the change class new_file_rules.";
+}
+
+export function checkNewFileRules(files, newFileClasses, newFileRules, changeClass) {
+  if (!newFileRules || Object.keys(newFileRules).length === 0) return { ok: true };
+
+  const detected = classifyNewFiles(files, newFileClasses);
+  const newFiles = detected.new_files;
+  const changeClassValue = changeClass || null;
+
+  if (newFiles.length === 0) {
+    return {
+      ok: true,
+      change_class: changeClassValue,
+      new_files: newFiles,
+      files_by_class: detected.files_by_class,
+      unclassified_files: detected.unclassified_files,
+    };
+  }
+
+  if (!changeClassValue) {
+    return {
+      ok: false,
+      message: "new_file_rules requires a declared change_class when new files are added",
+      change_class: null,
+      new_files: newFiles,
+      files_by_class: detected.files_by_class,
+      unclassified_files: detected.unclassified_files,
+      details: newFiles.map((file) => {
+        const classes = detected.class_by_file[file] || ["unclassified"];
+        return `file ${file} detected class: ${classes.join(", ")}`;
+      }),
+      hint: "Set change_class in the contract or pass --change-class <name>.",
+    };
+  }
+
+  const rule = newFileRules[changeClassValue];
+  if (!rule) {
+    return {
+      ok: false,
+      message: `change_class "${changeClassValue}" is not defined in new_file_rules`,
+      change_class: changeClassValue,
+      new_files: newFiles,
+      files_by_class: detected.files_by_class,
+      unclassified_files: detected.unclassified_files,
+      details: [`known change classes: ${formatList(Object.keys(newFileRules).sort())}`],
+      hint: "Define the change class in new_file_rules or use one of the configured classes.",
+    };
+  }
+
+  const allowedClasses = uniqueSorted(rule.allow_classes || []);
+  const allowedSet = new Set(allowedClasses);
+  const touchedClasses = uniqueSorted(Object.keys(detected.files_by_class));
+  const violatingClasses = allowedClasses.length > 0
+    ? touchedClasses.filter((fileClass) => !allowedSet.has(fileClass))
+    : touchedClasses;
+  const hasUnclassifiedViolation = detected.unclassified_files.length > 0;
+  const classBudgetViolations = [];
+
+  for (const [fileClass, limit] of Object.entries(rule.max_per_class || {})) {
+    const actual = (detected.files_by_class[fileClass] || []).length;
+    if (actual > limit) {
+      classBudgetViolations.push({
+        class: fileClass,
+        actual,
+        limit,
+        files: detected.files_by_class[fileClass],
+      });
+    }
+  }
+
+  const maxNewFiles = rule.max_new_files;
+  const exceedsMaxNewFiles = maxNewFiles !== undefined && newFiles.length > maxNewFiles;
+  const details = [
+    ...violatingClasses.map(
+      (fileClass) => `class ${fileClass} is not allowed by new_file_rules["${changeClassValue}"].allow_classes; files: ${detected.files_by_class[fileClass].join(", ")}`
+    ),
+    ...detected.unclassified_files.map(
+      (file) => `file ${file} detected class: unclassified; violated rule: new_file_rules["${changeClassValue}"].allow_classes`
+    ),
+    ...classBudgetViolations.map(
+      (v) => `class ${v.class} has ${v.actual} new file(s), limit ${v.limit}; files: ${v.files.join(", ")}`
+    ),
+  ];
+  if (exceedsMaxNewFiles) {
+    details.push(`new files ${newFiles.length} exceeds new_file_rules["${changeClassValue}"].max_new_files ${maxNewFiles}`);
+  }
+
+  let message;
+  if (violatingClasses.length > 0) {
+    message = `change_class "${changeClassValue}" cannot add new-file classes: ${violatingClasses.join(", ")}`;
+  } else if (hasUnclassifiedViolation) {
+    message = unclassifiedNewFilesMessage(detected.unclassified_files);
+  } else if (classBudgetViolations.length > 0 || exceedsMaxNewFiles) {
+    message = `change_class "${changeClassValue}" exceeds new_file_rules budget`;
+  }
+
+  return {
+    ok: violatingClasses.length === 0 && !hasUnclassifiedViolation && classBudgetViolations.length === 0 && !exceedsMaxNewFiles,
+    message,
+    change_class: changeClassValue,
+    new_files: newFiles,
+    actual: exceedsMaxNewFiles ? newFiles.length : undefined,
+    limit: exceedsMaxNewFiles ? maxNewFiles : undefined,
+    allowed_classes: allowedClasses,
+    touched_classes: touchedClasses,
+    violating_classes: violatingClasses,
+    class_budget_violations: classBudgetViolations,
+    files_by_class: detected.files_by_class,
+    unclassified_files: detected.unclassified_files,
+    details,
+    hint: hasUnclassifiedViolation ? unclassifiedNewFilesHint() : undefined,
+  };
+}
+
 export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass, options = {}) {
   if (!surfaceMatrix || Object.keys(surfaceMatrix).length === 0) return { ok: true };
 

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -83,6 +83,18 @@ function printCheckDetails(mode, check) {
   if (check.touched_surfaces) {
     write(`    touched_surfaces: ${formatList(check.touched_surfaces)}`);
   }
+  if (check.new_files) {
+    write(`    new_files: ${formatList(check.new_files)}`);
+  }
+  if (check.allowed_classes) {
+    write(`    allowed_classes: ${formatList(check.allowed_classes)}`);
+  }
+  if (check.touched_classes) {
+    write(`    touched_classes: ${formatList(check.touched_classes)}`);
+  }
+  if (check.violating_classes) {
+    write(`    violating_classes: ${formatList(check.violating_classes)}`);
+  }
   if (check.allowed_surfaces) {
     write(`    allowed_surfaces: ${formatList(check.allowed_surfaces)}`);
   }
@@ -94,6 +106,11 @@ function printCheckDetails(mode, check) {
   }
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     write(`    unclassified_files: ${formatList(check.unclassified_files)}`);
+  }
+  if (check.class_budget_violations && check.class_budget_violations.length > 0) {
+    for (const v of check.class_budget_violations) {
+      write(`    class_budget: ${v.class} actual=${v.actual}, limit=${v.limit}, files=${formatList(v.files)}`);
+    }
   }
   if (check.details) {
     for (const detail of check.details) write(`    ${detail}`);
@@ -120,11 +137,20 @@ function detailFromCheck(check) {
   if (check.must_not_touch) details.push(`must_not_touch: ${check.must_not_touch.join(", ")}`);
   if (hasOwn(check, "change_class")) details.push(`change_class: ${check.change_class || "(missing)"}`);
   if (check.touched_surfaces) details.push(`touched_surfaces: ${formatList(check.touched_surfaces)}`);
+  if (check.new_files) details.push(`new_files: ${formatList(check.new_files)}`);
+  if (check.allowed_classes) details.push(`allowed_classes: ${formatList(check.allowed_classes)}`);
+  if (check.touched_classes) details.push(`touched_classes: ${formatList(check.touched_classes)}`);
+  if (check.violating_classes) details.push(`violating_classes: ${formatList(check.violating_classes)}`);
   if (check.allowed_surfaces) details.push(`allowed_surfaces: ${formatList(check.allowed_surfaces)}`);
   if (check.forbidden_surfaces) details.push(`forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
   if (check.violating_surfaces) details.push(`violating_surfaces: ${formatList(check.violating_surfaces)}`);
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     details.push(`unclassified_files: ${formatList(check.unclassified_files)}`);
+  }
+  if (check.class_budget_violations && check.class_budget_violations.length > 0) {
+    details.push(...check.class_budget_violations.map(
+      (v) => `class_budget: ${v.class} actual=${v.actual}, limit=${v.limit}, files=${formatList(v.files)}`
+    ));
   }
   if (check.details) details.push(...check.details);
   if (check.errors) details.push(...check.errors);
@@ -152,6 +178,12 @@ function violationFromCheck(name, check) {
   if (check.surface_debt) violation.surface_debt = check.surface_debt;
   if (hasOwn(check, "change_class")) violation.change_class = check.change_class;
   if (check.touched_surfaces) violation.touched_surfaces = check.touched_surfaces;
+  if (check.new_files) violation.new_files = check.new_files;
+  if (check.allowed_classes) violation.allowed_classes = check.allowed_classes;
+  if (check.touched_classes) violation.touched_classes = check.touched_classes;
+  if (check.violating_classes) violation.violating_classes = check.violating_classes;
+  if (check.class_budget_violations) violation.class_budget_violations = check.class_budget_violations;
+  if (check.files_by_class) violation.files_by_class = check.files_by_class;
   if (check.allowed_surfaces) violation.allowed_surfaces = check.allowed_surfaces;
   if (check.forbidden_surfaces) violation.forbidden_surfaces = check.forbidden_surfaces;
   if (check.violating_surfaces) violation.violating_surfaces = check.violating_surfaces;

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -5,6 +5,7 @@ import Ajv from "ajv";
 import { extractContract, extractLinkedIssueNumbers, resolveContract } from "./markdown-contract.mjs";
 import {
   compileForbidRegex,
+  compileNewFilePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
@@ -24,6 +25,7 @@ import {
   checkNetAddedLinesBudget,
   checkSurfaceDebt,
   checkCochangeRules,
+  checkNewFileRules,
   checkSurfaceMatrix,
   checkContentRules,
   checkMustTouch,
@@ -171,6 +173,15 @@ export function runCheckPR(roots, args = []) {
     }
   }
 
+  const newFileErrors = compileNewFilePolicy(policy);
+  if (newFileErrors.length > 0) {
+    ok = false;
+    console.error("FAIL: new file policy compilation");
+    for (const e of newFileErrors) {
+      console.error(`  ${e.message}`);
+    }
+  }
+
   for (const w of warnReservedPolicyFields(policy)) {
     console.warn(`WARN: ${w}`);
   }
@@ -250,6 +261,13 @@ export function runCheckPR(roots, args = []) {
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+
+  if (policy.new_file_rules) {
+    reporter.report(
+      "new-file-rules",
+      checkNewFileRules(files, policy.new_file_classes, policy.new_file_rules, contract?.change_class || null)
+    );
+  }
 
   if (policy.surface_matrix) {
     reporter.report(

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -68,6 +68,54 @@ export function compileSurfacePolicy(policy) {
   return errors;
 }
 
+export function compileNewFilePolicy(policy) {
+  const errors = [];
+  const newFileClasses = policy.new_file_classes || {};
+  const classNames = new Set(Object.keys(newFileClasses));
+  const changeClasses = new Set(policy.change_classes || []);
+  const newFileRules = policy.new_file_rules || {};
+
+  if (!policy.new_file_rules) return errors;
+
+  if (classNames.size === 0) {
+    errors.push({ message: "new_file_rules requires at least one named class in new_file_classes" });
+  }
+  if (changeClasses.size === 0) {
+    errors.push({ message: "new_file_rules requires at least one named change class in change_classes" });
+  }
+
+  for (const [changeClass, rule] of Object.entries(newFileRules)) {
+    if (changeClasses.size > 0 && !changeClasses.has(changeClass)) {
+      errors.push({
+        change_class: changeClass,
+        message: `new_file_rules entry "${changeClass}" is not listed in change_classes`,
+      });
+    }
+
+    for (const fileClass of rule.allow_classes || []) {
+      if (!classNames.has(fileClass)) {
+        errors.push({
+          change_class: changeClass,
+          class: fileClass,
+          message: `new_file_rules["${changeClass}"].allow_classes references unknown class "${fileClass}"`,
+        });
+      }
+    }
+
+    for (const fileClass of Object.keys(rule.max_per_class || {})) {
+      if (!classNames.has(fileClass)) {
+        errors.push({
+          change_class: changeClass,
+          class: fileClass,
+          message: `new_file_rules["${changeClass}"].max_per_class references unknown class "${fileClass}"`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function warnReservedContractFields(contract) {
   const warnings = [];
   if (contract.overrides && contract.overrides.length > 0) {

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -92,6 +92,13 @@ export function compileNewFilePolicy(policy) {
       });
     }
 
+    if (!Object.hasOwn(rule, "allow_classes")) {
+      errors.push({
+        change_class: changeClass,
+        message: `new_file_rules["${changeClass}"].allow_classes is required; use [] to forbid all new-file classes`,
+      });
+    }
+
     for (const fileClass of rule.allow_classes || []) {
       if (!classNames.has(fileClass)) {
         errors.push({

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -14,6 +14,7 @@ import {
   checkNetAddedLinesBudget,
   checkSurfaceDebt,
   checkCochangeRules,
+  checkNewFileRules,
   checkSurfaceMatrix,
   checkContentRules,
   checkMustTouch,
@@ -21,6 +22,7 @@ import {
 } from "./diff-checker.mjs";
 import {
   compileForbidRegex,
+  compileNewFilePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
@@ -178,6 +180,17 @@ function runCheckDiff(roots, args) {
     }
   }
 
+  const newFileErrors = compileNewFilePolicy(policy);
+  if (newFileErrors.length > 0) {
+    ok = false;
+    if (!quiet) {
+      console.error("FAIL: new file policy compilation");
+      for (const e of newFileErrors) {
+        console.error(`  ${e.message}`);
+      }
+    }
+  }
+
   if (!quiet) {
     for (const w of warnReservedPolicyFields(policy)) {
       console.warn(`WARN: ${w}`);
@@ -242,8 +255,15 @@ function runCheckDiff(roots, args) {
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
 
+  const declaredChangeClass = cliChangeClass || contract?.change_class || null;
+  if (policy.new_file_rules) {
+    reporter.report(
+      "new-file-rules",
+      checkNewFileRules(files, policy.new_file_classes, policy.new_file_rules, declaredChangeClass)
+    );
+  }
+
   if (policy.surface_matrix) {
-    const declaredChangeClass = cliChangeClass || contract?.change_class || null;
     reporter.report(
       "surface-matrix",
       checkSurfaceMatrix(

--- a/tests/fixtures/valid-policy.json
+++ b/tests/fixtures/valid-policy.json
@@ -37,6 +37,34 @@
       "forbid": ["kernel", "docs", "tests"]
     }
   },
+  "new_file_classes": {
+    "test": ["tests/**"],
+    "canonical_doc": ["README.md", "docs/**"],
+    "generated": ["single_include/**"],
+    "changelog_fragment": ["changelog.d/*.md"]
+  },
+  "new_file_rules": {
+    "kernel-hardening": {
+      "allow_classes": ["test", "changelog_fragment"],
+      "max_per_class": {
+        "test": 2,
+        "changelog_fragment": 1
+      }
+    },
+    "docs-cleanup": {
+      "allow_classes": ["canonical_doc"],
+      "max_per_class": {
+        "canonical_doc": 1
+      }
+    },
+    "generated-refresh": {
+      "allow_classes": ["generated", "changelog_fragment"],
+      "max_per_class": {
+        "generated": 10,
+        "changelog_fragment": 1
+      }
+    }
+  },
   "content_rules": [
     {
       "id": "forbid_doxygen_tags_in_headers",

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -12,6 +12,8 @@ import {
   checkMustNotTouch,
   detectTouchedSurfaces,
   checkSurfaceMatrix,
+  classifyNewFiles,
+  checkNewFileRules,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -404,6 +406,110 @@ expect("10. missing change_class message", missingClassResult.message, "surface_
 const unknownClassResult = checkSurfaceMatrix(surfaceFiles, surfaces, surfaceMatrix, "release");
 expect("10. undefined change_class fails", unknownClassResult.ok, false);
 expect("10. undefined change_class is reported", unknownClassResult.change_class, "release");
+
+// --- 11. new file classes ---
+
+const newFileClassFiles = [
+  { path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+  { path: "tests/core.test.mjs", addedLines: ["test"], deletedLines: [], status: "added" },
+  { path: "changelog.d/core.md", addedLines: ["note"], deletedLines: [], status: "added" },
+  { path: "single_include/core.h", addedLines: ["generated"], deletedLines: [], status: "added" },
+  { path: "scratch.txt", addedLines: ["temp"], deletedLines: [], status: "added" },
+];
+
+const newFileClasses = {
+  test: ["tests/**"],
+  changelog_fragment: ["changelog.d/*.md"],
+  generated: ["single_include/**"],
+};
+
+const classifiedNewFiles = classifyNewFiles(newFileClassFiles, newFileClasses);
+expect("11. classifies only added files", classifiedNewFiles.new_files.length, 4);
+expect("11. detects test class", classifiedNewFiles.files_by_class.test[0], "tests/core.test.mjs");
+expect("11. reports unclassified new file", classifiedNewFiles.unclassified_files[0], "scratch.txt");
+expect("11. ignores modified files for classification", classifiedNewFiles.new_files.includes("src/core.mjs"), false);
+
+const newFileRules = {
+  "kernel-hardening": {
+    allow_classes: ["test", "changelog_fragment"],
+    max_per_class: {
+      test: 2,
+      changelog_fragment: 1,
+    },
+  },
+  "docs-cleanup": {
+    allow_classes: [],
+    max_new_files: 0,
+  },
+  "generated-refresh": {
+    allow_classes: ["generated"],
+    max_per_class: {
+      generated: 1,
+    },
+  },
+};
+
+const allowedTypedNewFiles = [
+  { path: "tests/core.test.mjs", addedLines: ["test"], deletedLines: [], status: "added" },
+  { path: "changelog.d/core.md", addedLines: ["note"], deletedLines: [], status: "added" },
+];
+
+const allowedNewFileResult = checkNewFileRules(
+  allowedTypedNewFiles,
+  newFileClasses,
+  newFileRules,
+  "kernel-hardening"
+);
+expect("11. allowed new file classes pass", allowedNewFileResult.ok, true);
+expect("11. reports declared new-file change_class", allowedNewFileResult.change_class, "kernel-hardening");
+
+const disallowedNewFileResult = checkNewFileRules(
+  newFileClassFiles,
+  newFileClasses,
+  newFileRules,
+  "kernel-hardening"
+);
+expect("11. rejects disallowed new file class", disallowedNewFileResult.ok, false);
+expect("11. reports generated class violation", disallowedNewFileResult.violating_classes[0], "generated");
+expect("11. failure names offending generated file", disallowedNewFileResult.details.some((d) => d.includes("single_include/core.h")), true);
+expect("11. failure names unclassified file", disallowedNewFileResult.details.some((d) => d.includes("scratch.txt")), true);
+
+const tooManyTestsResult = checkNewFileRules(
+  [
+    { path: "tests/a.test.mjs", addedLines: ["test"], deletedLines: [], status: "added" },
+    { path: "tests/b.test.mjs", addedLines: ["test"], deletedLines: [], status: "added" },
+  ],
+  newFileClasses,
+  {
+    "kernel-hardening": {
+      allow_classes: ["test"],
+      max_per_class: { test: 1 },
+    },
+  },
+  "kernel-hardening"
+);
+expect("11. enforces max_per_class", tooManyTestsResult.ok, false);
+expect("11. max_per_class reports class", tooManyTestsResult.class_budget_violations[0].class, "test");
+
+const docsCleanupResult = checkNewFileRules(
+  allowedTypedNewFiles,
+  newFileClasses,
+  newFileRules,
+  "docs-cleanup"
+);
+expect("11. per-change max_new_files can forbid all new files", docsCleanupResult.ok, false);
+expect("11. per-change max_new_files reports actual", docsCleanupResult.actual, 2);
+
+expect(
+  "11. new file rules require change_class when new files exist",
+  checkNewFileRules(allowedTypedNewFiles, newFileClasses, newFileRules, null).ok,
+  false
+);
+expect(
+  "11. new file rules pass when no new files exist without change_class",
+  checkNewFileRules([{ path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" }], newFileClasses, newFileRules, null).ok,
+  true
+);
 
 // --- Summary ---
 

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   compileForbidRegex,
+  compileNewFilePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
@@ -104,6 +105,63 @@ describe("surface policy compilation", () => {
         release: {
           allow: ["docs"],
           forbid: [],
+        },
+      },
+    });
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("change_classes"));
+  });
+});
+
+describe("new file policy compilation", () => {
+  it("accepts rules that reference declared classes and change classes", () => {
+    const errors = compileNewFilePolicy({
+      new_file_classes: {
+        test: ["tests/**"],
+        changelog_fragment: ["changelog.d/*.md"],
+      },
+      change_classes: ["kernel-hardening"],
+      new_file_rules: {
+        "kernel-hardening": {
+          allow_classes: ["test", "changelog_fragment"],
+          max_per_class: {
+            test: 2,
+          },
+        },
+      },
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it("rejects rules that reference unknown classes", () => {
+    const errors = compileNewFilePolicy({
+      new_file_classes: {
+        test: ["tests/**"],
+      },
+      change_classes: ["kernel-hardening"],
+      new_file_rules: {
+        "kernel-hardening": {
+          allow_classes: ["test", "generated"],
+          max_per_class: {
+            changelog_fragment: 1,
+          },
+        },
+      },
+    });
+    assert.equal(errors.length, 2);
+    assert.ok(errors.some((e) => e.message.includes("generated")));
+    assert.ok(errors.some((e) => e.message.includes("changelog_fragment")));
+  });
+
+  it("rejects entries that are not declared change classes", () => {
+    const errors = compileNewFilePolicy({
+      new_file_classes: {
+        test: ["tests/**"],
+      },
+      change_classes: ["kernel-hardening"],
+      new_file_rules: {
+        "docs-cleanup": {
+          allow_classes: ["test"],
         },
       },
     });

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -168,6 +168,40 @@ describe("new file policy compilation", () => {
     assert.equal(errors.length, 1);
     assert.ok(errors[0].message.includes("change_classes"));
   });
+
+  it("requires explicit allow_classes in every rule", () => {
+    const errors = compileNewFilePolicy({
+      new_file_classes: {
+        test: ["tests/**"],
+      },
+      change_classes: ["kernel-hardening"],
+      new_file_rules: {
+        "kernel-hardening": {
+          max_per_class: {
+            test: 1,
+          },
+        },
+      },
+    });
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("allow_classes is required"));
+  });
+
+  it("accepts empty allow_classes as explicit deny-all semantics", () => {
+    const errors = compileNewFilePolicy({
+      new_file_classes: {
+        test: ["tests/**"],
+      },
+      change_classes: ["docs-cleanup"],
+      new_file_rules: {
+        "docs-cleanup": {
+          allow_classes: [],
+          max_new_files: 0,
+        },
+      },
+    });
+    assert.equal(errors.length, 0);
+  });
 });
 
 describe("overrides reserved semantics", () => {

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -49,6 +49,21 @@ expect("old-form content_rules (pattern/severity/message) fails schema", validat
 const invalidOpPaths = loadJSON(resolve(root, "tests/fixtures/invalid-operational-paths.json"));
 expect("invalid operational_paths (string instead of array) fails schema", validatePolicy(invalidOpPaths), false);
 
+const missingAllowClassesPolicy = {
+  change_classes: ["kernel-hardening"],
+  new_file_classes: {
+    test: ["tests/**"],
+  },
+  new_file_rules: {
+    "kernel-hardening": {
+      max_per_class: {
+        test: 1,
+      },
+    },
+  },
+};
+expect("new_file_rules without allow_classes fails schema", validatePolicy(missingAllowClassesPolicy), false);
+
 // Contract tests
 const validContract = loadJSON(resolve(root, "tests/fixtures/valid-contract.json"));
 expect("valid-contract.json passes schema", validateContract(validContract), true);


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#36.

Adds typed new-file classification so policy can distinguish classes of added files instead of relying only on a flat `max_new_files` count. Reviewer feedback addressed: every `new_file_rules` entry now requires explicit `allow_classes`; `allow_classes: []` is the intentional deny-all spelling.

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - README.md
  - schemas/repo-policy.schema.json
  - src/diff-checker.mjs
  - src/enforcement.mjs
  - src/github-pr.mjs
  - src/policy-compiler.mjs
  - src/repo-guard.mjs
  - tests/fixtures/valid-policy.json
  - tests/test-diff-rules.mjs
  - tests/test-hardening.mjs
  - tests/validate-schemas.mjs
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 2000
must_touch:
  - src/diff-checker.mjs
  - tests/test-diff-rules.mjs
must_not_touch:
  - docs/phase-*
  - docs/history-*
expected_effects:
  - Policies can classify added files into named classes.
  - New-file rules can restrict allowed classes and per-class budgets by change class.
  - Existing flat max_new_files behavior remains supported when typed rules are absent.
  - allow_classes is explicit for every new_file_rules entry, and [] intentionally forbids all classes.
```

## What changed

- Added `new_file_classes` and `new_file_rules` to `repo-policy.schema.json`.
- Added runtime classification for added files only, including unclassified-file reporting.
- Added per-`change_class` enforcement for `allow_classes`, `max_per_class`, and rule-level `max_new_files`.
- Made `allow_classes` required in schema/compiler validation to avoid omitted-field deny-all ambiguity.
- Wired the check into both `check-diff` and `check-pr` while preserving existing flat budgets when no new-file rules are configured.
- Extended text, JSON, and summary reporting with new-file class details.
- Documented why typed rules are more precise than a flat new-file count.

## Reproduction / Verification

The unit coverage reproduces the requested behavior in `tests/test-diff-rules.mjs` and the reviewer-requested semantic guard in `tests/test-hardening.mjs` / `tests/validate-schemas.mjs`:

- allowed test/changelog new files pass for `kernel-hardening`;
- generated and unclassified new files fail with offending file and class details;
- per-class budgets fail when a class exceeds its configured limit;
- `max_new_files: 0` can forbid new files for a specific change class;
- omitting `allow_classes` fails schema/compiler validation;
- existing behavior still passes when no new-file rules are configured.

Local checks run:

```bash
npm test
```

Result: passed.
