### PR TITLE
Refactor repo-guard checks into shared pipeline

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T18:38:38.988Z for PR creation at branch issue-45-36612e1ca36d for issue https://github.com/netkeep80/repo-guard/issues/45

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T18:38:38.988Z for PR creation at branch issue-45-36612e1ca36d for issue https://github.com/netkeep80/repo-guard/issues/45

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
@@ -27,6 +27,7 @@
     "test:doctor": "node tests/test-doctor.mjs",
     "test:enforcement": "node tests/test-enforcement-mode.mjs",
     "test:structured-output": "node tests/test-structured-output.mjs",
+    "test:pipeline": "node tests/test-pipeline.mjs",
     "test:self-hosting": "node tests/test-self-hosting.mjs"
   },
   "keywords": [

--- a/src/checks/orchestrator.mjs
+++ b/src/checks/orchestrator.mjs
@@ -1,0 +1,103 @@
+import {
+  checkForbiddenPaths,
+  checkCanonicalDocsBudget,
+  checkNewFilesBudget,
+  checkNetAddedLinesBudget,
+  checkSurfaceDebt,
+  checkCochangeRules,
+  checkNewFileRules,
+  checkSurfaceMatrix,
+  checkContentRules,
+  checkMustTouch,
+  checkMustNotTouch,
+  checkChangeTypeRules,
+  checkRegistryRules,
+  checkAdvisoryTextRules,
+} from "../diff-checker.mjs";
+
+export function runPolicyChecks(facts, reporter) {
+  const policy = facts.policy;
+  const files = facts.filteredOperationalFiles;
+  const contract = facts.contract;
+
+  const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
+  reporter.report("forbidden-paths", {
+    ok: forbiddenViolations.length === 0,
+    files: forbiddenViolations,
+  });
+
+  const budgets = contract?.budgets || {};
+  reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(
+    files,
+    policy.paths.canonical_docs,
+    budgets.max_new_docs ?? policy.diff_rules.max_new_docs
+  ));
+  reporter.report("max-new-files", checkNewFilesBudget(
+    files,
+    budgets.max_new_files ?? policy.diff_rules.max_new_files
+  ));
+  reporter.report("max-net-added-lines", checkNetAddedLinesBudget(
+    files,
+    budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines
+  ));
+  reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+  reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: facts.repositoryRoot }));
+  reporter.report(
+    "advisory-text-rules",
+    checkAdvisoryTextRules(files, policy.advisory_text_rules, {
+      repoRoot: facts.repositoryRoot,
+      allFiles: facts.trackedFiles,
+    })
+  );
+
+  if (policy.change_type_rules) {
+    reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));
+  }
+
+  if (policy.new_file_rules) {
+    reporter.report(
+      "new-file-rules",
+      checkNewFileRules(files, policy.new_file_classes, policy.new_file_rules, facts.declaredChangeClass)
+    );
+  }
+
+  if (policy.surface_matrix) {
+    reporter.report(
+      "surface-matrix",
+      checkSurfaceMatrix(
+        files,
+        policy.surfaces,
+        policy.surface_matrix,
+        facts.declaredChangeClass,
+        { allow_unclassified_files: policy.allow_unclassified_files }
+      )
+    );
+  }
+
+  const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
+  if (cochangeViolations.length > 0) {
+    for (const violation of cochangeViolations) {
+      reporter.report(`cochange: ${violation.if_changed.join(",")} -> ${violation.must_change_any.join(",")}`, {
+        ok: false,
+        must_touch: violation.must_change_any,
+      });
+    }
+  } else {
+    reporter.report("cochange-rules", { ok: true });
+  }
+
+  const contentViolations = checkContentRules(files, policy.content_rules);
+  if (contentViolations.length > 0) {
+    reporter.report("content-rules", {
+      ok: false,
+      details: contentViolations.map((v) => `[${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`),
+    });
+  } else {
+    reporter.report("content-rules", { ok: true });
+  }
+
+  if (contract) {
+    reporter.report("must-touch", checkMustTouch(files, contract.must_touch));
+    reporter.report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
+  }
+}

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -1,0 +1,50 @@
+import { execSync } from "node:child_process";
+import {
+  parseDiff,
+  filterOperationalPaths,
+  detectTouchedSurfaces,
+  classifyNewFiles,
+} from "../diff-checker.mjs";
+
+export function listTrackedFiles(repoRoot) {
+  return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
+    .split(/\r?\n/)
+    .filter(Boolean);
+}
+
+export function buildPolicyFacts({
+  repositoryRoot,
+  policy,
+  contract = null,
+  enforcement,
+  diffText,
+  trackedFiles = null,
+  declaredChangeClass = null,
+}) {
+  const diffFiles = parseDiff(diffText);
+  const filteredOperationalFiles = filterOperationalPaths(diffFiles, policy.paths.operational_paths);
+  const changedPaths = filteredOperationalFiles.map((file) => file.path);
+  const skippedOperationalFiles = diffFiles.length - filteredOperationalFiles.length;
+
+  return {
+    repositoryRoot,
+    policy,
+    contract,
+    enforcementMode: enforcement.mode,
+    enforcement,
+    diffFiles,
+    filteredOperationalFiles,
+    changedPaths,
+    trackedFiles: trackedFiles || listTrackedFiles(repositoryRoot),
+    touchedSurfaces: policy.surfaces
+      ? detectTouchedSurfaces(filteredOperationalFiles, policy.surfaces)
+      : null,
+    newFileClasses: policy.new_file_classes
+      ? classifyNewFiles(filteredOperationalFiles, policy.new_file_classes)
+      : null,
+    declaredChangeClass,
+    diagnostics: {
+      skippedOperationalFiles,
+    },
+  };
+}

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -1,75 +1,10 @@
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
-import { resolve } from "node:path";
-import Ajv from "ajv";
 import { extractContract, extractLinkedIssueNumbers, resolveContract } from "./markdown-contract.mjs";
-import {
-  compileForbidRegex,
-  compileNewFilePolicy,
-  compileChangeTypePolicy,
-  compileSurfacePolicy,
-  warnReservedContractFields,
-  warnReservedPolicyFields,
-} from "./policy-compiler.mjs";
-import {
-  ajvErrors,
-  createCheckReporter,
-  printEnforcementMode,
-  resolveEnforcementMode,
-} from "./enforcement.mjs";
-import {
-  parseDiff,
-  filterOperationalPaths,
-  checkForbiddenPaths,
-  checkCanonicalDocsBudget,
-  checkNewFilesBudget,
-  checkNetAddedLinesBudget,
-  checkSurfaceDebt,
-  checkCochangeRules,
-  checkNewFileRules,
-  checkSurfaceMatrix,
-  checkContentRules,
-  checkMustTouch,
-  checkMustNotTouch,
-  checkChangeTypeRules,
-  checkRegistryRules,
-  checkAdvisoryTextRules,
-} from "./diff-checker.mjs";
-
-function loadJSON(path) {
-  return JSON.parse(readFileSync(path, "utf-8"));
-}
-
-function listTrackedFiles(repoRoot) {
-  return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
-    .split(/\r?\n/)
-    .filter(Boolean);
-}
-
-function validate(ajv, schema, data, label) {
-  const valid = ajv.validate(schema, data);
-  if (!valid) {
-    console.error(`FAIL: ${label}`);
-    for (const err of ajv.errors) {
-      console.error(`  ${err.instancePath || "/"} ${err.message}`);
-    }
-    return false;
-  }
-  console.log(`OK: ${label}`);
-  return true;
-}
-
-function validationCheck(ajv, schema, data, label) {
-  const valid = ajv.validate(schema, data);
-  if (valid) {
-    return { ok: true };
-  }
-  return {
-    ok: false,
-    message: `${label} failed schema validation`,
-    errors: ajvErrors(ajv.errors),
-  };
-}
+import { warnReservedContractFields } from "./policy-compiler.mjs";
+import { resolveEnforcementMode } from "./enforcement.mjs";
+import { loadPolicyRuntime, validationCheck } from "./runtime/validation.mjs";
+import { runPolicyPipeline } from "./runtime/pipeline.mjs";
 
 export function loadGitHubEvent() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
@@ -156,56 +91,10 @@ export function runCheckPR(roots, args = []) {
   const { base, head, prBody, prNumber, repoFullName } = eventInfo;
   console.log(`PR #${prNumber}: checking contract and diff (${base?.slice(0, 7)}..${head?.slice(0, 7)})`);
 
-  const policySchema = loadJSON(resolve(roots.packageRoot, "schemas/repo-policy.schema.json"));
-  const contractSchema = loadJSON(resolve(roots.packageRoot, "schemas/change-contract.schema.json"));
-  const policy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
+  const runtime = loadPolicyRuntime(roots);
+  const { ajv, policy, contractSchema } = runtime;
 
-  const ajv = new Ajv({ allErrors: true });
-
-  let ok = true;
-  ok = validate(ajv, policySchema, policy, "repo-policy.json") && ok;
-
-  const regexErrors = compileForbidRegex(policy.content_rules);
-  if (regexErrors.length > 0) {
-    ok = false;
-    console.error("FAIL: forbid_regex compilation");
-    for (const e of regexErrors) {
-      console.error(`  [${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`);
-    }
-  }
-
-  const surfaceErrors = compileSurfacePolicy(policy);
-  if (surfaceErrors.length > 0) {
-    ok = false;
-    console.error("FAIL: surface policy compilation");
-    for (const e of surfaceErrors) {
-      console.error(`  ${e.message}`);
-    }
-  }
-
-  const newFileErrors = compileNewFilePolicy(policy);
-  if (newFileErrors.length > 0) {
-    ok = false;
-    console.error("FAIL: new file policy compilation");
-    for (const e of newFileErrors) {
-      console.error(`  ${e.message}`);
-    }
-  }
-
-  const changeTypeErrors = compileChangeTypePolicy(policy);
-  if (changeTypeErrors.length > 0) {
-    ok = false;
-    console.error("FAIL: change type policy compilation");
-    for (const e of changeTypeErrors) {
-      console.error(`  ${e.message}`);
-    }
-  }
-
-  for (const w of warnReservedPolicyFields(policy)) {
-    console.warn(`WARN: ${w}`);
-  }
-
-  if (!ok) {
+  if (!runtime.ok) {
     console.error("\nPolicy compilation failed");
     process.exit(1);
   }
@@ -215,8 +104,6 @@ export function runCheckPR(roots, args = []) {
     console.error(`ERROR: ${enforcement.message}`);
     process.exit(1);
   }
-  printEnforcementMode(enforcement);
-  const reporter = createCheckReporter(enforcement.mode);
 
   let issueBody = null;
   let contractFailure = null;
@@ -242,14 +129,18 @@ export function runCheckPR(roots, args = []) {
 
   const contractResult = contractFailure || resolveContract(prBody, issueBody);
   let contract = null;
+  const initialChecks = [];
   if (!contractResult.ok) {
-    reporter.report("change-contract", {
-      ok: false,
-      message: `[${contractResult.error}]: ${contractResult.message}`,
+    initialChecks.push({
+      name: "change-contract",
+      check: {
+        ok: false,
+        message: `[${contractResult.error}]: ${contractResult.message}`,
+      },
     });
   } else {
     const contractCheck = validationCheck(ajv, contractSchema, contractResult.contract, "change-contract (from markdown)");
-    reporter.report("change-contract", contractCheck);
+    initialChecks.push({ name: "change-contract", check: contractCheck });
     if (contractCheck.ok) {
       contract = contractResult.contract;
       for (const w of warnReservedContractFields(contract)) {
@@ -259,87 +150,14 @@ export function runCheckPR(roots, args = []) {
   }
 
   const diffText = execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: roots.repoRoot });
-  const allFiles = parseDiff(diffText);
-  const files = filterOperationalPaths(allFiles, policy.paths.operational_paths);
-
-  const skipped = allFiles.length - files.length;
-  console.log(`\nDiff analysis: ${allFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
-
-  const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
-  reporter.report("forbidden-paths", {
-    ok: forbiddenViolations.length === 0,
-    files: forbiddenViolations,
+  const summary = runPolicyPipeline({
+    repositoryRoot: roots.repoRoot,
+    policy,
+    contract,
+    enforcement,
+    diffText,
+    declaredChangeClass: contract?.change_class || null,
+    initialChecks,
   });
-
-  const budgets = contract?.budgets || {};
-  const maxNewDocs = budgets.max_new_docs ?? policy.diff_rules.max_new_docs;
-  const maxNewFiles = budgets.max_new_files ?? policy.diff_rules.max_new_files;
-  const maxNetAddedLines = budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines;
-
-  reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
-  reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
-  reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
-  reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
-  reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: roots.repoRoot }));
-  reporter.report(
-    "advisory-text-rules",
-    checkAdvisoryTextRules(files, policy.advisory_text_rules, {
-      repoRoot: roots.repoRoot,
-      allFiles: listTrackedFiles(roots.repoRoot),
-    })
-  );
-
-  if (policy.change_type_rules) {
-    reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));
-  }
-
-  if (policy.new_file_rules) {
-    reporter.report(
-      "new-file-rules",
-      checkNewFileRules(files, policy.new_file_classes, policy.new_file_rules, contract?.change_class || null)
-    );
-  }
-
-  if (policy.surface_matrix) {
-    reporter.report(
-      "surface-matrix",
-      checkSurfaceMatrix(
-        files,
-        policy.surfaces,
-        policy.surface_matrix,
-        contract?.change_class || null,
-        { allow_unclassified_files: policy.allow_unclassified_files }
-      )
-    );
-  }
-
-  const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
-  if (cochangeViolations.length > 0) {
-    for (const v of cochangeViolations) {
-      reporter.report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
-        ok: false,
-        must_touch: v.must_change_any,
-      });
-    }
-  } else {
-    reporter.report("cochange-rules", { ok: true });
-  }
-
-  const contentViolations = checkContentRules(files, policy.content_rules);
-  if (contentViolations.length > 0) {
-    reporter.report("content-rules", {
-      ok: false,
-      details: contentViolations.map((v) => `[${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`),
-    });
-  } else {
-    reporter.report("content-rules", { ok: true });
-  }
-
-  if (contract) {
-    reporter.report("must-touch", checkMustTouch(files, contract.must_touch));
-    reporter.report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
-  }
-
-  const summary = reporter.finish();
   process.exit(summary.exitCode);
 }

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -5,45 +5,13 @@ import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
+import { compileForbidRegex, warnReservedContractFields, warnReservedPolicyFields } from "./policy-compiler.mjs";
 import {
-  parseDiff,
-  filterOperationalPaths,
-  checkForbiddenPaths,
-  checkCanonicalDocsBudget,
-  checkNewFilesBudget,
-  checkNetAddedLinesBudget,
-  checkSurfaceDebt,
-  checkCochangeRules,
-  checkNewFileRules,
-  checkSurfaceMatrix,
-  checkContentRules,
-  checkMustTouch,
-  checkMustNotTouch,
-  checkChangeTypeRules,
-  checkRegistryRules,
-  checkAdvisoryTextRules,
-} from "./diff-checker.mjs";
-import {
-  compileForbidRegex,
-  compileNewFilePolicy,
-  compileChangeTypePolicy,
-  compileSurfacePolicy,
-  warnReservedContractFields,
-  warnReservedPolicyFields,
-} from "./policy-compiler.mjs";
-
-function listTrackedFiles(repoRoot) {
-  return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
-    .split(/\r?\n/)
-    .filter(Boolean);
-}
-import {
-  ajvErrors,
-  createCheckReporter,
-  printEnforcementMode,
-  renderCheckSummary,
   resolveEnforcementMode,
 } from "./enforcement.mjs";
+import { renderCheckSummary } from "./reporting/renderers.mjs";
+import { loadJSON, loadPolicyRuntime, validate, validationCheck } from "./runtime/validation.mjs";
+import { runPolicyPipeline } from "./runtime/pipeline.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
@@ -76,37 +44,6 @@ export function resolveRoots(args) {
   return { packageRoot, repoRoot, enforcementMode, args: filtered };
 }
 
-function loadJSON(path) {
-  return JSON.parse(readFileSync(path, "utf-8"));
-}
-
-function validate(ajv, schema, data, label, options = {}) {
-  const valid = ajv.validate(schema, data);
-  if (!valid) {
-    if (!options.quiet) {
-      console.error(`FAIL: ${label}`);
-      for (const err of ajv.errors) {
-        console.error(`  ${err.instancePath || "/"} ${err.message}`);
-      }
-    }
-    return false;
-  }
-  if (!options.quiet) console.log(`OK: ${label}`);
-  return true;
-}
-
-function validationCheck(ajv, schema, data, label) {
-  const valid = ajv.validate(schema, data);
-  if (valid) {
-    return { ok: true };
-  }
-  return {
-    ok: false,
-    message: `${label} failed schema validation`,
-    errors: ajvErrors(ajv.errors),
-  };
-}
-
 function getDiff(base, head, cwd) {
   if (base && head) {
     return execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd });
@@ -117,10 +54,6 @@ function getDiff(base, head, cwd) {
 }
 
 function runCheckDiff(roots, args) {
-  const policySchemaPath = resolve(roots.packageRoot, "schemas/repo-policy.schema.json");
-  const contractSchemaPath = resolve(roots.packageRoot, "schemas/change-contract.schema.json");
-  const policyPath = resolve(roots.repoRoot, "repo-policy.json");
-
   let base = null;
   let head = null;
   let contractPath = null;
@@ -159,66 +92,10 @@ function runCheckDiff(roots, args) {
 
   const quiet = format === "json";
 
-  const policySchema = loadJSON(policySchemaPath);
-  const contractSchema = loadJSON(contractSchemaPath);
-  const policy = loadJSON(policyPath);
+  const runtime = loadPolicyRuntime(roots, { quiet });
+  const { ajv, policy, contractSchema } = runtime;
 
-  const ajv = new Ajv({ allErrors: true });
-
-  let ok = true;
-  ok = validate(ajv, policySchema, policy, "repo-policy.json", { quiet }) && ok;
-
-  const regexErrors = compileForbidRegex(policy.content_rules);
-  if (regexErrors.length > 0) {
-    ok = false;
-    if (!quiet) {
-      console.error("FAIL: forbid_regex compilation");
-      for (const e of regexErrors) {
-        console.error(`  [${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`);
-      }
-    }
-  }
-
-  const surfaceErrors = compileSurfacePolicy(policy);
-  if (surfaceErrors.length > 0) {
-    ok = false;
-    if (!quiet) {
-      console.error("FAIL: surface policy compilation");
-      for (const e of surfaceErrors) {
-        console.error(`  ${e.message}`);
-      }
-    }
-  }
-
-  const newFileErrors = compileNewFilePolicy(policy);
-  if (newFileErrors.length > 0) {
-    ok = false;
-    if (!quiet) {
-      console.error("FAIL: new file policy compilation");
-      for (const e of newFileErrors) {
-        console.error(`  ${e.message}`);
-      }
-    }
-  }
-
-  const changeTypeErrors = compileChangeTypePolicy(policy);
-  if (changeTypeErrors.length > 0) {
-    ok = false;
-    if (!quiet) {
-      console.error("FAIL: change type policy compilation");
-      for (const e of changeTypeErrors) {
-        console.error(`  ${e.message}`);
-      }
-    }
-  }
-
-  if (!quiet) {
-    for (const w of warnReservedPolicyFields(policy)) {
-      console.warn(`WARN: ${w}`);
-    }
-  }
-
-  if (!ok) {
+  if (!runtime.ok) {
     if (!quiet) console.error("\nPolicy compilation failed; aborting enforcement.");
     process.exit(1);
   }
@@ -228,15 +105,14 @@ function runCheckDiff(roots, args) {
     console.error(`ERROR: ${enforcement.message}`);
     process.exit(1);
   }
-  if (!quiet) printEnforcementMode(enforcement);
-  const reporter = createCheckReporter(enforcement.mode, { quiet });
 
   let contract = null;
+  const initialChecks = [];
   if (contractPath) {
     try {
       const loadedContract = loadJSON(contractPath);
       const contractCheck = validationCheck(ajv, contractSchema, loadedContract, contractPath);
-      reporter.report("change-contract", contractCheck);
+      initialChecks.push({ name: "change-contract", check: contractCheck });
       if (contractCheck.ok) {
         contract = loadedContract;
         if (!quiet) {
@@ -246,104 +122,29 @@ function runCheckDiff(roots, args) {
         }
       }
     } catch (e) {
-      reporter.report("change-contract", {
-        ok: false,
-        message: `Cannot read ${contractPath}: ${e.message}`,
+      initialChecks.push({
+        name: "change-contract",
+        check: {
+          ok: false,
+          message: `Cannot read ${contractPath}: ${e.message}`,
+        },
       });
     }
   }
 
   const diffText = getDiff(base, head, roots.repoRoot);
-  const allFiles = parseDiff(diffText);
-  const files = filterOperationalPaths(allFiles, policy.paths.operational_paths);
-
-  const skipped = allFiles.length - files.length;
-  if (!quiet) console.log(`\nDiff analysis: ${allFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
-
-  const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);
-  reporter.report("forbidden-paths", {
-    ok: forbiddenViolations.length === 0,
-    files: forbiddenViolations,
-  });
-
-  const budgets = contract?.budgets || {};
-  const maxNewDocs = budgets.max_new_docs ?? policy.diff_rules.max_new_docs;
-  const maxNewFiles = budgets.max_new_files ?? policy.diff_rules.max_new_files;
-  const maxNetAddedLines = budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines;
-
-  reporter.report("canonical-docs-budget", checkCanonicalDocsBudget(files, policy.paths.canonical_docs, maxNewDocs));
-  reporter.report("max-new-files", checkNewFilesBudget(files, maxNewFiles));
-  reporter.report("max-net-added-lines", checkNetAddedLinesBudget(files, maxNetAddedLines));
-  reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
-  reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: roots.repoRoot }));
-  reporter.report(
-    "advisory-text-rules",
-    checkAdvisoryTextRules(files, policy.advisory_text_rules, {
-      repoRoot: roots.repoRoot,
-      allFiles: listTrackedFiles(roots.repoRoot),
-    })
-  );
-
-  if (policy.change_type_rules) {
-    reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));
-  }
-
   const declaredChangeClass = cliChangeClass || contract?.change_class || null;
-  if (policy.new_file_rules) {
-    reporter.report(
-      "new-file-rules",
-      checkNewFileRules(files, policy.new_file_classes, policy.new_file_rules, declaredChangeClass)
-    );
-  }
 
-  if (policy.surface_matrix) {
-    reporter.report(
-      "surface-matrix",
-      checkSurfaceMatrix(
-        files,
-        policy.surfaces,
-        policy.surface_matrix,
-        declaredChangeClass,
-        { allow_unclassified_files: policy.allow_unclassified_files }
-      )
-    );
-  }
-
-  const cochangeViolations = checkCochangeRules(files, policy.cochange_rules);
-  if (cochangeViolations.length > 0) {
-    for (const v of cochangeViolations) {
-      reporter.report(`cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, {
-        ok: false,
-        must_touch: v.must_change_any,
-      });
-    }
-  } else {
-    reporter.report("cochange-rules", { ok: true });
-  }
-
-  const contentViolations = checkContentRules(files, policy.content_rules);
-  if (contentViolations.length > 0) {
-    reporter.report("content-rules", {
-      ok: false,
-      details: contentViolations.map((v) => `[${v.rule_id}] ${v.file}: "${v.line}" matched /${v.matched_regex}/`),
-    });
-  } else {
-    reporter.report("content-rules", { ok: true });
-  }
-
-  if (contract) {
-    reporter.report("must-touch", checkMustTouch(files, contract.must_touch));
-    reporter.report("must-not-touch", checkMustNotTouch(files, contract.must_not_touch));
-  }
-
-  const summary = reporter.finish({
+  const summary = runPolicyPipeline({
     repositoryRoot: roots.repoRoot,
-    diff: {
-      changedFiles: allFiles.length,
-      checkedFiles: files.length,
-      skippedOperationalFiles: skipped,
-    },
-  });
+    policy,
+    contract,
+    enforcement,
+    diffText,
+    declaredChangeClass,
+    initialChecks,
+  }, { quiet });
+
   if (format === "json") {
     console.log(JSON.stringify(summary, null, 2));
   } else if (format === "summary") {

--- a/src/reporting/renderers.mjs
+++ b/src/reporting/renderers.mjs
@@ -1,0 +1,1 @@
+export { renderCheckSummary } from "../enforcement.mjs";

--- a/src/runtime/pipeline.mjs
+++ b/src/runtime/pipeline.mjs
@@ -1,0 +1,38 @@
+import { createCheckReporter, printEnforcementMode } from "../enforcement.mjs";
+import { buildPolicyFacts } from "../facts/input.mjs";
+import { runPolicyChecks } from "../checks/orchestrator.mjs";
+
+export function runPolicyPipeline(input, options = {}) {
+  const quiet = options.quiet || false;
+  if (!quiet && options.printEnforcement !== false) {
+    printEnforcementMode(input.enforcement);
+  }
+
+  const reporter = createCheckReporter(input.enforcement.mode, { quiet });
+
+  for (const initialCheck of input.initialChecks || []) {
+    reporter.report(initialCheck.name, initialCheck.check);
+  }
+
+  const facts = buildPolicyFacts(input);
+  if (!quiet) {
+    const skipped = facts.diagnostics.skippedOperationalFiles;
+    console.log(`\nDiff analysis: ${facts.diffFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
+  }
+
+  runPolicyChecks(facts, reporter);
+
+  return reporter.finish({
+    repositoryRoot: facts.repositoryRoot,
+    diff: {
+      changedFiles: facts.diffFiles.length,
+      checkedFiles: facts.filteredOperationalFiles.length,
+      skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
+    },
+    facts: {
+      changedPaths: facts.changedPaths,
+      touchedSurfaces: facts.touchedSurfaces,
+      newFileClasses: facts.newFileClasses,
+    },
+  });
+}

--- a/src/runtime/pipeline.mjs
+++ b/src/runtime/pipeline.mjs
@@ -29,10 +29,5 @@ export function runPolicyPipeline(input, options = {}) {
       checkedFiles: facts.filteredOperationalFiles.length,
       skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
     },
-    facts: {
-      changedPaths: facts.changedPaths,
-      touchedSurfaces: facts.touchedSurfaces,
-      newFileClasses: facts.newFileClasses,
-    },
   });
 }

--- a/src/runtime/validation.mjs
+++ b/src/runtime/validation.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Ajv from "ajv";
+import { ajvErrors } from "../enforcement.mjs";
+import {
+  compileForbidRegex,
+  compileNewFilePolicy,
+  compileChangeTypePolicy,
+  compileSurfacePolicy,
+  warnReservedPolicyFields,
+} from "../policy-compiler.mjs";
+
+export function loadJSON(path) {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+export function createAjv() {
+  return new Ajv({ allErrors: true });
+}
+
+export function validate(ajv, schema, data, label, options = {}) {
+  const valid = ajv.validate(schema, data);
+  if (!valid) {
+    if (!options.quiet) {
+      console.error(`FAIL: ${label}`);
+      for (const err of ajv.errors) {
+        console.error(`  ${err.instancePath || "/"} ${err.message}`);
+      }
+    }
+    return false;
+  }
+  if (!options.quiet) console.log(`OK: ${label}`);
+  return true;
+}
+
+export function validationCheck(ajv, schema, data, label) {
+  const valid = ajv.validate(schema, data);
+  if (valid) return { ok: true };
+  return {
+    ok: false,
+    message: `${label} failed schema validation`,
+    errors: ajvErrors(ajv.errors),
+  };
+}
+
+export function loadPolicyRuntime(roots, options = {}) {
+  const policySchema = loadJSON(resolve(roots.packageRoot, "schemas/repo-policy.schema.json"));
+  const contractSchema = loadJSON(resolve(roots.packageRoot, "schemas/change-contract.schema.json"));
+  const policy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
+  const ajv = createAjv();
+  const quiet = options.quiet || false;
+
+  let ok = true;
+  ok = validate(ajv, policySchema, policy, "repo-policy.json", { quiet }) && ok;
+
+  const compileGroups = [
+    ["forbid_regex compilation", compileForbidRegex(policy.content_rules), (e) => `[${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`],
+    ["surface policy compilation", compileSurfacePolicy(policy), (e) => e.message],
+    ["new file policy compilation", compileNewFilePolicy(policy), (e) => e.message],
+    ["change type policy compilation", compileChangeTypePolicy(policy), (e) => e.message],
+  ];
+
+  for (const [label, errors, format] of compileGroups) {
+    if (errors.length === 0) continue;
+    ok = false;
+    if (!quiet) {
+      console.error(`FAIL: ${label}`);
+      for (const error of errors) {
+        console.error(`  ${format(error)}`);
+      }
+    }
+  }
+
+  if (!quiet) {
+    for (const warning of warnReservedPolicyFields(policy)) {
+      console.warn(`WARN: ${warning}`);
+    }
+  }
+
+  return { ok, ajv, policy, contractSchema };
+}

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from "node:assert";
+import { buildPolicyFacts } from "../src/facts/input.mjs";
 import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
 
 let failures = 0;
@@ -65,17 +66,31 @@ function runEquivalentInput(extra = {}) {
   }, { quiet: true });
 }
 
+function buildEquivalentFacts(extra = {}) {
+  return buildPolicyFacts({
+    repositoryRoot: "/tmp/repo-guard-test",
+    policy,
+    contract: null,
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles: ["README.md", "src/existing.mjs"],
+    declaredChangeClass: null,
+    ...extra,
+  });
+}
+
 console.log("\n--- shared policy pipeline normalizes facts and checks ---");
 {
+  const facts = buildEquivalentFacts();
   const result = runEquivalentInput();
   expect("pipeline records changed files before and after operational filtering", result.diff, {
     changedFiles: 2,
     checkedFiles: 1,
     skippedOperationalFiles: 1,
   });
-  expect("pipeline exposes normalized changed paths", result.facts.changedPaths, ["src/feature.mjs"]);
-  expect("pipeline extracts touched surfaces", result.facts.touchedSurfaces.touched_surfaces, ["source"]);
-  expect("pipeline classifies new files", result.facts.newFileClasses.files_by_class, {
+  expect("facts expose normalized changed paths", facts.changedPaths, ["src/feature.mjs"]);
+  expect("facts extract touched surfaces", facts.touchedSurfaces.touched_surfaces, ["source"]);
+  expect("facts classify new files", facts.newFileClasses.files_by_class, {
     source: ["src/feature.mjs"],
   });
   expect(
@@ -91,8 +106,10 @@ console.log("\n--- equivalent command inputs share one result shape ---");
   const checkPrStyle = runEquivalentInput({
     initialChecks: [{ name: "change-contract", check: { ok: true } }],
   });
+  const checkDiffFacts = buildEquivalentFacts();
+  const checkPrFacts = buildEquivalentFacts();
 
-  expect("equivalent facts are identical", checkPrStyle.facts, checkDiffStyle.facts);
+  expect("equivalent facts are identical", checkPrFacts, checkDiffFacts);
   expect(
     "check-pr style input adds contract validation without changing policy check result",
     checkPrStyle.violations.map((violation) => violation.rule),

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -1,0 +1,104 @@
+import { strict as assert } from "node:assert";
+import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (e) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+const policy = {
+  policy_format_version: "0.3.0",
+  repository_kind: "tooling",
+  paths: {
+    forbidden: ["secrets/**"],
+    canonical_docs: ["README.md"],
+    operational_paths: [".github/**"],
+    governance_paths: ["repo-policy.json"],
+  },
+  diff_rules: {
+    max_new_docs: 5,
+    max_new_files: 3,
+    max_net_added_lines: 500,
+  },
+  surfaces: {
+    source: ["src/**"],
+    docs: ["docs/**"],
+  },
+  new_file_classes: {
+    source: ["src/**"],
+  },
+  content_rules: [],
+  cochange_rules: [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }],
+};
+
+const diffText = [
+  "diff --git a/src/feature.mjs b/src/feature.mjs",
+  "new file mode 100644",
+  "--- /dev/null",
+  "+++ b/src/feature.mjs",
+  "+export const value = 1;",
+  "diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml",
+  "--- a/.github/workflows/ci.yml",
+  "+++ b/.github/workflows/ci.yml",
+  "+name: ci",
+].join("\n");
+
+function runEquivalentInput(extra = {}) {
+  return runPolicyPipeline({
+    repositoryRoot: "/tmp/repo-guard-test",
+    policy,
+    contract: null,
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles: ["README.md", "src/existing.mjs"],
+    declaredChangeClass: null,
+    initialChecks: [],
+    ...extra,
+  }, { quiet: true });
+}
+
+console.log("\n--- shared policy pipeline normalizes facts and checks ---");
+{
+  const result = runEquivalentInput();
+  expect("pipeline records changed files before and after operational filtering", result.diff, {
+    changedFiles: 2,
+    checkedFiles: 1,
+    skippedOperationalFiles: 1,
+  });
+  expect("pipeline exposes normalized changed paths", result.facts.changedPaths, ["src/feature.mjs"]);
+  expect("pipeline extracts touched surfaces", result.facts.touchedSurfaces.touched_surfaces, ["source"]);
+  expect("pipeline classifies new files", result.facts.newFileClasses.files_by_class, {
+    source: ["src/feature.mjs"],
+  });
+  expect(
+    "pipeline runs existing checks",
+    result.violations.some((violation) => violation.rule.startsWith("cochange:")),
+    true
+  );
+}
+
+console.log("\n--- equivalent command inputs share one result shape ---");
+{
+  const checkDiffStyle = runEquivalentInput();
+  const checkPrStyle = runEquivalentInput({
+    initialChecks: [{ name: "change-contract", check: { ok: true } }],
+  });
+
+  expect("equivalent facts are identical", checkPrStyle.facts, checkDiffStyle.facts);
+  expect(
+    "check-pr style input adds contract validation without changing policy check result",
+    checkPrStyle.violations.map((violation) => violation.rule),
+    checkDiffStyle.violations.map((violation) => violation.rule)
+  );
+}
+
+console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -28,6 +28,11 @@ function expectIncludes(label, str, substring) {
   }
 }
 
+function expectTopLevelKeys(label, actual, expected) {
+  const keys = Object.keys(actual || {}).sort();
+  expect(label, JSON.stringify(keys), JSON.stringify([...expected].sort()));
+}
+
 function runGuard(args, opts = {}) {
   const result = spawnSync(process.execPath, [repoGuard, ...args], {
     cwd: opts.cwd || projectRoot,
@@ -383,6 +388,22 @@ console.log("\n--- check-diff --format json emits stable machine-readable result
   expect("ok is false", parsed?.ok, false);
   expect("exitCode is 1", parsed?.exitCode, 1);
   expect("changed file count", parsed?.diff?.changedFiles, 2);
+  expectTopLevelKeys("top-level json shape is stable", parsed, [
+    "advisoryWarnings",
+    "diff",
+    "exitCode",
+    "failed",
+    "hints",
+    "mode",
+    "ok",
+    "passed",
+    "repositoryRoot",
+    "result",
+    "ruleResults",
+    "violationCount",
+    "violations",
+    "warnings",
+  ]);
   expect("result array is stable", Array.isArray(parsed?.ruleResults), true);
   expect("violations array is stable", Array.isArray(parsed?.violations), true);
   expect("hints array is stable", Array.isArray(parsed?.hints), true);


### PR DESCRIPTION
## Summary
- route check-diff and check-pr through a shared policy pipeline
- add normalized fact construction for diff files, filtered operational files, changed paths, tracked files, touched surfaces, and new file classes
- move check orchestration into src/checks and keep rendering via reporting/runtime modules without changing CLI UX or exit semantics

Fixes netkeep80/repo-guard#45

## repo-guard contract

```repo-guard-json
{
  "change_type": "refactor",
  "change_class": "core-refactor",
  "scope": [
    "src/repo-guard.mjs",
    "src/github-pr.mjs",
    "src/facts/**",
    "src/checks/**",
    "src/reporting/**",
    "src/runtime/**",
    "tests/test-pipeline.mjs",
    "package.json"
  ],
  "budgets": {
    "max_new_files": 6,
    "max_net_added_lines": 600
  },
  "must_touch": [
    "src/repo-guard.mjs",
    "src/github-pr.mjs",
    "src/runtime/pipeline.mjs",
    "tests/test-pipeline.mjs"
  ],
  "must_not_touch": [
    "schemas/**"
  ],
  "expected_effects": [
    "check-diff and check-pr share one internal policy pipeline",
    "existing CLI output formats and exit semantics remain compatible"
  ]
}
```

## Tests
- npm test
