### PR TITLE
Add anchor intent to change contracts

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-contract.yml
+++ b/.github/ISSUE_TEMPLATE/change-contract.yml
@@ -25,6 +25,13 @@ body:
         scope:
           - src/
         budgets: {}
+        anchors:
+          affects:
+            - FR-014
+          implements:
+            - FR-014
+          verifies:
+            - FR-014
         must_touch: []
         must_not_touch: []
         expected_effects:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,13 @@ change_class: kernel-hardening
 scope:
   - src/
 budgets: {}
+anchors:
+  affects:
+    - FR-014
+  implements:
+    - FR-014
+  verifies:
+    - FR-014
 must_touch: []
 must_not_touch: []
 expected_effects:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T19:38:40.261Z for PR creation at branch issue-50-d9605ccde2fc for issue https://github.com/netkeep80/repo-guard/issues/50

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T19:38:40.261Z for PR creation at branch issue-50-d9605ccde2fc for issue https://github.com/netkeep80/repo-guard/issues/50

--- a/README.md
+++ b/README.md
@@ -477,6 +477,13 @@ surface_debt:
     max_new_files: 1
     max_net_added_lines: 60
   repayment_issue: 123
+anchors:
+  affects:
+    - FR-014
+  implements:
+    - FR-014
+  verifies:
+    - FR-014
 must_touch:
   - src/pagination.mjs
 must_not_touch:
@@ -487,7 +494,7 @@ expected_effects:
 ```
 ````
 
-Contract говорит: это bugfix, который должен затронуть `src/pagination.mjs`, не должен трогать схемы и policy, и не должен создавать новых файлов. Если diff всё же временно увеличивает поверхность репозитория, `surface_debt` фиксирует причину, ожидаемый рост и issue, где долг будет погашен.
+Contract говорит: это bugfix, который должен затронуть `src/pagination.mjs`, не должен трогать схемы и policy, и не должен создавать новых файлов. Опциональный `anchors` фиксирует intent на уровне требований или других якорей: какие anchors изменение affects, implements и verifies. Если diff всё же временно увеличивает поверхность репозитория, `surface_debt` фиксирует причину, ожидаемый рост и issue, где долг будет погашен.
 
 `surface_debt` проверяется только когда contract явно его объявляет. Проверка сравнивает declaration с фактическим ростом diff: количеством новых файлов и `added - deleted` строк. Если рост есть, но `surface_debt` не объявлен, repo-guard сообщает не блокирующий статус `undeclared`; если фактический рост больше `expected_delta`, статус будет `declared_debt_exceeded`; если нет `repayment_issue`, статус будет `missing_repayment_target`.
 
@@ -971,6 +978,7 @@ The self-hosted governance surface is declared in `repo-policy.json` under `path
 
 - `governance_paths` — информационное поле, не проверяется в runtime. Документирует, какие файлы управляют governance.
 - `public_api` — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
+- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой, но runtime extraction/enforcement для anchors зарезервирован для будущих версий.
 - `overrides` (в change contract) — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
 - `repo-guard` пока не публикует комментарии к PR.
 - Паттерны `forbid_regex` компилируются и проверяются до начала enforcement — ошибки в regex выявляются на этапе загрузки policy.

--- a/schemas/change-contract.schema.json
+++ b/schemas/change-contract.schema.json
@@ -81,6 +81,28 @@
         }
       }
     },
+    "anchors": {
+      "type": "object",
+      "description": "Optional declared anchor intent for the change. Accepted as contract metadata; runtime enforcement is reserved for future versions.",
+      "additionalProperties": false,
+      "properties": {
+        "affects": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "implements": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "verifies": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
     "must_touch": {
       "type": "array",
       "items": { "type": "string" },

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -104,6 +104,13 @@ change_class: kernel-hardening
 scope:
   - src/
 budgets: {}
+anchors:
+  affects:
+    - FR-014
+  implements:
+    - FR-014
+  verifies:
+    - FR-014
 must_touch: []
 must_not_touch: []
 expected_effects:
@@ -140,6 +147,13 @@ body:
         scope:
           - src/
         budgets: {}
+        anchors:
+          affects:
+            - FR-014
+          implements:
+            - FR-014
+          verifies:
+            - FR-014
         must_touch: []
         must_not_touch: []
         expected_effects:

--- a/templates/issue-contract-example.md
+++ b/templates/issue-contract-example.md
@@ -19,6 +19,13 @@ surface_debt:
     max_new_files: 1
     max_net_added_lines: 80
   repayment_issue: 456
+anchors:
+  affects:
+    - FR-014
+  implements:
+    - FR-014
+  verifies:
+    - FR-014
 must_touch:
   - src/auth.mjs
 must_not_touch:

--- a/templates/pr-contract-example.md
+++ b/templates/pr-contract-example.md
@@ -18,6 +18,13 @@ surface_debt:
     max_new_files: 1
     max_net_added_lines: 60
   repayment_issue: 123
+anchors:
+  affects:
+    - FR-014
+  implements:
+    - FR-014
+  verifies:
+    - FR-014
 must_touch:
   - src/pagination.mjs
 must_not_touch:

--- a/tests/test-markdown-contract.mjs
+++ b/tests/test-markdown-contract.mjs
@@ -57,6 +57,49 @@ Some description here.
 More text after.
 `;
 
+const yamlAnchorsMarkdown = `
+## My PR
+
+\`\`\`repo-guard-yaml
+change_type: feature
+scope:
+  - src/app.mjs
+budgets: {}
+anchors:
+  affects:
+    - FR-014
+  implements:
+    - FR-014
+  verifies:
+    - FR-014
+must_touch:
+  - src/app.mjs
+must_not_touch: []
+expected_effects:
+  - Implement anchor-aware contracts
+\`\`\`
+`;
+
+const jsonAnchorsMarkdown = `
+## My PR
+
+\`\`\`repo-guard-json
+{
+  "change_type": "feature",
+  "scope": ["src/app.mjs"],
+  "budgets": {},
+  "anchors": {
+    "affects": ["FR-014"],
+    "implements": ["FR-014"],
+    "verifies": ["FR-014"]
+  },
+  "must_touch": ["src/app.mjs"],
+  "must_not_touch": [],
+  "expected_effects": ["Implement anchor-aware contracts"]
+}
+\`\`\`
+`;
+
 {
   const result = extractContract(validMarkdown);
   expect("valid markdown: ok", result.ok, true);
@@ -82,6 +125,22 @@ More text after.
   const result = extractContract(validJsonMarkdown);
   expect("valid JSON markdown remains supported: ok", result.ok, true);
   expect("valid JSON markdown remains supported: change_type", result.contract?.change_type, "bugfix");
+}
+
+{
+  const result = extractContract(yamlAnchorsMarkdown);
+  expect("YAML markdown with anchors remains supported: ok", result.ok, true);
+  expect("YAML markdown with anchors: affects", result.contract?.anchors?.affects?.join(","), "FR-014");
+  expect("YAML markdown with anchors: implements", result.contract?.anchors?.implements?.join(","), "FR-014");
+  expect("YAML markdown with anchors: verifies", result.contract?.anchors?.verifies?.join(","), "FR-014");
+}
+
+{
+  const result = extractContract(jsonAnchorsMarkdown);
+  expect("JSON markdown with anchors remains supported: ok", result.ok, true);
+  expect("JSON markdown with anchors: affects", result.contract?.anchors?.affects?.join(","), "FR-014");
+  expect("JSON markdown with anchors: implements", result.contract?.anchors?.implements?.join(","), "FR-014");
+  expect("JSON markdown with anchors: verifies", result.contract?.anchors?.verifies?.join(","), "FR-014");
 }
 
 {

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -523,6 +523,49 @@ console.log("\n--- check-diff reports surface debt status in JSON output ---");
   rmSync(repo.dir, { recursive: true });
 }
 
+console.log("\n--- check-diff reports anchor contract schema errors in JSON output ---");
+{
+  const contract = {
+    change_type: "feature",
+    scope: ["src/**"],
+    budgets: {},
+    anchors: {
+      affects: ["FR-014", "FR-014"],
+    },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["Anchor intent should be unique"],
+  };
+  const repo = makeSurfaceDebtRepo(contract);
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+    "--contract", repo.contractPath,
+  ]);
+
+  expect("malformed anchor contract exit code", result.code, 1);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("malformed anchor contract stdout is valid json", true, true);
+  } catch (e) {
+    expect("malformed anchor contract stdout is valid json", e.message, "valid json");
+  }
+  const contractViolation = parsed?.violations.find((v) => v.rule === "change-contract");
+  expect("anchor contract violation is present", Boolean(contractViolation), true);
+  expect("anchor contract error points to anchors",
+    contractViolation?.errors.some((error) => error.includes("/anchors/affects")),
+    true);
+  expect("anchor contract error reports duplicate items",
+    contractViolation?.errors.some((error) => error.includes("duplicate")),
+    true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
 console.log("\n--- check-diff evaluates registry_rules in JSON output ---");
 {
   const repo = makeRegistryRepo();

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -109,6 +109,16 @@ expect("new_file_rules without allow_classes fails schema", validatePolicy(missi
 const validContract = loadJSON(resolve(root, "tests/fixtures/valid-contract.json"));
 expect("valid-contract.json passes schema", validateContract(validContract), true);
 
+const contractWithAnchors = {
+  ...validContract,
+  anchors: {
+    affects: ["FR-014"],
+    implements: ["FR-014"],
+    verifies: ["FR-014"],
+  },
+};
+expect("contract with anchor intent passes schema", validateContract(contractWithAnchors), true);
+
 const repositoryTypedContract = {
   ...validContract,
   change_type: "governance",
@@ -117,6 +127,31 @@ expect("repository-specific change_type passes schema", validateContract(reposit
 
 const invalidContract = loadJSON(resolve(root, "tests/fixtures/invalid-contract.json"));
 expect("invalid-contract.json fails schema", validateContract(invalidContract), false);
+
+const malformedAnchorContract = {
+  ...validContract,
+  anchors: {
+    affects: ["FR-014", "FR-014"],
+  },
+};
+expect("contract with duplicate anchor intent fails schema", validateContract(malformedAnchorContract), false);
+
+const unknownAnchorFieldContract = {
+  ...validContract,
+  anchors: {
+    affects: ["FR-014"],
+    notes: ["reserved for a future schema version"],
+  },
+};
+expect("contract with unknown anchor field fails schema", validateContract(unknownAnchorFieldContract), false);
+
+const nonStringAnchorContract = {
+  ...validContract,
+  anchors: {
+    verifies: ["FR-014", 14],
+  },
+};
+expect("contract with non-string anchor intent fails schema", validateContract(nonStringAnchorContract), false);
 
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- extend `change-contract.schema.json` with optional `anchors.affects`, `anchors.implements`, and `anchors.verifies` intent arrays
- keep unknown/malformed anchor fields rejected by schema while leaving runtime enforcement out of scope
- update contract examples, init templates, and tests for YAML/JSON extraction plus structured validation output

Fixes netkeep80/repo-guard#50

## Reproduce
Before this change, a change contract containing an `anchors` section failed schema validation because `anchors` was rejected as an additional top-level property.

## Tests
- `npm run test:schemas`
- `npm run test:contract`
- `npm run test:structured-output`
- `npm test`
- `npm run validate`
- package smoke: `npm pack`, install the tarball into a temp prefix, and run the installed `repo-guard` against this repo
- local ready-PR simulation: `node src/repo-guard.mjs --enforcement blocking check-diff --base upstream/main --head HEAD --contract <temp-contract>`

## repo-guard contract

```repo-guard-yaml
change_type: feature
scope:
  - schemas/change-contract.schema.json
  - tests/validate-schemas.mjs
  - tests/test-markdown-contract.mjs
  - tests/test-structured-output.mjs
  - README.md
  - templates/
  - .github/
  - src/init.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 300
anchors:
  affects:
    - FR-014
  implements:
    - FR-014
  verifies:
    - FR-014
must_touch:
  - schemas/change-contract.schema.json
must_not_touch:
  - LICENSE
expected_effects:
  - change-contract schema accepts optional anchor intent.
  - malformed anchor intent fails schema validation with anchor-specific structured errors.
  - YAML and JSON markdown contract extraction preserve anchor fields.
```
