### PR TITLE
Add anchor-aware policy schema

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T19:26:49.789Z for PR creation at branch issue-49-f9906f6a435a for issue https://github.com/netkeep80/repo-guard/issues/49

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T19:26:49.789Z for PR creation at branch issue-49-f9906f6a435a for issue https://github.com/netkeep80/repo-guard/issues/49

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -270,6 +270,45 @@
         }
       }
     },
+    "anchors": {
+      "type": "object",
+      "description": "Named anchor types and extractors used as shared trace vocabulary. Runtime extraction is reserved for future versions.",
+      "required": ["types"],
+      "additionalProperties": false,
+      "properties": {
+        "types": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": {
+            "type": "object",
+            "required": ["sources"],
+            "additionalProperties": false,
+            "properties": {
+              "sources": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/anchor_source" },
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "trace_rules": {
+      "type": "array",
+      "description": "Trace/evidence rules between declared anchor types. Runtime enforcement is reserved for future versions.",
+      "items": {
+        "type": "object",
+        "required": ["id", "kind", "from_anchor_type", "to_anchor_type"],
+        "additionalProperties": false,
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "kind": { "type": "string", "enum": ["must_resolve"] },
+          "from_anchor_type": { "type": "string", "minLength": 1 },
+          "to_anchor_type": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
     "content_rules": {
       "type": "array",
       "items": {
@@ -313,6 +352,30 @@
     }
   },
   "definitions": {
+    "anchor_source": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "glob", "field"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "json_field" },
+            "glob": { "type": "string", "minLength": 1 },
+            "field": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "glob", "pattern"],
+          "additionalProperties": false,
+          "properties": {
+            "kind": { "const": "regex" },
+            "glob": { "type": "string", "minLength": 1 },
+            "pattern": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    },
     "registry_source": {
       "oneOf": [
         {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -2,7 +2,7 @@ import { readFileSync, existsSync, statSync, readdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import { compileForbidRegex } from "./policy-compiler.mjs";
+import { compileAnchorPolicy, compileForbidRegex } from "./policy-compiler.mjs";
 
 const PASS = "PASS";
 const WARN = "WARN";
@@ -95,6 +95,12 @@ function checkPolicyDiscovery(repoRoot, packageRoot) {
     if (regexErrors.length > 0) {
       const details = regexErrors.map(e => `[${e.rule_id}] /${e.pattern}/: ${e.message}`).join("; ");
       return { name: "repo-policy.json", status: FAIL, message: `Invalid forbid_regex: ${details}`, hint: "Fix the regular expressions in content_rules" };
+    }
+
+    const anchorErrors = compileAnchorPolicy(policy);
+    if (anchorErrors.length > 0) {
+      const details = anchorErrors.map(e => e.message).join("; ");
+      return { name: "repo-policy.json", status: FAIL, message: `Invalid anchor policy: ${details}`, hint: "Fix anchors and trace_rules references in repo-policy.json" };
     }
 
     return { name: "repo-policy.json", status: PASS, message: `Valid (${policy.repository_kind}, format ${policy.policy_format_version})` };

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -191,6 +191,61 @@ export function compileChangeTypePolicy(policy) {
   return errors;
 }
 
+export function compileAnchorPolicy(policy) {
+  const errors = [];
+  const anchors = policy.anchors;
+  const traceRules = policy.trace_rules || [];
+  const anchorTypes = anchors?.types || {};
+  const anchorTypeNames = new Set(Object.keys(anchorTypes));
+  const traceRuleIds = new Set();
+
+  if (!anchors && traceRules.length === 0) return errors;
+
+  if (traceRules.length > 0 && anchorTypeNames.size === 0) {
+    errors.push({ message: "trace_rules requires anchor types in anchors.types" });
+  }
+
+  for (const [anchorType, config] of Object.entries(anchorTypes)) {
+    for (const [index, source] of (config.sources || []).entries()) {
+      if (source.kind === "regex") {
+        try {
+          new RegExp(source.pattern);
+        } catch (e) {
+          errors.push({
+            anchor_type: anchorType,
+            source_index: index,
+            pattern: source.pattern,
+            message: `anchors.types["${anchorType}"].sources[${index}].pattern is invalid: ${e.message}`,
+          });
+        }
+      }
+    }
+  }
+
+  for (const [index, rule] of traceRules.entries()) {
+    if (traceRuleIds.has(rule.id)) {
+      errors.push({
+        trace_rule: rule.id,
+        message: `trace_rules[${index}].id duplicates trace rule "${rule.id}"`,
+      });
+    }
+    traceRuleIds.add(rule.id);
+
+    for (const field of ["from_anchor_type", "to_anchor_type"]) {
+      const anchorType = rule[field];
+      if (!anchorTypeNames.has(anchorType)) {
+        errors.push({
+          trace_rule: rule.id,
+          anchor_type: anchorType,
+          message: `trace_rules[${index}].${field} references unknown anchor type "${anchorType}"`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function warnReservedContractFields(contract) {
   const warnings = [];
   if (contract.overrides && contract.overrides.length > 0) {

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -5,7 +5,15 @@ import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import Ajv from "ajv";
-import { compileForbidRegex, warnReservedContractFields, warnReservedPolicyFields } from "./policy-compiler.mjs";
+import {
+  compileAnchorPolicy,
+  compileChangeTypePolicy,
+  compileForbidRegex,
+  compileNewFilePolicy,
+  compileSurfacePolicy,
+  warnReservedContractFields,
+  warnReservedPolicyFields,
+} from "./policy-compiler.mjs";
 import {
   resolveEnforcementMode,
 } from "./enforcement.mjs";
@@ -169,12 +177,20 @@ function runValidate(roots, args) {
   let ok = true;
   ok = validate(ajv, policySchema, policy, "repo-policy.json") && ok;
 
-  const regexErrors = compileForbidRegex(policy.content_rules);
-  if (regexErrors.length > 0) {
+  const compileGroups = [
+    ["forbid_regex compilation", compileForbidRegex(policy.content_rules), (e) => `[${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`],
+    ["surface policy compilation", compileSurfacePolicy(policy), (e) => e.message],
+    ["new file policy compilation", compileNewFilePolicy(policy), (e) => e.message],
+    ["change type policy compilation", compileChangeTypePolicy(policy), (e) => e.message],
+    ["anchor policy compilation", compileAnchorPolicy(policy), (e) => e.message],
+  ];
+
+  for (const [label, errors, format] of compileGroups) {
+    if (errors.length === 0) continue;
     ok = false;
-    console.error("FAIL: forbid_regex compilation");
-    for (const e of regexErrors) {
-      console.error(`  [${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`);
+    console.error(`FAIL: ${label}`);
+    for (const error of errors) {
+      console.error(`  ${format(error)}`);
     }
   }
 

--- a/src/runtime/validation.mjs
+++ b/src/runtime/validation.mjs
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import Ajv from "ajv";
 import { ajvErrors } from "../enforcement.mjs";
 import {
+  compileAnchorPolicy,
   compileForbidRegex,
   compileNewFilePolicy,
   compileChangeTypePolicy,
@@ -58,6 +59,7 @@ export function loadPolicyRuntime(roots, options = {}) {
     ["surface policy compilation", compileSurfacePolicy(policy), (e) => e.message],
     ["new file policy compilation", compileNewFilePolicy(policy), (e) => e.message],
     ["change type policy compilation", compileChangeTypePolicy(policy), (e) => e.message],
+    ["anchor policy compilation", compileAnchorPolicy(policy), (e) => e.message],
   ];
 
   for (const [label, errors, format] of compileGroups) {

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  compileAnchorPolicy,
   compileForbidRegex,
   compileNewFilePolicy,
   compileSurfacePolicy,
@@ -200,6 +201,112 @@ describe("new file policy compilation", () => {
         },
       },
     });
+    assert.equal(errors.length, 0);
+  });
+});
+
+describe("anchor policy compilation", () => {
+  it("accepts declared anchor types and trace rule references", () => {
+    const errors = compileAnchorPolicy({
+      anchors: {
+        types: {
+          requirement_id: {
+            sources: [
+              { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+            ],
+          },
+          code_req_ref: {
+            sources: [
+              { kind: "regex", glob: "src/**", pattern: "@req\\s+((BR|SR)-[0-9]{3})" },
+            ],
+          },
+        },
+      },
+      trace_rules: [
+        {
+          id: "code-refs-must-resolve",
+          kind: "must_resolve",
+          from_anchor_type: "code_req_ref",
+          to_anchor_type: "requirement_id",
+        },
+      ],
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it("rejects trace rules that reference unknown anchor types", () => {
+    const errors = compileAnchorPolicy({
+      anchors: {
+        types: {
+          requirement_id: {
+            sources: [
+              { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+            ],
+          },
+        },
+      },
+      trace_rules: [
+        {
+          id: "code-refs-must-resolve",
+          kind: "must_resolve",
+          from_anchor_type: "code_req_ref",
+          to_anchor_type: "missing_requirement_id",
+        },
+      ],
+    });
+    assert.equal(errors.length, 2);
+    assert.ok(errors.some((e) => e.message.includes("code_req_ref")));
+    assert.ok(errors.some((e) => e.message.includes("missing_requirement_id")));
+  });
+
+  it("rejects duplicate trace rule ids", () => {
+    const errors = compileAnchorPolicy({
+      anchors: {
+        types: {
+          requirement_id: {
+            sources: [
+              { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+            ],
+          },
+        },
+      },
+      trace_rules: [
+        {
+          id: "code-refs-must-resolve",
+          kind: "must_resolve",
+          from_anchor_type: "requirement_id",
+          to_anchor_type: "requirement_id",
+        },
+        {
+          id: "code-refs-must-resolve",
+          kind: "must_resolve",
+          from_anchor_type: "requirement_id",
+          to_anchor_type: "requirement_id",
+        },
+      ],
+    });
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("duplicates"));
+  });
+
+  it("rejects invalid regex extractor patterns", () => {
+    const errors = compileAnchorPolicy({
+      anchors: {
+        types: {
+          code_req_ref: {
+            sources: [
+              { kind: "regex", glob: "src/**", pattern: "[bad" },
+            ],
+          },
+        },
+      },
+    });
+    assert.equal(errors.length, 1);
+    assert.ok(errors[0].message.includes("pattern is invalid"));
+  });
+
+  it("keeps policies without anchors and trace_rules compatible", () => {
+    const errors = compileAnchorPolicy({});
     assert.equal(errors.length, 0);
   });
 });

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -41,6 +41,33 @@ expect("invalid-policy.json fails schema", validatePolicy(invalidPolicy), false)
 const repoPolicy = loadJSON(resolve(root, "repo-policy.json"));
 expect("repo-policy.json (self) passes schema", validatePolicy(repoPolicy), true);
 
+const policyWithAnchors = {
+  ...validPolicy,
+  anchors: {
+    types: {
+      requirement_id: {
+        sources: [
+          { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+        ],
+      },
+      code_req_ref: {
+        sources: [
+          { kind: "regex", glob: "src/**", pattern: "@req\\s+((BR|SR|FR|NFR|CR|IR)-[0-9]{3})" },
+        ],
+      },
+    },
+  },
+  trace_rules: [
+    {
+      id: "code-refs-must-resolve",
+      kind: "must_resolve",
+      from_anchor_type: "code_req_ref",
+      to_anchor_type: "requirement_id",
+    },
+  ],
+};
+expect("policy with anchors and trace_rules passes schema", validatePolicy(policyWithAnchors), true);
+
 // Content rules normalization tests
 const oldFormPolicy = loadJSON(resolve(root, "tests/fixtures/invalid-content-rule-old-form.json"));
 expect("old-form content_rules (pattern/severity/message) fails schema", validatePolicy(oldFormPolicy), false);
@@ -48,6 +75,20 @@ expect("old-form content_rules (pattern/severity/message) fails schema", validat
 // Operational paths validation tests
 const invalidOpPaths = loadJSON(resolve(root, "tests/fixtures/invalid-operational-paths.json"));
 expect("invalid operational_paths (string instead of array) fails schema", validatePolicy(invalidOpPaths), false);
+
+const invalidAnchorPolicy = {
+  ...validPolicy,
+  anchors: {
+    types: {
+      requirement_id: {
+        sources: [
+          { kind: "json_field", glob: "requirements/**/*.json", pattern: "id" },
+        ],
+      },
+    },
+  },
+};
+expect("invalid json_field anchor source fails schema", validatePolicy(invalidAnchorPolicy), false);
 
 const missingAllowClassesPolicy = {
   change_classes: ["kernel-hardening"],


### PR DESCRIPTION
## Summary
- add optional repo-policy anchors and trace_rules schema sections for json_field and regex anchor sources
- add compile-time anchor policy validation for invalid regex extractors, duplicate trace rule ids, and unknown anchor type references
- wire anchor policy compilation into runtime validation, repo-guard validate, and doctor checks

Fixes netkeep80/repo-guard#49

## Reproduce
Before this change, a repo-policy containing anchors and trace_rules failed schema validation because those top-level sections were rejected as additional properties.

## Tests
- npm run test:schemas
- npm run test:hardening
- npm test

## repo-guard contract
```repo-guard-yaml
change_type: feature
scope:
  - schemas/repo-policy.schema.json
  - src/policy-compiler.mjs
  - src/runtime/validation.mjs
  - src/repo-guard.mjs
  - src/doctor.mjs
  - tests/validate-schemas.mjs
  - tests/test-hardening.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
must_touch:
  - schemas/repo-policy.schema.json
  - src/policy-compiler.mjs
  - tests/validate-schemas.mjs
  - tests/test-hardening.mjs
must_not_touch: []
expected_effects:
  - repo-policy schema accepts optional anchors and trace_rules sections
  - policy compilation rejects unknown trace anchor references and invalid regex extractor patterns
```