### PR TITLE
Add advisory text duplication warnings

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T09:37:49.668Z for PR creation at branch issue-39-54dfa5ae8947 for issue https://github.com/netkeep80/repo-guard/issues/39

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T09:37:49.668Z for PR creation at branch issue-39-54dfa5ae8947 for issue https://github.com/netkeep80/repo-guard/issues/39

--- a/README.md
+++ b/README.md
@@ -609,6 +609,34 @@ When a rule fails, output identifies the rule, both registry contents, and the m
 
 Policies without `registry_rules` keep the previous behavior and report `PASS: registry-rules`.
 
+## Advisory Text Duplication Rules
+
+`advisory_text_rules` enables heuristic markdown duplication warnings. This check is advisory-only in v1: it can print `WARN` and appear in structured output, but it never changes the command exit code and never blocks a PR, even when enforcement mode is `blocking`.
+
+```json
+{
+  "advisory_text_rules": {
+    "canonical_files": ["docs/index.md", "docs/**/*.md"],
+    "warn_on_similarity_above": 0.70,
+    "max_reported_matches": 3
+  }
+}
+```
+
+The check compares changed markdown files with tracked markdown files that match `canonical_files`. It normalizes markdown prose into word tokens, reports a similarity score, and also flags duplicate section titles against canonical files. This is a practical early-warning heuristic for documentation sprawl, not proof of semantic equivalence, plagiarism, or copyright status.
+
+Example output:
+
+```text
+  WARN: advisory-text-rules
+    heuristic markdown duplication advisory
+    match: docs/new-policy.md -> docs/canonical.md, score=0.82, threshold=0.7, duplicate_sections=Release Policy
+    docs/new-policy.md overlaps docs/canonical.md (score 0.82, threshold 0.7; duplicate sections: Release Policy)
+    hint: Review whether the changed markdown should update the canonical source instead of duplicating policy prose.
+```
+
+Policies without `advisory_text_rules` keep the previous behavior and report `PASS: advisory-text-rules`.
+
 ## Issue Type Rules
 
 `change_type` в contract описывает тип работы: например `governance`, `kernel-hardening`, `docs-cleanup` или любой другой тип, принятый в репозитории. Policy может сделать этот тип first-class input через `change_type_rules`:

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -247,6 +247,29 @@
         }
       }
     },
+    "advisory_text_rules": {
+      "type": "object",
+      "description": "Optional heuristic markdown duplication advisories. These warnings never block the PR in v1.",
+      "additionalProperties": false,
+      "properties": {
+        "canonical_files": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "warn_on_similarity_above": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0.7
+        },
+        "max_reported_matches": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 3
+        }
+      }
+    },
     "content_rules": {
       "type": "array",
       "items": {

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -205,6 +205,17 @@ function formatList(values) {
   return values && values.length > 0 ? values.join(", ") : "(none)";
 }
 
+function readPolicyFile(path, options) {
+  if (options.readFile) {
+    const content = options.readFile(path);
+    if (content === undefined || content === null) {
+      throw new Error(`cannot read ${path}`);
+    }
+    return String(content);
+  }
+  return readFileSync(resolve(options.repoRoot || process.cwd(), path), "utf-8");
+}
+
 function normalizeRegistryEntry(value) {
   return String(value || "").trim().replace(/^\.\//, "");
 }
@@ -303,19 +314,8 @@ function applyMarkdownLinkPrefix(target, source) {
   return target;
 }
 
-function readRegistryFile(source, options) {
-  if (options.readFile) {
-    const content = options.readFile(source.file);
-    if (content === undefined || content === null) {
-      throw new Error(`cannot read ${source.file}`);
-    }
-    return String(content);
-  }
-  return readFileSync(resolve(options.repoRoot || process.cwd(), source.file), "utf-8");
-}
-
 function readRegistrySource(source, options = {}) {
-  const content = readRegistryFile(source, options);
+  const content = readPolicyFile(source.file, options);
 
   if (source.type === "json_array") {
     const data = JSON.parse(content);
@@ -405,6 +405,141 @@ export function checkRegistryRules(registryRules = [], options = {}) {
       `extra in right: ${formatList(result.extra_in_right)}`,
       ...(result.details || []),
     ]),
+  };
+}
+
+function stripMarkdownNoise(content) {
+  return content
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<[^>]+>/g, " ");
+}
+
+function markdownTokens(content) {
+  const normalized = stripMarkdownNoise(content)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ");
+  return normalized.split(/\s+/).filter((token) => token.length >= 3);
+}
+
+function tokenSet(content) {
+  return new Set(markdownTokens(content));
+}
+
+function jaccardScore(left, right) {
+  if (left.size === 0 || right.size === 0) return 0;
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) intersection++;
+  }
+  const union = left.size + right.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function markdownHeadings(content) {
+  const headings = [];
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (match) {
+      headings.push({
+        level: match[1].length,
+        title: match[2].trim(),
+        normalized: match[2].trim().toLowerCase().replace(/\s+/g, " "),
+      });
+    }
+  }
+  return headings;
+}
+
+export function checkAdvisoryTextRules(files, rules, options = {}) {
+  if (!rules) return { ok: true, matches: [] };
+
+  const canonicalPatterns = rules.canonical_files || [];
+  const changedMarkdown = files.filter(
+    (file) => file.status !== "deleted" && file.path.match(/\.md$/i)
+  );
+  if (changedMarkdown.length === 0 || canonicalPatterns.length === 0) {
+    return { ok: true, matches: [] };
+  }
+
+  const threshold = rules.warn_on_similarity_above ?? 0.7;
+  const maxReported = rules.max_reported_matches ?? 3;
+  const canonicalFiles = uniqueSorted(options.allFiles || []);
+  const results = [];
+  const readErrors = [];
+
+  for (const changed of changedMarkdown) {
+    let changedContent;
+    try {
+      changedContent = readPolicyFile(changed.path, options);
+    } catch (e) {
+      readErrors.push(`${changed.path}: ${e.message}`);
+      continue;
+    }
+
+    const changedTokens = tokenSet(changedContent);
+    const changedHeadings = markdownHeadings(changedContent);
+    const changedHeadingSet = new Set(changedHeadings.map((heading) => heading.normalized));
+
+    for (const canonicalPath of canonicalFiles) {
+      if (canonicalPath === changed.path) continue;
+      if (!canonicalPath.match(/\.md$/i)) continue;
+      if (!matchesAny(canonicalPath, canonicalPatterns)) continue;
+
+      let canonicalContent;
+      try {
+        canonicalContent = readPolicyFile(canonicalPath, options);
+      } catch (e) {
+        readErrors.push(`${canonicalPath}: ${e.message}`);
+        continue;
+      }
+
+      const score = jaccardScore(changedTokens, tokenSet(canonicalContent));
+      const canonicalHeadings = markdownHeadings(canonicalContent);
+      const duplicateHeadings = uniqueSorted(
+        canonicalHeadings
+          .filter((heading) => changedHeadingSet.has(heading.normalized))
+          .map((heading) => heading.title)
+      );
+
+      if (score >= threshold || duplicateHeadings.length > 0) {
+        results.push({
+          changed_file: changed.path,
+          canonical_file: canonicalPath,
+          score: Number(score.toFixed(3)),
+          threshold,
+          duplicate_section_titles: duplicateHeadings,
+          reason: score >= threshold ? "text_similarity" : "duplicate_section_title",
+        });
+      }
+    }
+  }
+
+  results.sort((a, b) =>
+    b.score - a.score ||
+    a.changed_file.localeCompare(b.changed_file) ||
+    a.canonical_file.localeCompare(b.canonical_file)
+  );
+
+  const matches = results.slice(0, maxReported);
+  const details = matches.map((match) => {
+    const sections = match.duplicate_section_titles.length > 0
+      ? `; duplicate sections: ${match.duplicate_section_titles.join(", ")}`
+      : "";
+    return `${match.changed_file} overlaps ${match.canonical_file} (score ${match.score}, threshold ${match.threshold}${sections})`;
+  });
+
+  return {
+    ok: matches.length === 0,
+    advisory: true,
+    message: matches.length > 0 ? "heuristic markdown duplication advisory" : undefined,
+    matches,
+    details: [...details, ...readErrors.map((error) => `read warning: ${error}`)],
+    hint: matches.length > 0
+      ? "Review whether the changed markdown should update the canonical source instead of duplicating policy prose."
+      : undefined,
   };
 }
 

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -110,6 +110,14 @@ function printCheckDetails(mode, check) {
   if (check.failed_rules) {
     write(`    failed_rules: ${formatList(check.failed_rules)}`);
   }
+  if (check.matches) {
+    for (const match of check.matches) {
+      const sections = match.duplicate_section_titles && match.duplicate_section_titles.length > 0
+        ? `, duplicate_sections=${formatList(match.duplicate_section_titles)}`
+        : "";
+      write(`    match: ${match.changed_file} -> ${match.canonical_file}, score=${match.score}, threshold=${match.threshold}${sections}`);
+    }
+  }
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     write(`    unclassified_files: ${formatList(check.unclassified_files)}`);
   }
@@ -152,6 +160,14 @@ function detailFromCheck(check) {
   if (check.forbidden_surfaces) details.push(`forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
   if (check.violating_surfaces) details.push(`violating_surfaces: ${formatList(check.violating_surfaces)}`);
   if (check.failed_rules) details.push(`failed_rules: ${formatList(check.failed_rules)}`);
+  if (check.matches) {
+    details.push(...check.matches.map((match) => {
+      const sections = match.duplicate_section_titles && match.duplicate_section_titles.length > 0
+        ? `, duplicate_sections=${formatList(match.duplicate_section_titles)}`
+        : "";
+      return `match: ${match.changed_file} -> ${match.canonical_file}, score=${match.score}, threshold=${match.threshold}${sections}`;
+    }));
+  }
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     details.push(`unclassified_files: ${formatList(check.unclassified_files)}`);
   }
@@ -199,6 +215,8 @@ function violationFromCheck(name, check) {
   if (check.files_by_surface) violation.files_by_surface = check.files_by_surface;
   if (check.failed_rules) violation.failed_rules = check.failed_rules;
   if (check.results) violation.results = check.results;
+  if (check.matches) violation.matches = check.matches;
+  if (check.advisory) violation.advisory = true;
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     violation.unclassified_files = check.unclassified_files;
   }
@@ -215,9 +233,11 @@ function renderMarkdownTableCell(value) {
 export function createCheckReporter(mode, options = {}) {
   let passed = 0;
   let violations = 0;
+  let warnings = 0;
   const quiet = options.quiet || false;
   const ruleResults = [];
   const violationDetails = [];
+  const warningDetails = [];
   const hints = [];
 
   return {
@@ -228,6 +248,19 @@ export function createCheckReporter(mode, options = {}) {
       if (check.ok) {
         passed++;
         if (!quiet) console.log(`  PASS: ${name}`);
+        return;
+      }
+
+      if (check.advisory) {
+        warnings++;
+        const warning = violationFromCheck(name, check);
+        warning.advisory = true;
+        warningDetails.push(warning);
+        if (check.hint) hints.push({ rule: name, message: check.hint });
+        if (!quiet) {
+          writeViolation("advisory", `  WARN: ${name}`);
+          printCheckDetails("advisory", check);
+        }
         return;
       }
 
@@ -247,10 +280,11 @@ export function createCheckReporter(mode, options = {}) {
       const advisoryPart = mode === "advisory" ? `, ${violations} advisory violation(s)` : "";
       const modePart = mode === "advisory" ? "violations reported as warnings" : "violations enforced";
       const exitCode = enforcedFailures > 0 ? 1 : 0;
-      const result = violations > 0 ? "failed" : "passed";
+      const warningPart = warnings > 0 ? `, ${warnings} warning(s)` : "";
+      const result = violations > 0 ? "failed" : warnings > 0 ? "passed_with_warnings" : "passed";
 
       if (!quiet) {
-        console.log(`\nSummary: ${passed} passed, ${enforcedFailures} failed${advisoryPart} (mode: ${mode}; ${modePart})`);
+        console.log(`\nSummary: ${passed} passed, ${enforcedFailures} failed${advisoryPart}${warningPart} (mode: ${mode}; ${modePart})`);
         console.log(`Result: ${result} (mode: ${mode}; exit code ${exitCode})`);
       }
 
@@ -260,6 +294,8 @@ export function createCheckReporter(mode, options = {}) {
         result,
         passed,
         violations: violationDetails,
+        advisoryWarnings: warningDetails,
+        warnings,
         violationCount: violations,
         failed: enforcedFailures,
         exitCode,
@@ -282,7 +318,7 @@ export function renderCheckSummary(result) {
     `- Result: ${result.result}`,
     `- Mode: ${result.mode}`,
     `- Repository root: \`${result.repositoryRoot}\``,
-    `- Checks: ${result.passed} passed, ${result.failed} failed${result.mode === "advisory" ? `, ${result.violationCount} advisory violation(s)` : ""}`,
+    `- Checks: ${result.passed} passed, ${result.failed} failed${result.mode === "advisory" ? `, ${result.violationCount} advisory violation(s)` : ""}${result.warnings ? `, ${result.warnings} warning(s)` : ""}`,
   ];
 
   if (result.diff) {
@@ -294,6 +330,14 @@ export function renderCheckSummary(result) {
     for (const violation of result.violations) {
       const details = detailFromCheck(violation).join("<br>") || "Violation reported";
       lines.push(`| ${renderMarkdownTableCell(violation.rule)} | ${renderMarkdownTableCell(details)} |`);
+    }
+  }
+
+  if (result.advisoryWarnings && result.advisoryWarnings.length > 0) {
+    lines.push("", "| Advisory | Details |", "|---|---|");
+    for (const warning of result.advisoryWarnings) {
+      const details = detailFromCheck(warning).join("<br>") || "Warning reported";
+      lines.push(`| ${renderMarkdownTableCell(warning.rule)} | ${renderMarkdownTableCell(details)} |`);
     }
   }
 

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -33,10 +33,17 @@ import {
   checkMustNotTouch,
   checkChangeTypeRules,
   checkRegistryRules,
+  checkAdvisoryTextRules,
 } from "./diff-checker.mjs";
 
 function loadJSON(path) {
   return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function listTrackedFiles(repoRoot) {
+  return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
+    .split(/\r?\n/)
+    .filter(Boolean);
 }
 
 function validate(ajv, schema, data, label) {
@@ -274,6 +281,13 @@ export function runCheckPR(roots, args = []) {
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
   reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: roots.repoRoot }));
+  reporter.report(
+    "advisory-text-rules",
+    checkAdvisoryTextRules(files, policy.advisory_text_rules, {
+      repoRoot: roots.repoRoot,
+      allFiles: listTrackedFiles(roots.repoRoot),
+    })
+  );
 
   if (policy.change_type_rules) {
     reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -21,6 +21,7 @@ import {
   checkMustNotTouch,
   checkChangeTypeRules,
   checkRegistryRules,
+  checkAdvisoryTextRules,
 } from "./diff-checker.mjs";
 import {
   compileForbidRegex,
@@ -30,6 +31,12 @@ import {
   warnReservedContractFields,
   warnReservedPolicyFields,
 } from "./policy-compiler.mjs";
+
+function listTrackedFiles(repoRoot) {
+  return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
+    .split(/\r?\n/)
+    .filter(Boolean);
+}
 import {
   ajvErrors,
   createCheckReporter,
@@ -269,6 +276,13 @@ function runCheckDiff(roots, args) {
   reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
   reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: roots.repoRoot }));
+  reporter.report(
+    "advisory-text-rules",
+    checkAdvisoryTextRules(files, policy.advisory_text_rules, {
+      repoRoot: roots.repoRoot,
+      allFiles: listTrackedFiles(roots.repoRoot),
+    })
+  );
 
   if (policy.change_type_rules) {
     reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -16,6 +16,7 @@ import {
   checkNewFileRules,
   checkChangeTypeRules,
   checkRegistryRules,
+  checkAdvisoryTextRules,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -722,6 +723,81 @@ const nonStringRegistryResult = checkRegistryRules(registryRules, {
 });
 expect("13. non-string JSON registry entries fail", nonStringRegistryResult.ok, false);
 expect("13. non-string JSON registry detail", nonStringRegistryResult.results[0].details[0].includes("only strings"), true);
+
+// --- 14. advisory text rules ---
+
+const advisoryFiles = new Map([
+  [
+    "docs/canonical.md",
+    [
+      "# Release Policy",
+      "",
+      "Policy text must live in the canonical document so maintainers update one source.",
+      "Release approvals require a changelog entry, owner review, and a documented rollback path.",
+    ].join("\n"),
+  ],
+  [
+    "docs/new-policy.md",
+    [
+      "# Release Policy",
+      "",
+      "Policy text must live in the canonical document so maintainers update one source.",
+      "Release approvals require a changelog entry, owner review, and a documented rollback path.",
+    ].join("\n"),
+  ],
+  [
+    "docs/other.md",
+    [
+      "# Independent Notes",
+      "",
+      "This document describes a separate maintenance workflow with different words.",
+    ].join("\n"),
+  ],
+]);
+
+const advisoryRules = {
+  canonical_files: ["docs/canonical.md"],
+  warn_on_similarity_above: 0.7,
+  max_reported_matches: 3,
+};
+
+const advisoryResult = checkAdvisoryTextRules(
+  [{ path: "docs/new-policy.md", addedLines: [], deletedLines: [], status: "added" }],
+  advisoryRules,
+  {
+    allFiles: ["docs/canonical.md", "docs/new-policy.md", "docs/other.md"],
+    readFile: (path) => advisoryFiles.get(path),
+  }
+);
+expect("14. advisory duplication warns", advisoryResult.ok, false);
+expect("14. advisory is warning-only", advisoryResult.advisory, true);
+expect("14. advisory changed file reported", advisoryResult.matches[0].changed_file, "docs/new-policy.md");
+expect("14. advisory canonical file reported", advisoryResult.matches[0].canonical_file, "docs/canonical.md");
+expect("14. advisory score crosses threshold", advisoryResult.matches[0].score >= 0.7, true);
+expect("14. duplicate section title reported", advisoryResult.matches[0].duplicate_section_titles[0], "Release Policy");
+
+const cleanAdvisoryResult = checkAdvisoryTextRules(
+  [{ path: "docs/other.md", addedLines: [], deletedLines: [], status: "modified" }],
+  advisoryRules,
+  {
+    allFiles: ["docs/canonical.md", "docs/other.md"],
+    readFile: (path) => advisoryFiles.get(path),
+  }
+);
+expect("14. unrelated markdown passes advisory", cleanAdvisoryResult.ok, true);
+
+const cappedAdvisoryResult = checkAdvisoryTextRules(
+  [
+    { path: "docs/new-policy.md", addedLines: [], deletedLines: [], status: "added" },
+    { path: "docs/other.md", addedLines: [], deletedLines: [], status: "modified" },
+  ],
+  { ...advisoryRules, canonical_files: ["docs/*.md"], max_reported_matches: 1 },
+  {
+    allFiles: ["docs/canonical.md", "docs/new-policy.md", "docs/other.md"],
+    readFile: (path) => advisoryFiles.get(path),
+  }
+);
+expect("14. advisory caps reported matches", cappedAdvisoryResult.matches.length, 1);
 
 // --- Summary ---
 

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -145,6 +145,65 @@ function makeSurfaceRepo() {
   };
 }
 
+function makeAdvisoryTextRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-advisory-text-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "documentation",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["docs/canonical.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    advisory_text_rules: {
+      canonical_files: ["docs/canonical.md"],
+      warn_on_similarity_above: 0.7,
+      max_reported_matches: 2,
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  execSync("mkdir -p docs", { cwd: dir, stdio: "pipe" });
+  writeFileSync(
+    join(dir, "docs", "canonical.md"),
+    [
+      "# Release Policy",
+      "",
+      "Policy prose belongs in the canonical document so maintainers update one source.",
+      "Release approvals require a changelog entry, owner review, and a documented rollback path.",
+    ].join("\n")
+  );
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  writeFileSync(
+    join(dir, "docs", "copy.md"),
+    [
+      "# Release Policy",
+      "",
+      "Policy prose belongs in the canonical document so maintainers update one source.",
+      "Release approvals require a changelog entry, owner review, and a documented rollback path.",
+    ].join("\n")
+  );
+  execSync("git add -A && git commit -m duplicate-doc", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
 function makeSurfaceDebtRepo(contract) {
   const dir = mkdtempSync(join(tmpdir(), "repo-guard-debt-"));
   execSync("git init", { cwd: dir, stdio: "pipe" });
@@ -534,6 +593,30 @@ console.log("\n--- check-diff treats undeclared growth as non-blocking and enfor
     exceededParsed.violations.find((v) => v.rule === "surface-debt")?.status,
     "declared_debt_exceeded");
   rmSync(exceededRepo.dir, { recursive: true });
+}
+
+console.log("\n--- advisory text rules warn without blocking in blocking mode ---");
+{
+  const repo = makeAdvisoryTextRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("advisory text exit code stays zero", result.code, 0);
+  const parsed = JSON.parse(result.stdout);
+  expect("advisory text result has warnings", parsed.result, "passed_with_warnings");
+  expect("advisory text warning count", parsed.warnings, 1);
+  const warning = parsed.advisoryWarnings.find((item) => item.rule === "advisory-text-rules");
+  expect("advisory text warning present", Boolean(warning), true);
+  expect("advisory text changed file in structured output", warning?.matches[0]?.changed_file, "docs/copy.md");
+  expect("advisory text canonical file in structured output", warning?.matches[0]?.canonical_file, "docs/canonical.md");
+  expect("advisory text has no enforced violations", parsed.violations.length, 0);
+
+  rmSync(repo.dir, { recursive: true });
 }
 
 console.log("\n--- check-diff --format summary emits GitHub-friendly concise summary ---");


### PR DESCRIPTION
## Summary
- add optional `advisory_text_rules` policy configuration for heuristic markdown duplication warnings
- compare changed markdown against canonical markdown using normalized token overlap and duplicate section titles
- report advisory warnings separately from enforceable violations so v1 never blocks PRs
- document the heuristic nature and structured/text output behavior

Fixes netkeep80/repo-guard#39

## Change Contract

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - README.md
  - schemas/repo-policy.schema.json
  - src/diff-checker.mjs
  - src/enforcement.mjs
  - src/github-pr.mjs
  - src/repo-guard.mjs
  - tests/test-diff-rules.mjs
  - tests/test-structured-output.mjs
budgets:
  max_new_files: 1
  max_net_added_lines: 900
must_touch:
  - src/diff-checker.mjs
  - src/enforcement.mjs
  - schemas/repo-policy.schema.json
  - tests/test-diff-rules.mjs
must_not_touch:
  - package.json
  - package-lock.json
  - action.yml
  - .github/workflows/**
expected_effects:
  - repo-guard can report advisory markdown duplication warnings from configured canonical documents.
  - Advisory text-rule findings are emitted separately from blocking policy violations.
  - Structured output includes advisory warning counts and details.
```

## Reproduce / Verify
- Configure `advisory_text_rules` with canonical markdown files, then add a markdown file duplicating canonical prose.
- Run `repo-guard check-diff --base <base> --head <head>`.
- The output reports `WARN: advisory-text-rules` with changed file, canonical file, score, threshold, and duplicate sections, while exit code remains 0 when no enforceable violations exist.

## Tests
- `node tests/test-diff-rules.mjs`
- `node tests/test-structured-output.mjs`
- `node tests/validate-schemas.mjs`
- `npm test`
