### PR TITLE
Add canonical registry integrity checks

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T09:15:58.310Z for PR creation at branch issue-38-f2c5026946aa for issue https://github.com/netkeep80/repo-guard/issues/38

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T09:15:58.310Z for PR creation at branch issue-38-f2c5026946aa for issue https://github.com/netkeep80/repo-guard/issues/38

--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ Diff analysis: 3 file(s) changed
   PASS: canonical-docs-budget
   PASS: max-new-files
   PASS: max-net-added-lines
+  PASS: registry-rules
   PASS: new-file-rules
   PASS: cochange-rules
   PASS: content-rules
@@ -556,6 +557,57 @@ Result: passed (mode: blocking; exit code 0)
 ```
 
 Файлы, которые не совпали ни с одним glob из `new_file_classes`, считаются unclassified и тоже fail, когда `new_file_rules` активны. Старое поведение `max_new_files` не меняется: если `new_file_classes` и `new_file_rules` отсутствуют, repo-guard продолжает применять только плоские budgets.
+
+## Registry Integrity Rules
+
+`registry_rules` сравнивает две canonical list и помогает держать несколько registry в согласованном состоянии. Правило не зависит от diff contents: `check-diff` читает указанные файлы из рабочей директории и проверяет agreement перед остальными policy checks.
+
+```json
+{
+  "registry_rules": [
+    {
+      "id": "canonical-docs-sync",
+      "kind": "set_equality",
+      "left": {
+        "type": "json_array",
+        "file": "repo-policy.json",
+        "json_pointer": "/paths/canonical_docs"
+      },
+      "right": {
+        "type": "markdown_section_links",
+        "file": "docs/index.md",
+        "section": "Canonical Documents",
+        "prefix": "docs/"
+      }
+    }
+  ]
+}
+```
+
+Supported `kind` values:
+
+- `set_equality`: both registries must contain the same entries.
+- `left_subset_of_right`: every left entry must appear on the right.
+- `right_subset_of_left`: every right entry must appear on the left.
+
+Supported source types in v1:
+
+- `json_array`: reads an array from `file` using `json_pointer`.
+- `markdown_section_links`: reads markdown links from a named heading section. Relative links are normalized to repository paths. `prefix` can map links inside the markdown file directory to canonical registry paths, for example `policy.md` in `docs/index.md` becomes `docs/policy.md`.
+
+When a rule fails, output identifies the rule, both registry contents, and the missing or extra entries:
+
+```text
+  FAIL: registry-rules
+    failed_rules: canonical-docs-sync
+    [canonical-docs-sync] registry rule "canonical-docs-sync" failed set_equality
+    left entries: README.md, docs/policy.md
+    right entries: README.md, docs/architecture.md
+    missing from right: docs/policy.md
+    extra in right: docs/architecture.md
+```
+
+Policies without `registry_rules` keep the previous behavior and report `PASS: registry-rules`.
 
 ## Issue Type Rules
 

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -229,6 +229,24 @@
         }
       }
     },
+    "registry_rules": {
+      "type": "array",
+      "description": "Rules that compare canonical registries from structured files or markdown sections.",
+      "items": {
+        "type": "object",
+        "required": ["id", "kind", "left", "right"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "kind": {
+            "type": "string",
+            "enum": ["set_equality", "left_subset_of_right", "right_subset_of_left"]
+          },
+          "left": { "$ref": "#/definitions/registry_source" },
+          "right": { "$ref": "#/definitions/registry_source" }
+        }
+      }
+    },
     "content_rules": {
       "type": "array",
       "items": {
@@ -269,6 +287,33 @@
           }
         }
       }
+    }
+  },
+  "definitions": {
+    "registry_source": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["type", "file", "json_pointer"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "json_array" },
+            "file": { "type": "string", "minLength": 1 },
+            "json_pointer": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["type", "file", "section"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "markdown_section_links" },
+            "file": { "type": "string", "minLength": 1 },
+            "section": { "type": "string", "minLength": 1 },
+            "prefix": { "type": "string" }
+          }
+        }
+      ]
     }
   }
 }

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -1,4 +1,6 @@
 import { minimatch } from "minimatch";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 export function matchesAny(filePath, patterns) {
   return patterns.some((p) => minimatch(filePath, p, { dot: true }));
@@ -201,6 +203,209 @@ function uniqueSorted(values) {
 
 function formatList(values) {
   return values && values.length > 0 ? values.join(", ") : "(none)";
+}
+
+function normalizeRegistryEntry(value) {
+  return String(value || "").trim().replace(/^\.\//, "");
+}
+
+function uniqueSortedNormalized(values) {
+  return uniqueSorted(values.map(normalizeRegistryEntry).filter(Boolean));
+}
+
+function decodeJsonPointerPart(part) {
+  return part.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+function resolveJsonPointer(data, pointer) {
+  if (pointer === "") return data;
+  if (!pointer || !pointer.startsWith("/")) {
+    throw new Error(`invalid json_pointer "${pointer}"`);
+  }
+
+  let current = data;
+  for (const rawPart of pointer.slice(1).split("/")) {
+    const part = decodeJsonPointerPart(rawPart);
+    if (current === null || current === undefined || !Object.prototype.hasOwnProperty.call(current, part)) {
+      throw new Error(`json_pointer "${pointer}" does not exist`);
+    }
+    current = current[part];
+  }
+  return current;
+}
+
+function markdownHeadingLevel(line, section) {
+  const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+  if (!match) return null;
+  return match[2].trim().toLowerCase() === section.trim().toLowerCase()
+    ? match[1].length
+    : null;
+}
+
+function extractMarkdownSection(content, section) {
+  const lines = content.split(/\r?\n/);
+  let inSection = false;
+  let level = null;
+  const sectionLines = [];
+
+  for (const line of lines) {
+    const heading = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (!inSection) {
+      const matchedLevel = markdownHeadingLevel(line, section);
+      if (matchedLevel) {
+        inSection = true;
+        level = matchedLevel;
+      }
+      continue;
+    }
+
+    if (heading && heading[1].length <= level) break;
+    sectionLines.push(line);
+  }
+
+  if (!inSection) {
+    throw new Error(`markdown section "${section}" not found`);
+  }
+  return sectionLines.join("\n");
+}
+
+function normalizeMarkdownLinkTarget(target, source) {
+  const cleanTarget = normalizeRegistryEntry(target.split("#")[0].split("?")[0]);
+  if (!cleanTarget || /^[a-z][a-z0-9+.-]*:/i.test(cleanTarget) || cleanTarget.startsWith("#")) {
+    return "";
+  }
+
+  const sourceDir = source.file.includes("/")
+    ? source.file.split("/").slice(0, -1).join("/")
+    : "";
+  const withSourceDir = cleanTarget.startsWith("/")
+    ? cleanTarget.slice(1)
+    : normalizeRegistryEntry(`${sourceDir}/${cleanTarget}`);
+  const parts = [];
+  for (const part of withSourceDir.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") parts.pop();
+    else parts.push(part);
+  }
+  return parts.join("/");
+}
+
+function applyMarkdownLinkPrefix(target, source) {
+  if (!source.prefix) return target;
+  const prefix = normalizeRegistryEntry(source.prefix);
+  if (target.startsWith(prefix)) return target;
+  const sourceDir = source.file.includes("/")
+    ? `${source.file.split("/").slice(0, -1).join("/")}/`
+    : "";
+  if (sourceDir && target.startsWith(sourceDir)) {
+    return normalizeRegistryEntry(`${prefix}${target.slice(sourceDir.length)}`);
+  }
+  return target;
+}
+
+function readRegistryFile(source, options) {
+  if (options.readFile) {
+    const content = options.readFile(source.file);
+    if (content === undefined || content === null) {
+      throw new Error(`cannot read ${source.file}`);
+    }
+    return String(content);
+  }
+  return readFileSync(resolve(options.repoRoot || process.cwd(), source.file), "utf-8");
+}
+
+function readRegistrySource(source, options = {}) {
+  const content = readRegistryFile(source, options);
+
+  if (source.type === "json_array") {
+    const data = JSON.parse(content);
+    const value = resolveJsonPointer(data, source.json_pointer);
+    if (!Array.isArray(value)) {
+      throw new Error(`${source.file}${source.json_pointer} is not a JSON array`);
+    }
+    if (value.some((entry) => typeof entry !== "string")) {
+      throw new Error(`${source.file}${source.json_pointer} must contain only strings`);
+    }
+    return uniqueSortedNormalized(value);
+  }
+
+  if (source.type === "markdown_section_links") {
+    const section = extractMarkdownSection(content, source.section);
+    const links = [];
+    const linkPattern = /\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+    for (const match of section.matchAll(linkPattern)) {
+      const normalized = normalizeMarkdownLinkTarget(match[1], source);
+      if (!normalized) continue;
+      links.push(applyMarkdownLinkPrefix(normalized, source));
+    }
+    return uniqueSortedNormalized(links);
+  }
+
+  throw new Error(`unsupported registry source type "${source.type}"`);
+}
+
+export function checkRegistryRules(registryRules = [], options = {}) {
+  if (!registryRules || registryRules.length === 0) return { ok: true, results: [] };
+
+  const results = [];
+  for (const rule of registryRules) {
+    try {
+      const leftEntries = readRegistrySource(rule.left, options);
+      const rightEntries = readRegistrySource(rule.right, options);
+      const leftSet = new Set(leftEntries);
+      const rightSet = new Set(rightEntries);
+      const missingFromRight = leftEntries.filter((entry) => !rightSet.has(entry));
+      const extraInRight = rightEntries.filter((entry) => !leftSet.has(entry));
+      let ok;
+      if (rule.kind === "set_equality") {
+        ok = missingFromRight.length === 0 && extraInRight.length === 0;
+      } else if (rule.kind === "left_subset_of_right") {
+        ok = missingFromRight.length === 0;
+      } else if (rule.kind === "right_subset_of_left") {
+        ok = extraInRight.length === 0;
+      } else {
+        throw new Error(`unsupported registry rule kind "${rule.kind}"`);
+      }
+
+      results.push({
+        ok,
+        rule_id: rule.id,
+        kind: rule.kind,
+        left_entries: leftEntries,
+        right_entries: rightEntries,
+        missing_from_right: missingFromRight,
+        extra_in_right: extraInRight,
+        message: ok ? undefined : `registry rule "${rule.id}" failed ${rule.kind}`,
+      });
+    } catch (e) {
+      results.push({
+        ok: false,
+        rule_id: rule.id,
+        kind: rule.kind,
+        left_entries: [],
+        right_entries: [],
+        missing_from_right: [],
+        extra_in_right: [],
+        message: `registry rule "${rule.id}" could not be evaluated`,
+        details: [e.message],
+      });
+    }
+  }
+
+  const failed = results.filter((result) => !result.ok);
+  return {
+    ok: failed.length === 0,
+    results,
+    failed_rules: failed.map((result) => result.rule_id),
+    details: failed.flatMap((result) => [
+      `[${result.rule_id}] ${result.message}`,
+      `left entries: ${formatList(result.left_entries)}`,
+      `right entries: ${formatList(result.right_entries)}`,
+      `missing from right: ${formatList(result.missing_from_right)}`,
+      `extra in right: ${formatList(result.extra_in_right)}`,
+      ...(result.details || []),
+    ]),
+  };
 }
 
 export function detectTouchedSurfaces(files, surfaces = {}) {

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -107,6 +107,9 @@ function printCheckDetails(mode, check) {
   if (check.violating_surfaces) {
     write(`    violating_surfaces: ${formatList(check.violating_surfaces)}`);
   }
+  if (check.failed_rules) {
+    write(`    failed_rules: ${formatList(check.failed_rules)}`);
+  }
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     write(`    unclassified_files: ${formatList(check.unclassified_files)}`);
   }
@@ -148,6 +151,7 @@ function detailFromCheck(check) {
   if (check.allowed_surfaces) details.push(`allowed_surfaces: ${formatList(check.allowed_surfaces)}`);
   if (check.forbidden_surfaces) details.push(`forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
   if (check.violating_surfaces) details.push(`violating_surfaces: ${formatList(check.violating_surfaces)}`);
+  if (check.failed_rules) details.push(`failed_rules: ${formatList(check.failed_rules)}`);
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     details.push(`unclassified_files: ${formatList(check.unclassified_files)}`);
   }
@@ -193,6 +197,8 @@ function violationFromCheck(name, check) {
   if (check.forbidden_surfaces) violation.forbidden_surfaces = check.forbidden_surfaces;
   if (check.violating_surfaces) violation.violating_surfaces = check.violating_surfaces;
   if (check.files_by_surface) violation.files_by_surface = check.files_by_surface;
+  if (check.failed_rules) violation.failed_rules = check.failed_rules;
+  if (check.results) violation.results = check.results;
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     violation.unclassified_files = check.unclassified_files;
   }

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -32,6 +32,7 @@ import {
   checkMustTouch,
   checkMustNotTouch,
   checkChangeTypeRules,
+  checkRegistryRules,
 } from "./diff-checker.mjs";
 
 function loadJSON(path) {
@@ -272,6 +273,7 @@ export function runCheckPR(roots, args = []) {
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+  reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: roots.repoRoot }));
 
   if (policy.change_type_rules) {
     reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -20,6 +20,7 @@ import {
   checkMustTouch,
   checkMustNotTouch,
   checkChangeTypeRules,
+  checkRegistryRules,
 } from "./diff-checker.mjs";
 import {
   compileForbidRegex,
@@ -267,6 +268,7 @@ function runCheckDiff(roots, args) {
   reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+  reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: roots.repoRoot }));
 
   if (policy.change_type_rules) {
     reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -15,6 +15,7 @@ import {
   classifyNewFiles,
   checkNewFileRules,
   checkChangeTypeRules,
+  checkRegistryRules,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -601,6 +602,126 @@ expect(
   checkChangeTypeRules(surfaceFiles, changeTypePolicy, "release").ok,
   false
 );
+
+// --- 13. registry rules ---
+
+const registryFiles = new Map([
+  [
+    "repo-policy.json",
+    JSON.stringify({
+      paths: {
+        canonical_docs: ["README.md", "docs/policy.md"],
+      },
+    }),
+  ],
+  [
+    "docs/index.md",
+    [
+      "# Documentation",
+      "",
+      "## Canonical Documents",
+      "",
+      "- [Readme](../README.md)",
+      "- [Policy](policy.md)",
+      "",
+      "## Other Documents",
+      "",
+      "- [Extra](extra.md)",
+    ].join("\n"),
+  ],
+]);
+
+const registryRules = [
+  {
+    id: "canonical-docs-sync",
+    kind: "set_equality",
+    left: {
+      type: "json_array",
+      file: "repo-policy.json",
+      json_pointer: "/paths/canonical_docs",
+    },
+    right: {
+      type: "markdown_section_links",
+      file: "docs/index.md",
+      section: "Canonical Documents",
+      prefix: "docs/",
+    },
+  },
+];
+
+const matchingRegistryResult = checkRegistryRules(registryRules, {
+  readFile: (path) => registryFiles.get(path),
+});
+expect("13. matching registry rule passes", matchingRegistryResult.ok, true);
+expect("13. matching registry rule count", matchingRegistryResult.results.length, 1);
+
+const mismatchedRegistryResult = checkRegistryRules(registryRules, {
+  readFile: (path) => {
+    if (path === "docs/index.md") {
+      return [
+        "# Documentation",
+        "",
+        "## Canonical Documents",
+        "",
+        "- [Readme](../README.md)",
+        "- [Architecture](architecture.md)",
+      ].join("\n");
+    }
+    return registryFiles.get(path);
+  },
+});
+expect("13. registry mismatch fails", mismatchedRegistryResult.ok, false);
+expect("13. failed rule id reported", mismatchedRegistryResult.results[0].rule_id, "canonical-docs-sync");
+expect("13. left entries reported", mismatchedRegistryResult.results[0].left_entries.includes("docs/policy.md"), true);
+expect("13. right entries reported", mismatchedRegistryResult.results[0].right_entries.includes("docs/architecture.md"), true);
+expect("13. missing entries reported", mismatchedRegistryResult.results[0].missing_from_right[0], "docs/policy.md");
+expect("13. extra entries reported", mismatchedRegistryResult.results[0].extra_in_right[0], "docs/architecture.md");
+
+const subsetRegistryResult = checkRegistryRules(
+  [
+    {
+      id: "canonical-docs-listed",
+      kind: "left_subset_of_right",
+      left: registryRules[0].left,
+      right: {
+        ...registryRules[0].right,
+        section: "All Documents",
+      },
+    },
+  ],
+  {
+    readFile: (path) => {
+      if (path === "docs/index.md") {
+        return [
+          "## All Documents",
+          "",
+          "- [Readme](../README.md)",
+          "- [Policy](policy.md)",
+          "- [Extra](extra.md)",
+        ].join("\n");
+      }
+      return registryFiles.get(path);
+    },
+  }
+);
+expect("13. left subset of right passes with extra right entries", subsetRegistryResult.ok, true);
+
+const missingSourceResult = checkRegistryRules(registryRules, {
+  readFile: () => undefined,
+});
+expect("13. missing source fails", missingSourceResult.ok, false);
+expect("13. missing source detail names file", missingSourceResult.results[0].details[0].includes("repo-policy.json"), true);
+
+const nonStringRegistryResult = checkRegistryRules(registryRules, {
+  readFile: (path) => {
+    if (path === "repo-policy.json") {
+      return JSON.stringify({ paths: { canonical_docs: ["README.md", 42] } });
+    }
+    return registryFiles.get(path);
+  },
+});
+expect("13. non-string JSON registry entries fail", nonStringRegistryResult.ok, false);
+expect("13. non-string JSON registry detail", nonStringRegistryResult.results[0].details[0].includes("only strings"), true);
 
 // --- Summary ---
 

--- a/tests/test-enforcement-mode.mjs
+++ b/tests/test-enforcement-mode.mjs
@@ -65,6 +65,30 @@ function makePolicy(enforcementMode) {
   return policy;
 }
 
+function makeRegistryPolicy(enforcementMode) {
+  const policy = makePolicy(enforcementMode);
+  policy.paths.canonical_docs = ["README.md", "docs/policy.md"];
+  policy.diff_rules.max_new_files = 5;
+  policy.registry_rules = [
+    {
+      id: "canonical-docs-sync",
+      kind: "set_equality",
+      left: {
+        type: "json_array",
+        file: "repo-policy.json",
+        json_pointer: "/paths/canonical_docs",
+      },
+      right: {
+        type: "markdown_section_links",
+        file: "docs/index.md",
+        section: "Canonical Documents",
+        prefix: "docs/",
+      },
+    },
+  ];
+  return policy;
+}
+
 function makeRepo(enforcementMode) {
   const dir = mkdtempSync(join(tmpdir(), "repo-guard-enforcement-"));
   execSync("git init", { cwd: dir, stdio: "pipe" });
@@ -77,6 +101,36 @@ function makeRepo(enforcementMode) {
 
   writeFileSync(join(dir, "new-file.txt"), "new\n");
   execSync("git add -A && git commit -m add-file", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
+function makeRegistryPrRepo(enforcementMode) {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-registry-pr-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(makeRegistryPolicy(enforcementMode), null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("mkdir -p docs", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "docs", "policy.md"), "# Policy\n");
+  writeFileSync(join(dir, "docs", "index.md"), [
+    "# Docs",
+    "",
+    "## Canonical Documents",
+    "",
+    "- [Readme](../README.md)",
+    "- [Architecture](architecture.md)",
+  ].join("\n"));
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  writeFileSync(join(dir, "README.md"), "# Test\n\nChange.\n");
+  execSync("git add -A && git commit -m change", { cwd: dir, stdio: "pipe" });
 
   return {
     dir,
@@ -198,6 +252,46 @@ console.log("\n--- check-pr missing contract is advisory when requested ---");
   expect("check-pr advisory missing contract exit code", result.code, 0);
   expectIncludes("check-pr missing contract warning", result.output, "WARN: change-contract");
   expectIncludes("check-pr advisory summary", result.output, "advisory violation");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-pr enforces registry_rules ---");
+{
+  const repo = makeRegistryPrRepo();
+  const eventPath = join(repo.dir, "event.json");
+  writeFileSync(eventPath, JSON.stringify({
+    pull_request: {
+      number: 124,
+      base: { sha: repo.base },
+      head: { sha: repo.head },
+      body: `
+\`\`\`repo-guard-json
+{
+  "change_type": "docs",
+  "scope": ["README.md"],
+  "budgets": {"max_new_files": 5},
+  "must_touch": [],
+  "must_not_touch": [],
+  "expected_effects": ["Docs updated"]
+}
+\`\`\`
+`,
+    },
+    repository: { full_name: "owner/repo" },
+  }));
+
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-pr",
+  ], {
+    env: { GITHUB_EVENT_PATH: eventPath },
+  });
+
+  expect("check-pr registry mismatch exit code", result.code, 1);
+  expectIncludes("check-pr registry mismatch reports failure", result.output, "FAIL: registry-rules");
+  expectIncludes("check-pr registry mismatch names rule", result.output, "failed_rules: canonical-docs-sync");
+  expectIncludes("check-pr registry mismatch details missing entry", result.output, "missing from right: docs/policy.md");
 
   rmSync(repo.dir, { recursive: true });
 }

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -235,6 +235,70 @@ function makeUnclassifiedOnlySurfaceRepo() {
   };
 }
 
+function makeRegistryRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-registry-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md", "docs/policy.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    registry_rules: [
+      {
+        id: "canonical-docs-sync",
+        kind: "set_equality",
+        left: {
+          type: "json_array",
+          file: "repo-policy.json",
+          json_pointer: "/paths/canonical_docs",
+        },
+        right: {
+          type: "markdown_section_links",
+          file: "docs/index.md",
+          section: "Canonical Documents",
+          prefix: "docs/",
+        },
+      },
+    ],
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("mkdir -p docs", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "docs", "policy.md"), "# Policy\n");
+  writeFileSync(join(dir, "docs", "index.md"), [
+    "# Docs",
+    "",
+    "## Canonical Documents",
+    "",
+    "- [Readme](../README.md)",
+    "- [Architecture](architecture.md)",
+  ].join("\n"));
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  writeFileSync(join(dir, "README.md"), "# Test\n\nChange.\n");
+  execSync("git add -A && git commit -m change", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
 console.log("\n--- check-diff --format json emits stable machine-readable result ---");
 {
   const repo = makeRepo();
@@ -375,6 +439,44 @@ console.log("\n--- check-diff reports surface debt status in JSON output ---");
   expect("surface debt rule exposes declared status",
     debtResult?.details.includes("status: declared"),
     true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff evaluates registry_rules in JSON output ---");
+{
+  const repo = makeRegistryRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("registry rule exit code follows blocking failure", result.code, 1);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("registry rule stdout is valid json", true, true);
+  } catch (e) {
+    expect("registry rule stdout is valid json", e.message, "valid json");
+  }
+  const registryViolation = parsed?.violations.find((v) => v.rule === "registry-rules");
+  expect("registry violation is present", Boolean(registryViolation), true);
+  expect("registry failed rule id reported", registryViolation?.failed_rules[0], "canonical-docs-sync");
+  expect(
+    "registry result includes left entries",
+    registryViolation?.results[0].left_entries.includes("docs/policy.md"),
+    true
+  );
+  expect(
+    "registry result includes right entries",
+    registryViolation?.results[0].right_entries.includes("docs/architecture.md"),
+    true
+  );
+  expect("registry missing item is reported", registryViolation?.results[0].missing_from_right[0], "docs/policy.md");
+  expect("registry extra item is reported", registryViolation?.results[0].extra_in_right[0], "docs/architecture.md");
 
   rmSync(repo.dir, { recursive: true });
 }


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#38.

Adds generic registry integrity checks for `check-diff` and `check-pr` so policy can compare canonical lists from multiple sources and fail when they drift in both local diff checks and GitHub PR policy gates.

```repo-guard-yaml
change_type: governance
change_class: docs-cleanup
scope:
  - src/diff-checker.mjs
  - src/repo-guard.mjs
  - src/github-pr.mjs
  - src/enforcement.mjs
  - schemas/repo-policy.schema.json
  - README.md
  - tests/test-diff-rules.mjs
  - tests/test-enforcement-mode.mjs
  - tests/test-structured-output.mjs
budgets:
  max_new_docs: 0
  max_new_files: 0
  max_net_added_lines: 700
surface_debt:
  kind: temporary_growth
  reason: Add generic registry comparison with check-diff/check-pr wiring, focused tests, and docs.
  expected_delta:
    max_new_files: 0
    max_net_added_lines: 700
  repayment_issue: 38
must_touch:
  - src/diff-checker.mjs
  - src/repo-guard.mjs
  - src/github-pr.mjs
  - schemas/repo-policy.schema.json
  - tests/test-diff-rules.mjs
  - tests/test-enforcement-mode.mjs
must_not_touch: []
expected_effects:
  - check-diff evaluates registry_rules and reports missing or extra entries.
  - check-pr evaluates the same registry_rules in GitHub PR policy gates.
  - Policies without registry_rules continue to pass unchanged.
```

## What Changed

- Added `registry_rules` to `repo-policy.schema.json` with supported rule kinds:
  - `set_equality`
  - `left_subset_of_right`
  - `right_subset_of_left`
- Added registry source readers for:
  - JSON arrays selected by JSON Pointer
  - Markdown links inside a named heading section, with optional prefix normalization
- Wired registry checks into both `check-diff` and `check-pr` output as `registry-rules`.
- Extended text and JSON reporter output with failed rule IDs and per-rule registry details.
- Documented configuration and failure output in the README.

## Reproduction / Verification

The reproducing coverage is in `tests/test-diff-rules.mjs`, `tests/test-enforcement-mode.mjs`, and `tests/test-structured-output.mjs`:

- matching registry rules pass
- mismatched registries fail and report left entries, right entries, missing entries, and extra entries
- subset rules allow intentional one-sided registry expansion
- missing/unreadable registry sources fail with a useful diagnostic
- `check-diff --format json` exposes the registry violation details for consumers
- simulated `check-pr` enforces `registry_rules` and reports `FAIL: registry-rules`

## Tests

- `npm run test:diff`
- `npm run test:structured-output`
- `npm run test:enforcement`
- `npm run test:schemas`
- `npm test`
