### PR TITLE
Add issue-type-aware policy validation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T08:45:47.754Z for PR creation at branch issue-37-66672fca68e7 for issue https://github.com/netkeep80/repo-guard/issues/37

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T08:45:47.754Z for PR creation at branch issue-37-66672fca68e7 for issue https://github.com/netkeep80/repo-guard/issues/37

--- a/README.md
+++ b/README.md
@@ -557,6 +557,55 @@ Result: passed (mode: blocking; exit code 0)
 
 Файлы, которые не совпали ни с одним glob из `new_file_classes`, считаются unclassified и тоже fail, когда `new_file_rules` активны. Старое поведение `max_new_files` не меняется: если `new_file_classes` и `new_file_rules` отсутствуют, repo-guard продолжает применять только плоские budgets.
 
+## Issue Type Rules
+
+`change_type` в contract описывает тип работы: например `governance`, `kernel-hardening`, `docs-cleanup` или любой другой тип, принятый в репозитории. Policy может сделать этот тип first-class input через `change_type_rules`:
+
+```json
+{
+  "surfaces": {
+    "kernel": ["src/**"],
+    "tests": ["tests/**"],
+    "docs": ["docs/**", "README.md"],
+    "generated": ["single_include/**"]
+  },
+  "new_file_classes": {
+    "test": ["tests/**"],
+    "changelog_fragment": ["changelog.d/*.md"],
+    "generated": ["single_include/**"]
+  },
+  "change_type_rules": {
+    "governance": {
+      "max_new_docs": 0,
+      "forbid_surfaces": ["kernel", "generated"],
+      "new_file_rules": {
+        "allow_classes": ["changelog_fragment"],
+        "max_per_class": {
+          "changelog_fragment": 1
+        }
+      }
+    },
+    "kernel-hardening": {
+      "require_surfaces": ["tests"]
+    }
+  }
+}
+```
+
+Type rules can constrain touched surfaces with `allow_surfaces`, `forbid_surfaces`, and `require_surfaces`; apply stricter budgets with `max_new_docs`, `max_new_files`, and `max_net_added_lines`; and embed a type-local `new_file_rules` block. Existing repositories that do not define `change_type_rules` keep the previous behavior.
+
+При нарушении output показывает declared type и конкретное type-aware правило:
+
+```text
+  FAIL: change-type-rules
+    change_type "governance" violated change_type_rules
+    change_type: governance
+    touched_surfaces: docs, generated, kernel
+    forbidden_surfaces: generated, kernel
+    violating_surfaces: generated, kernel
+    new docs 1 exceeds change_type_rules["governance"].max_new_docs 0; files: docs/new.md
+```
+
 ## Ownership-aware surfaces
 
 Глобальный `paths.forbidden` хорошо работает для файлов, которые нельзя трогать никогда. Но generated, release или governance surfaces часто нельзя запрещать глобально: regeneration PR должен иметь право менять generated-файлы, а обычный docs PR — нет.

--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ Result: passed (mode: blocking; exit code 0)
 }
 ```
 
-Type rules can constrain touched surfaces with `allow_surfaces`, `forbid_surfaces`, and `require_surfaces`; apply stricter budgets with `max_new_docs`, `max_new_files`, and `max_net_added_lines`; and embed a type-local `new_file_rules` block. Existing repositories that do not define `change_type_rules` keep the previous behavior.
+Type rules can constrain touched surfaces with `allow_surfaces`, `forbid_surfaces`, and `require_surfaces`; apply stricter budgets with `max_new_docs`, `max_new_files`, and `max_net_added_lines`; and embed a type-local `new_file_rules` block. When a type rule uses surface constraints, every changed file must match at least one declared surface. This matches the fail-closed `surface_matrix` model so unclassified files cannot bypass type-aware topology checks. Existing repositories that do not define `change_type_rules` keep the previous behavior.
 
 При нарушении output показывает declared type и конкретное type-aware правило:
 

--- a/schemas/change-contract.schema.json
+++ b/schemas/change-contract.schema.json
@@ -15,7 +15,8 @@
   "properties": {
     "change_type": {
       "type": "string",
-      "enum": ["feature", "bugfix", "refactor", "docs", "chore"]
+      "minLength": 1,
+      "description": "Declared issue or change type. Repositories may attach policy constraints to this value with change_type_rules."
     },
     "change_class": {
       "type": "string",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -168,6 +168,67 @@
         }
       }
     },
+    "change_type_rules": {
+      "type": "object",
+      "description": "Per-change-type policy constraints keyed by contract change_type.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allow_surfaces": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "forbid_surfaces": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "require_surfaces": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "uniqueItems": true
+          },
+          "max_new_docs": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_new_files": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "max_net_added_lines": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "new_file_rules": {
+            "type": "object",
+            "required": ["allow_classes"],
+            "additionalProperties": false,
+            "properties": {
+              "allow_classes": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 },
+                "uniqueItems": true
+              },
+              "max_per_class": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "max_new_files": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        }
+      }
+    },
     "content_rules": {
       "type": "array",
       "items": {

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -390,6 +390,101 @@ export function checkNewFileRules(files, newFileClasses, newFileRules, changeCla
   };
 }
 
+export function checkChangeTypeRules(files, policy, changeType) {
+  const changeTypeRules = policy.change_type_rules || {};
+  if (Object.keys(changeTypeRules).length === 0) return { ok: true };
+
+  const changeTypeValue = changeType || null;
+  if (!changeTypeValue) {
+    return {
+      ok: false,
+      message: "change_type_rules requires a declared change_type",
+      change_type: null,
+      hint: "Set change_type in the contract.",
+    };
+  }
+
+  const rule = changeTypeRules[changeTypeValue];
+  if (!rule) {
+    return {
+      ok: false,
+      message: `change_type "${changeTypeValue}" is not defined in change_type_rules`,
+      change_type: changeTypeValue,
+      details: [`known change types: ${formatList(Object.keys(changeTypeRules).sort())}`],
+      hint: "Define the change type in change_type_rules or use one of the configured types.",
+    };
+  }
+
+  const detectedSurfaces = detectTouchedSurfaces(files, policy.surfaces);
+  const touchedSurfaces = detectedSurfaces.touched_surfaces;
+  const requiredSurfaces = uniqueSorted(rule.require_surfaces || []);
+  const allowedSurfaces = uniqueSorted(rule.allow_surfaces || []);
+  const forbiddenSurfaces = uniqueSorted(rule.forbid_surfaces || []);
+  const allowedSet = new Set(allowedSurfaces);
+  const forbiddenSet = new Set(forbiddenSurfaces);
+  const touchedSet = new Set(touchedSurfaces);
+  const missingRequiredSurfaces = requiredSurfaces.filter((surface) => !touchedSet.has(surface));
+  const notAllowedSurfaces = allowedSurfaces.length > 0
+    ? touchedSurfaces.filter((surface) => !allowedSet.has(surface))
+    : [];
+  const explicitlyForbiddenSurfaces = touchedSurfaces.filter((surface) => forbiddenSet.has(surface));
+  const violatingSurfaces = uniqueSorted([...notAllowedSurfaces, ...explicitlyForbiddenSurfaces]);
+
+  const newFileResult = rule.new_file_rules
+    ? checkNewFileRules(files, policy.new_file_classes, { [changeTypeValue]: rule.new_file_rules }, changeTypeValue)
+    : { ok: true };
+  const docsBudget = checkCanonicalDocsBudget(files, policy.paths.canonical_docs, rule.max_new_docs);
+  const newFilesBudget = checkNewFilesBudget(files, rule.max_new_files);
+  const netLinesBudget = checkNetAddedLinesBudget(files, rule.max_net_added_lines);
+
+  const details = [
+    ...missingRequiredSurfaces.map(
+      (surface) => `required surface ${surface} was not touched by change_type_rules["${changeTypeValue}"].require_surfaces`
+    ),
+    ...violatingSurfaces.map(
+      (surface) => `surface ${surface} violated change_type_rules["${changeTypeValue}"] surface constraints; files: ${detectedSurfaces.files_by_surface[surface].join(", ")}`
+    ),
+  ];
+  if (!docsBudget.ok) {
+    details.push(`new docs ${docsBudget.actual} exceeds change_type_rules["${changeTypeValue}"].max_new_docs ${docsBudget.limit}; files: ${docsBudget.files.join(", ")}`);
+  }
+  if (!newFilesBudget.ok) {
+    details.push(`new files ${newFilesBudget.actual} exceeds change_type_rules["${changeTypeValue}"].max_new_files ${newFilesBudget.limit}; files: ${newFilesBudget.files.join(", ")}`);
+  }
+  if (!netLinesBudget.ok) {
+    details.push(`net added lines ${netLinesBudget.actual} exceeds change_type_rules["${changeTypeValue}"].max_net_added_lines ${netLinesBudget.limit}`);
+  }
+  if (!newFileResult.ok) {
+    details.push(...(newFileResult.details || [newFileResult.message]).filter(Boolean));
+  }
+
+  const ok = missingRequiredSurfaces.length === 0 &&
+    violatingSurfaces.length === 0 &&
+    docsBudget.ok &&
+    newFilesBudget.ok &&
+    netLinesBudget.ok &&
+    newFileResult.ok;
+
+  return {
+    ok,
+    message: ok ? undefined : `change_type "${changeTypeValue}" violated change_type_rules`,
+    change_type: changeTypeValue,
+    touched_surfaces: touchedSurfaces,
+    required_surfaces: requiredSurfaces,
+    allowed_surfaces: allowedSurfaces,
+    forbidden_surfaces: forbiddenSurfaces,
+    missing_required_surfaces: missingRequiredSurfaces,
+    violating_surfaces: violatingSurfaces,
+    files_by_surface: detectedSurfaces.files_by_surface,
+    unclassified_files: detectedSurfaces.unclassified_files,
+    docs_budget: docsBudget,
+    new_files_budget: newFilesBudget,
+    net_added_lines_budget: netLinesBudget,
+    new_file_rules: newFileResult,
+    details,
+  };
+}
+
 export function checkSurfaceMatrix(files, surfaces, surfaceMatrix, changeClass, options = {}) {
   if (!surfaceMatrix || Object.keys(surfaceMatrix).length === 0) return { ok: true };
 

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -423,6 +423,11 @@ export function checkChangeTypeRules(files, policy, changeType) {
   const allowedSet = new Set(allowedSurfaces);
   const forbiddenSet = new Set(forbiddenSurfaces);
   const touchedSet = new Set(touchedSurfaces);
+  const usesSurfaceConstraints = requiredSurfaces.length > 0 ||
+    allowedSurfaces.length > 0 ||
+    forbiddenSurfaces.length > 0;
+  const unclassifiedFiles = detectedSurfaces.unclassified_files;
+  const hasUnclassifiedViolation = usesSurfaceConstraints && unclassifiedFiles.length > 0;
   const missingRequiredSurfaces = requiredSurfaces.filter((surface) => !touchedSet.has(surface));
   const notAllowedSurfaces = allowedSurfaces.length > 0
     ? touchedSurfaces.filter((surface) => !allowedSet.has(surface))
@@ -445,6 +450,9 @@ export function checkChangeTypeRules(files, policy, changeType) {
       (surface) => `surface ${surface} violated change_type_rules["${changeTypeValue}"] surface constraints; files: ${detectedSurfaces.files_by_surface[surface].join(", ")}`
     ),
   ];
+  if (hasUnclassifiedViolation) {
+    details.push(`changed files matched no declared surface: ${unclassifiedFiles.join(", ")}`);
+  }
   if (!docsBudget.ok) {
     details.push(`new docs ${docsBudget.actual} exceeds change_type_rules["${changeTypeValue}"].max_new_docs ${docsBudget.limit}; files: ${docsBudget.files.join(", ")}`);
   }
@@ -460,6 +468,7 @@ export function checkChangeTypeRules(files, policy, changeType) {
 
   const ok = missingRequiredSurfaces.length === 0 &&
     violatingSurfaces.length === 0 &&
+    !hasUnclassifiedViolation &&
     docsBudget.ok &&
     newFilesBudget.ok &&
     netLinesBudget.ok &&
@@ -476,12 +485,13 @@ export function checkChangeTypeRules(files, policy, changeType) {
     missing_required_surfaces: missingRequiredSurfaces,
     violating_surfaces: violatingSurfaces,
     files_by_surface: detectedSurfaces.files_by_surface,
-    unclassified_files: detectedSurfaces.unclassified_files,
+    unclassified_files: unclassifiedFiles,
     docs_budget: docsBudget,
     new_files_budget: newFilesBudget,
     net_added_lines_budget: netLinesBudget,
     new_file_rules: newFileResult,
     details,
+    hint: hasUnclassifiedViolation ? "Add matching surface globs so change_type_rules can classify every changed file." : undefined,
   };
 }
 

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -80,6 +80,9 @@ function printCheckDetails(mode, check) {
   if (hasOwn(check, "change_class")) {
     write(`    change_class: ${check.change_class || "(missing)"}`);
   }
+  if (hasOwn(check, "change_type")) {
+    write(`    change_type: ${check.change_type || "(missing)"}`);
+  }
   if (check.touched_surfaces) {
     write(`    touched_surfaces: ${formatList(check.touched_surfaces)}`);
   }
@@ -136,6 +139,7 @@ function detailFromCheck(check) {
   if (check.must_touch) details.push(`must_touch: ${check.must_touch.join(", ")}`);
   if (check.must_not_touch) details.push(`must_not_touch: ${check.must_not_touch.join(", ")}`);
   if (hasOwn(check, "change_class")) details.push(`change_class: ${check.change_class || "(missing)"}`);
+  if (hasOwn(check, "change_type")) details.push(`change_type: ${check.change_type || "(missing)"}`);
   if (check.touched_surfaces) details.push(`touched_surfaces: ${formatList(check.touched_surfaces)}`);
   if (check.new_files) details.push(`new_files: ${formatList(check.new_files)}`);
   if (check.allowed_classes) details.push(`allowed_classes: ${formatList(check.allowed_classes)}`);
@@ -177,6 +181,7 @@ function violationFromCheck(name, check) {
   if (check.growth) violation.growth = check.growth;
   if (check.surface_debt) violation.surface_debt = check.surface_debt;
   if (hasOwn(check, "change_class")) violation.change_class = check.change_class;
+  if (hasOwn(check, "change_type")) violation.change_type = check.change_type;
   if (check.touched_surfaces) violation.touched_surfaces = check.touched_surfaces;
   if (check.new_files) violation.new_files = check.new_files;
   if (check.allowed_classes) violation.allowed_classes = check.allowed_classes;

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -6,6 +6,7 @@ import { extractContract, extractLinkedIssueNumbers, resolveContract } from "./m
 import {
   compileForbidRegex,
   compileNewFilePolicy,
+  compileChangeTypePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
@@ -30,6 +31,7 @@ import {
   checkContentRules,
   checkMustTouch,
   checkMustNotTouch,
+  checkChangeTypeRules,
 } from "./diff-checker.mjs";
 
 function loadJSON(path) {
@@ -182,6 +184,15 @@ export function runCheckPR(roots, args = []) {
     }
   }
 
+  const changeTypeErrors = compileChangeTypePolicy(policy);
+  if (changeTypeErrors.length > 0) {
+    ok = false;
+    console.error("FAIL: change type policy compilation");
+    for (const e of changeTypeErrors) {
+      console.error(`  ${e.message}`);
+    }
+  }
+
   for (const w of warnReservedPolicyFields(policy)) {
     console.warn(`WARN: ${w}`);
   }
@@ -261,6 +272,10 @@ export function runCheckPR(roots, args = []) {
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+
+  if (policy.change_type_rules) {
+    reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));
+  }
 
   if (policy.new_file_rules) {
     reporter.report(

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -123,6 +123,74 @@ export function compileNewFilePolicy(policy) {
   return errors;
 }
 
+export function compileChangeTypePolicy(policy) {
+  const errors = [];
+  const changeTypeRules = policy.change_type_rules || {};
+  const surfaces = policy.surfaces || {};
+  const surfaceNames = new Set(Object.keys(surfaces));
+  const newFileClasses = policy.new_file_classes || {};
+  const classNames = new Set(Object.keys(newFileClasses));
+
+  if (!policy.change_type_rules) return errors;
+
+  for (const [changeType, rule] of Object.entries(changeTypeRules)) {
+    for (const field of ["allow_surfaces", "forbid_surfaces", "require_surfaces"]) {
+      for (const surface of rule[field] || []) {
+        if (!surfaceNames.has(surface)) {
+          errors.push({
+            change_type: changeType,
+            surface,
+            message: `change_type_rules["${changeType}"].${field} references unknown surface "${surface}"`,
+          });
+        }
+      }
+    }
+
+    const allowed = new Set(rule.allow_surfaces || []);
+    for (const surface of rule.forbid_surfaces || []) {
+      if (allowed.has(surface)) {
+        errors.push({
+          change_type: changeType,
+          surface,
+          message: `change_type_rules["${changeType}"] lists surface "${surface}" in both allow_surfaces and forbid_surfaces`,
+        });
+      }
+    }
+
+    const newFileRules = rule.new_file_rules;
+    if (!newFileRules) continue;
+
+    if (!Object.hasOwn(newFileRules, "allow_classes")) {
+      errors.push({
+        change_type: changeType,
+        message: `change_type_rules["${changeType}"].new_file_rules.allow_classes is required; use [] to forbid all new-file classes`,
+      });
+    }
+
+    for (const fileClass of newFileRules.allow_classes || []) {
+      if (!classNames.has(fileClass)) {
+        errors.push({
+          change_type: changeType,
+          class: fileClass,
+          message: `change_type_rules["${changeType}"].new_file_rules.allow_classes references unknown class "${fileClass}"`,
+        });
+      }
+    }
+
+    for (const fileClass of Object.keys(newFileRules.max_per_class || {})) {
+      if (!classNames.has(fileClass)) {
+        errors.push({
+          change_type: changeType,
+          class: fileClass,
+          message: `change_type_rules["${changeType}"].new_file_rules.max_per_class references unknown class "${fileClass}"`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function warnReservedContractFields(contract) {
   const warnings = [];
   if (contract.overrides && contract.overrides.length > 0) {

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -19,10 +19,12 @@ import {
   checkContentRules,
   checkMustTouch,
   checkMustNotTouch,
+  checkChangeTypeRules,
 } from "./diff-checker.mjs";
 import {
   compileForbidRegex,
   compileNewFilePolicy,
+  compileChangeTypePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
   warnReservedPolicyFields,
@@ -191,6 +193,17 @@ function runCheckDiff(roots, args) {
     }
   }
 
+  const changeTypeErrors = compileChangeTypePolicy(policy);
+  if (changeTypeErrors.length > 0) {
+    ok = false;
+    if (!quiet) {
+      console.error("FAIL: change type policy compilation");
+      for (const e of changeTypeErrors) {
+        console.error(`  ${e.message}`);
+      }
+    }
+  }
+
   if (!quiet) {
     for (const w of warnReservedPolicyFields(policy)) {
       console.warn(`WARN: ${w}`);
@@ -254,6 +267,10 @@ function runCheckDiff(roots, args) {
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+
+  if (policy.change_type_rules) {
+    reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));
+  }
 
   const declaredChangeClass = cliChangeClass || contract?.change_class || null;
   if (policy.new_file_rules) {

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -557,6 +557,22 @@ expect("12. change type reports violating kernel surface", governanceViolation.v
 expect("12. change type reports docs budget", governanceViolation.docs_budget.ok, false);
 expect("12. change type reports new-file class violations", governanceViolation.new_file_rules.ok, false);
 
+const governanceUnclassifiedViolation = checkChangeTypeRules(
+  [
+    { path: "docs/policy.md", addedLines: ["docs"], deletedLines: [], status: "modified" },
+    { path: "scripts/tool.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+  ],
+  changeTypePolicy,
+  "governance"
+);
+expect("12. change type surface constraints reject unclassified files", governanceUnclassifiedViolation.ok, false);
+expect("12. change type reports unclassified file", governanceUnclassifiedViolation.unclassified_files[0], "scripts/tool.mjs");
+expect(
+  "12. change type unclassified file appears in details",
+  governanceUnclassifiedViolation.details.some((detail) => detail.includes("scripts/tool.mjs")),
+  true
+);
+
 const kernelHardeningAllowed = checkChangeTypeRules(
   [
     { path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -14,6 +14,7 @@ import {
   checkSurfaceMatrix,
   classifyNewFiles,
   checkNewFileRules,
+  checkChangeTypeRules,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -509,6 +510,80 @@ expect(
   "11. new file rules pass when no new files exist without change_class",
   checkNewFileRules([{ path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" }], newFileClasses, newFileRules, null).ok,
   true
+);
+
+// --- 12. change type rules ---
+
+const changeTypePolicy = {
+  paths: {
+    canonical_docs: ["README.md"],
+  },
+  surfaces: {
+    ...surfaces,
+    docs: [...surfaces.docs, "changelog.d/*.md"],
+  },
+  new_file_classes: newFileClasses,
+  change_type_rules: {
+    governance: {
+      allow_surfaces: ["docs"],
+      forbid_surfaces: ["kernel", "generated"],
+      max_new_docs: 0,
+      max_new_files: 1,
+      new_file_rules: {
+        allow_classes: ["changelog_fragment"],
+        max_per_class: {
+          changelog_fragment: 1,
+        },
+      },
+    },
+    "kernel-hardening": {
+      require_surfaces: ["tests"],
+    },
+  },
+};
+
+const governanceViolation = checkChangeTypeRules(
+  [
+    { path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+    { path: "docs/new.md", addedLines: ["docs"], deletedLines: [], status: "added" },
+    { path: "single_include/core.h", addedLines: ["generated"], deletedLines: [], status: "added" },
+  ],
+  changeTypePolicy,
+  "governance"
+);
+expect("12. change type rules reject forbidden surfaces", governanceViolation.ok, false);
+expect("12. change type result names declared type", governanceViolation.change_type, "governance");
+expect("12. change type reports violating kernel surface", governanceViolation.violating_surfaces.includes("kernel"), true);
+expect("12. change type reports docs budget", governanceViolation.docs_budget.ok, false);
+expect("12. change type reports new-file class violations", governanceViolation.new_file_rules.ok, false);
+
+const kernelHardeningAllowed = checkChangeTypeRules(
+  [
+    { path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" },
+    { path: "tests/core.test.mjs", addedLines: ["test"], deletedLines: [], status: "modified" },
+  ],
+  changeTypePolicy,
+  "kernel-hardening"
+);
+expect("12. change type rules pass allowed constraints", kernelHardeningAllowed.ok, true);
+
+const missingRequiredSurface = checkChangeTypeRules(
+  [{ path: "src/core.mjs", addedLines: ["code"], deletedLines: [], status: "modified" }],
+  changeTypePolicy,
+  "kernel-hardening"
+);
+expect("12. change type require_surfaces fails when missing", missingRequiredSurface.ok, false);
+expect("12. change type missing surface reported", missingRequiredSurface.missing_required_surfaces[0], "tests");
+
+expect(
+  "12. change type rules require declared change_type",
+  checkChangeTypeRules(surfaceFiles, changeTypePolicy, null).ok,
+  false
+);
+expect(
+  "12. unknown change_type fails with known types",
+  checkChangeTypeRules(surfaceFiles, changeTypePolicy, "release").ok,
+  false
 );
 
 // --- Summary ---

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -68,6 +68,12 @@ expect("new_file_rules without allow_classes fails schema", validatePolicy(missi
 const validContract = loadJSON(resolve(root, "tests/fixtures/valid-contract.json"));
 expect("valid-contract.json passes schema", validateContract(validContract), true);
 
+const repositoryTypedContract = {
+  ...validContract,
+  change_type: "governance",
+};
+expect("repository-specific change_type passes schema", validateContract(repositoryTypedContract), true);
+
 const invalidContract = loadJSON(resolve(root, "tests/fixtures/invalid-contract.json"));
 expect("invalid-contract.json fails schema", validateContract(invalidContract), false);
 


### PR DESCRIPTION
## Summary

Adds first-class `change_type` policy validation for repo-guard contracts.

## Changes

- Allows repository-specific `change_type` values in change contracts.
- Adds `change_type_rules` policy schema support for per-type surface constraints, stricter budgets, required surfaces, and type-local new-file rules.
- Enforces `change_type_rules` in both `check-diff` and `check-pr`.
- Fails closed when a type rule uses surface constraints and changed files match no declared surface.
- Reports the declared `change_type` and violated type-aware rule details in text and structured output.
- Documents issue type rules in the README.

## Verification

- `npm test`

## Repo Guard Contract

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - README.md
  - schemas/change-contract.schema.json
  - schemas/repo-policy.schema.json
  - src/diff-checker.mjs
  - src/enforcement.mjs
  - src/github-pr.mjs
  - src/policy-compiler.mjs
  - src/repo-guard.mjs
  - tests/test-diff-rules.mjs
  - tests/validate-schemas.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 500
must_touch:
  - src/diff-checker.mjs
  - schemas/repo-policy.schema.json
  - tests/test-diff-rules.mjs
must_not_touch:
  - LICENSE
expected_effects:
  - check-diff and check-pr enforce declared change_type policy rules
  - change_type_rules surface constraints reject unclassified changed files by default
```

Fixes netkeep80/repo-guard#37
