### PR TITLE
Unify check-diff and check-pr facts model

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T19:12:48.795Z for PR creation at branch issue-47-1473f930e990 for issue https://github.com/netkeep80/repo-guard/issues/47

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T19:12:48.795Z for PR creation at branch issue-47-1473f930e990 for issue https://github.com/netkeep80/repo-guard/issues/47

--- a/README.md
+++ b/README.md
@@ -279,6 +279,39 @@ repo-guard check-pr
 - `gh` CLI с авторизацией (для fallback на linked issue);
 - event payload типа `pull_request` с base/head SHA.
 
+### Normalized Facts Model
+
+`check-diff` and `check-pr` both normalize their inputs before policy checks run. The command modes differ only in how they gather input: `check-diff` reads local CLI refs and an optional contract file, while `check-pr` reads the GitHub pull request event and optionally falls back to a linked issue. After that adapter step, checks consume the same facts object:
+
+```js
+{
+  mode: "check-diff" | "check-pr",
+  repositoryRoot: "/absolute/repo",
+  policy: { /* validated repo-policy.json */ },
+  contract: { /* validated change contract */ } | null,
+  contractSource: "cli file" | "pr body" | "linked issue" | "none",
+  enforcement: { mode: "blocking" | "advisory" },
+  diff: {
+    files: {
+      all: [/* parsed git diff files */],
+      checked: [/* all minus operational paths */],
+      skippedOperational: [/* files ignored by policy.paths.operational_paths */]
+    }
+  },
+  trackedFiles: ["README.md"],
+  derived: {
+    changedPaths: ["src/example.mjs"],
+    touchedSurfaces: { /* surface detection result */ } | null,
+    newFileClasses: { /* new file classification result */ } | null
+  },
+  diagnostics: {
+    skippedOperationalFiles: 0
+  }
+}
+```
+
+Policy checks read from this normalized model instead of from raw command parameters. That keeps runtime checks source-agnostic and leaves PR markdown, linked issue lookup, and CLI file loading in adapter code that can be tested directly.
+
 ### Advisory vs blocking
 
 `repo-guard` separates command mode (`check-pr`, `check-diff`) from enforcement behavior:

--- a/src/checks/orchestrator.mjs
+++ b/src/checks/orchestrator.mjs
@@ -17,7 +17,7 @@ import {
 
 export function runPolicyChecks(facts, reporter) {
   const policy = facts.policy;
-  const files = facts.filteredOperationalFiles;
+  const files = facts.diff.files.checked;
   const contract = facts.contract;
 
   const forbiddenViolations = checkForbiddenPaths(files, policy.paths.forbidden);

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -13,38 +13,54 @@ export function listTrackedFiles(repoRoot) {
 }
 
 export function buildPolicyFacts({
+  mode = "check-diff",
   repositoryRoot,
   policy,
   contract = null,
+  contractSource = "none",
   enforcement,
   diffText,
   trackedFiles = null,
   declaredChangeClass = null,
+  diagnostics = {},
 }) {
-  const diffFiles = parseDiff(diffText);
-  const filteredOperationalFiles = filterOperationalPaths(diffFiles, policy.paths.operational_paths);
-  const changedPaths = filteredOperationalFiles.map((file) => file.path);
-  const skippedOperationalFiles = diffFiles.length - filteredOperationalFiles.length;
+  const allFiles = parseDiff(diffText);
+  const checkedFiles = filterOperationalPaths(allFiles, policy.paths.operational_paths);
+  const skippedOperationalFiles = allFiles.filter((file) => !checkedFiles.includes(file));
+  const changedPaths = checkedFiles.map((file) => file.path);
+  const resolvedTrackedFiles = trackedFiles || listTrackedFiles(repositoryRoot);
+  const touchedSurfaces = policy.surfaces
+    ? detectTouchedSurfaces(checkedFiles, policy.surfaces)
+    : null;
+  const newFileClasses = policy.new_file_classes
+    ? classifyNewFiles(checkedFiles, policy.new_file_classes)
+    : null;
 
   return {
+    mode,
     repositoryRoot,
     policy,
     contract,
+    contractSource,
     enforcementMode: enforcement.mode,
     enforcement,
-    diffFiles,
-    filteredOperationalFiles,
-    changedPaths,
-    trackedFiles: trackedFiles || listTrackedFiles(repositoryRoot),
-    touchedSurfaces: policy.surfaces
-      ? detectTouchedSurfaces(filteredOperationalFiles, policy.surfaces)
-      : null,
-    newFileClasses: policy.new_file_classes
-      ? classifyNewFiles(filteredOperationalFiles, policy.new_file_classes)
-      : null,
+    diff: {
+      files: {
+        all: allFiles,
+        checked: checkedFiles,
+        skippedOperational: skippedOperationalFiles,
+      },
+    },
+    trackedFiles: resolvedTrackedFiles,
+    derived: {
+      changedPaths,
+      touchedSurfaces,
+      newFileClasses,
+    },
     declaredChangeClass,
     diagnostics: {
-      skippedOperationalFiles,
+      ...diagnostics,
+      skippedOperationalFiles: skippedOperationalFiles.length,
     },
   };
 }

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -64,6 +64,58 @@ export function checkPrerequisites() {
   return missing;
 }
 
+export function resolvePRContractFacts({ prBody, issueBody = null, linkedIssueCount = null }) {
+  const prResult = extractContract(prBody);
+  if (prResult.ok) {
+    return {
+      ok: true,
+      contract: prResult.contract,
+      contractSource: "pr body",
+      linkedIssues: extractLinkedIssueNumbers(prBody),
+    };
+  }
+
+  if (prResult.error !== "contract_not_found") {
+    return {
+      ok: false,
+      error: prResult.error,
+      message: prResult.message,
+      contractSource: "pr body",
+      linkedIssues: extractLinkedIssueNumbers(prBody),
+    };
+  }
+
+  const linkedIssues = extractLinkedIssueNumbers(prBody);
+  const resolvedLinkedIssueCount = linkedIssueCount ?? linkedIssues.length;
+  if (resolvedLinkedIssueCount > 1) {
+    return {
+      ok: false,
+      error: "issue_link_ambiguous",
+      message: `PR body references ${resolvedLinkedIssueCount} issues (${linkedIssues.map(n => `#${n}`).join(", ")}); expected exactly one`,
+      contractSource: "none",
+      linkedIssues,
+    };
+  }
+
+  const issueResult = resolveContract(prBody, issueBody);
+  if (issueResult.ok) {
+    return {
+      ok: true,
+      contract: issueResult.contract,
+      contractSource: "linked issue",
+      linkedIssues,
+    };
+  }
+
+  return {
+    ok: false,
+    error: issueResult.error,
+    message: issueResult.message,
+    contractSource: "none",
+    linkedIssues,
+  };
+}
+
 export function runCheckPR(roots, args = []) {
   for (const arg of args) {
     if (arg.startsWith("-")) {
@@ -106,29 +158,32 @@ export function runCheckPR(roots, args = []) {
   }
 
   let issueBody = null;
-  let contractFailure = null;
   const prResult = extractContract(prBody);
   if (!prResult.ok && prResult.error === "contract_not_found") {
     const linkedIssues = extractLinkedIssueNumbers(prBody);
     if (linkedIssues.length > 1) {
-      contractFailure = {
-        error: "issue_link_ambiguous",
-        message: `PR body references ${linkedIssues.length} issues (${linkedIssues.map(n => `#${n}`).join(", ")}); expected exactly one`,
-      };
+      // Handled by resolvePRContractFacts after preserving linked issue diagnostics.
     } else if (linkedIssues.length === 1) {
       console.log(`No contract in PR body; trying linked issue #${linkedIssues[0]}...`);
       issueBody = fetchIssueBody(repoFullName, linkedIssues[0]);
-      if (!issueBody) {
-        contractFailure = {
-          error: "issue_fetch_failed",
-          message: `Could not fetch issue #${linkedIssues[0]} body`,
-        };
-      }
     }
   }
 
-  const contractResult = contractFailure || resolveContract(prBody, issueBody);
+  let contractResult = resolvePRContractFacts({ prBody, issueBody });
+  if (
+    !contractResult.ok &&
+    contractResult.linkedIssues.length === 1 &&
+    issueBody === null &&
+    contractResult.error !== "issue_link_ambiguous"
+  ) {
+    contractResult = {
+      ...contractResult,
+      error: "issue_fetch_failed",
+      message: `Could not fetch issue #${contractResult.linkedIssues[0]} body`,
+    };
+  }
   let contract = null;
+  let contractSource = contractResult.contractSource || "none";
   const initialChecks = [];
   if (!contractResult.ok) {
     initialChecks.push({
@@ -143,6 +198,7 @@ export function runCheckPR(roots, args = []) {
     initialChecks.push({ name: "change-contract", check: contractCheck });
     if (contractCheck.ok) {
       contract = contractResult.contract;
+      contractSource = contractResult.contractSource;
       for (const w of warnReservedContractFields(contract)) {
         console.warn(`WARN: ${w}`);
       }
@@ -151,9 +207,11 @@ export function runCheckPR(roots, args = []) {
 
   const diffText = execSync(`git diff ${base}...${head}`, { encoding: "utf-8", cwd: roots.repoRoot });
   const summary = runPolicyPipeline({
+    mode: "check-pr",
     repositoryRoot: roots.repoRoot,
     policy,
     contract,
+    contractSource,
     enforcement,
     diffText,
     declaredChangeClass: contract?.change_class || null,

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -136,9 +136,11 @@ function runCheckDiff(roots, args) {
   const declaredChangeClass = cliChangeClass || contract?.change_class || null;
 
   const summary = runPolicyPipeline({
+    mode: "check-diff",
     repositoryRoot: roots.repoRoot,
     policy,
     contract,
+    contractSource: contractPath ? "cli file" : "none",
     enforcement,
     diffText,
     declaredChangeClass,

--- a/src/runtime/pipeline.mjs
+++ b/src/runtime/pipeline.mjs
@@ -17,7 +17,7 @@ export function runPolicyPipeline(input, options = {}) {
   const facts = buildPolicyFacts(input);
   if (!quiet) {
     const skipped = facts.diagnostics.skippedOperationalFiles;
-    console.log(`\nDiff analysis: ${facts.diffFiles.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
+    console.log(`\nDiff analysis: ${facts.diff.files.all.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
   }
 
   runPolicyChecks(facts, reporter);
@@ -25,8 +25,8 @@ export function runPolicyPipeline(input, options = {}) {
   return reporter.finish({
     repositoryRoot: facts.repositoryRoot,
     diff: {
-      changedFiles: facts.diffFiles.length,
-      checkedFiles: facts.filteredOperationalFiles.length,
+      changedFiles: facts.diff.files.all.length,
+      checkedFiles: facts.diff.files.checked.length,
       skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
     },
   });

--- a/tests/test-github-pr.mjs
+++ b/tests/test-github-pr.mjs
@@ -1,7 +1,7 @@
 import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { loadGitHubEvent } from "../src/github-pr.mjs";
+import { loadGitHubEvent, resolvePRContractFacts } from "../src/github-pr.mjs";
 import { resolveContract, extractLinkedIssueNumbers } from "../src/markdown-contract.mjs";
 
 let failures = 0;
@@ -96,6 +96,10 @@ Fixes #10
   expect("integration valid: change_type", result.contract.change_type, "bugfix");
   expect("integration valid: scope", result.contract.scope[0], "src/auth.mjs");
 
+  const facts = resolvePRContractFacts({ prBody });
+  expect("integration valid: adapter ok", facts.ok, true);
+  expect("integration valid: adapter source", facts.contractSource, "pr body");
+
   const issues = extractLinkedIssueNumbers(prBody);
   expect("integration valid: linked issue", issues[0], 10);
 }
@@ -122,6 +126,11 @@ Feature request.
   const result = resolveContract(prBody, issueBody);
   expect("integration fallback: ok", result.ok, true);
   expect("integration fallback: from issue", result.contract.change_type, "feature");
+
+  const facts = resolvePRContractFacts({ prBody, issueBody });
+  expect("integration fallback: adapter ok", facts.ok, true);
+  expect("integration fallback: adapter source", facts.contractSource, "linked issue");
+  expect("integration fallback: adapter linked issue", facts.linkedIssues[0], 15);
 }
 
 // --- Integration: ambiguous linked issues (>1) should be detected ---
@@ -137,6 +146,11 @@ Feature request.
   const prResult = resolveContract(prBody, null);
   expect("ambiguous links: no contract in PR", prResult.ok, false);
   expect("ambiguous links: contract_not_found", prResult.error, "contract_not_found");
+
+  const facts = resolvePRContractFacts({ prBody });
+  expect("ambiguous links: adapter fails", facts.ok, false);
+  expect("ambiguous links: adapter error", facts.error, "issue_link_ambiguous");
+  expect("ambiguous links: adapter source", facts.contractSource, "none");
 }
 
 {
@@ -154,6 +168,11 @@ Feature request.
   const result = resolveContract(prBody, issueBody);
   expect("integration missing: ok", result.ok, false);
   expect("integration missing: error", result.error, "fallback_missing");
+
+  const facts = resolvePRContractFacts({ prBody, issueBody });
+  expect("integration missing: adapter ok", facts.ok, false);
+  expect("integration missing: adapter error", facts.error, "fallback_missing");
+  expect("integration missing: adapter source", facts.contractSource, "none");
 }
 
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -54,9 +54,11 @@ const diffText = [
 
 function runEquivalentInput(extra = {}) {
   return runPolicyPipeline({
+    mode: "check-diff",
     repositoryRoot: "/tmp/repo-guard-test",
     policy,
     contract: null,
+    contractSource: "none",
     enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
     diffText,
     trackedFiles: ["README.md", "src/existing.mjs"],
@@ -68,9 +70,11 @@ function runEquivalentInput(extra = {}) {
 
 function buildEquivalentFacts(extra = {}) {
   return buildPolicyFacts({
+    mode: "check-diff",
     repositoryRoot: "/tmp/repo-guard-test",
     policy,
     contract: null,
+    contractSource: "none",
     enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
     diffText,
     trackedFiles: ["README.md", "src/existing.mjs"],
@@ -88,9 +92,17 @@ console.log("\n--- shared policy pipeline normalizes facts and checks ---");
     checkedFiles: 1,
     skippedOperationalFiles: 1,
   });
-  expect("facts expose normalized changed paths", facts.changedPaths, ["src/feature.mjs"]);
-  expect("facts extract touched surfaces", facts.touchedSurfaces.touched_surfaces, ["source"]);
-  expect("facts classify new files", facts.newFileClasses.files_by_class, {
+  expect("facts identify check-diff mode", facts.mode, "check-diff");
+  expect("facts identify contract source", facts.contractSource, "none");
+  expect("facts expose all diff files", facts.diff.files.all.map((file) => file.path), [
+    "src/feature.mjs",
+    ".github/workflows/ci.yml",
+  ]);
+  expect("facts expose checked diff files", facts.diff.files.checked.map((file) => file.path), ["src/feature.mjs"]);
+  expect("facts expose skipped operational files", facts.diff.files.skippedOperational.map((file) => file.path), [".github/workflows/ci.yml"]);
+  expect("facts expose normalized changed paths", facts.derived.changedPaths, ["src/feature.mjs"]);
+  expect("facts extract touched surfaces", facts.derived.touchedSurfaces.touched_surfaces, ["source"]);
+  expect("facts classify new files", facts.derived.newFileClasses.files_by_class, {
     source: ["src/feature.mjs"],
   });
   expect(
@@ -104,12 +116,21 @@ console.log("\n--- equivalent command inputs share one result shape ---");
 {
   const checkDiffStyle = runEquivalentInput();
   const checkPrStyle = runEquivalentInput({
+    mode: "check-pr",
+    contractSource: "pr body",
     initialChecks: [{ name: "change-contract", check: { ok: true } }],
   });
   const checkDiffFacts = buildEquivalentFacts();
-  const checkPrFacts = buildEquivalentFacts();
+  const checkPrFacts = buildEquivalentFacts({ mode: "check-pr", contractSource: "pr body" });
 
-  expect("equivalent facts are identical", checkPrFacts, checkDiffFacts);
+  expect("equivalent facts keep mode-specific provenance", {
+    mode: checkPrFacts.mode,
+    contractSource: checkPrFacts.contractSource,
+  }, {
+    mode: "check-pr",
+    contractSource: "pr body",
+  });
+  expect("equivalent facts share checked diff paths", checkPrFacts.derived.changedPaths, checkDiffFacts.derived.changedPaths);
   expect(
     "check-pr style input adds contract validation without changing policy check result",
     checkPrStyle.violations.map((violation) => violation.rule),


### PR DESCRIPTION
## Summary

- Introduces a documented normalized facts model shared by `check-diff` and `check-pr`.
- Moves policy checks to consume nested facts (`diff.files.checked`, `derived.*`) instead of raw/legacy command-specific fields.
- Adds a testable PR contract adapter that reports contract provenance as `pr body`, `linked issue`, or `none`.

Fixes netkeep80/repo-guard#47

## Repo Guard Contract

```repo-guard-yaml
change_type: architecture
scope:
  - README.md
  - src/facts/input.mjs
  - src/runtime/pipeline.mjs
  - src/checks/orchestrator.mjs
  - src/github-pr.mjs
  - src/repo-guard.mjs
  - tests/test-pipeline.mjs
  - tests/test-github-pr.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 250
must_touch:
  - src/facts/input.mjs
  - tests/test-pipeline.mjs
must_not_touch:
  - schemas/**
expected_effects:
  - check-diff and check-pr share a normalized facts object before policy checks run
  - PR markdown and linked issue contract extraction is testable as an adapter layer
```

## Testing

- `node tests/test-pipeline.mjs`
- `node tests/test-github-pr.mjs`
- `npm test`