### PR TITLE
Implement anchor extraction facts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Run hardening tests
         run: npm run test:hardening
 
+      - name: Run anchor extraction tests
+        run: npm run test:anchors
+
       - name: Run repo-root separation tests
         run: npm run test:repo-root
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T19:53:57.454Z for PR creation at branch issue-52-f98ec23457a6 for issue https://github.com/netkeep80/repo-guard/issues/52

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T19:53:57.454Z for PR creation at branch issue-52-f98ec23457a6 for issue https://github.com/netkeep80/repo-guard/issues/52

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Policy engine для репозитория: формализует правил
 | New file rules | Проверяет классы новых файлов и per-class бюджеты для объявленного `change_class` |
 | Co-change rules | Если изменён X, должен быть изменён и Y |
 | Surface matrix | Проверяет, что объявленный `change_class` трогает только разрешённые surface-классы |
+| Anchor extraction | Извлекает anchor facts из настроенных `regex` и `json_field` sources |
 | Content rules | Запрещает regex-паттерны в добавленных строках |
 | must_touch | Хотя бы один из указанных паттернов должен совпасть с изменённым файлом (из contract) |
 | must_not_touch | Ни один из указанных паттернов не должен совпасть с изменённым файлом (из contract) |
@@ -527,6 +528,33 @@ Summary: 9 passed, 0 failed (mode: blocking; violations enforced)
 Result: passed (mode: blocking; exit code 0)
 ```
 
+### Anchor Extraction
+
+`anchors` в `repo-policy.json` задают типы якорей и источники, из которых repo-guard строит нормализованные facts перед проверками. Runtime v1 поддерживает два extractor kind:
+
+```json
+{
+  "anchors": {
+    "types": {
+      "requirement_id": {
+        "sources": [
+          { "kind": "json_field", "glob": "requirements/**/*.json", "field": "id" }
+        ]
+      },
+      "code_req_ref": {
+        "sources": [
+          { "kind": "regex", "glob": "src/**", "pattern": "@req\\s+((FR|SR)-[0-9]{3})" }
+        ]
+      }
+    }
+  }
+}
+```
+
+`json_field` читает top-level JSON field и нормализует scalar value в строку. `regex` сканирует matching files и, если pattern содержит capture group, берёт value из первого matched group; без capture group value равен полной matched строке. Каждый instance содержит `anchorType`, `value`, `file`, `sourceKind`, а regex instances также получают `line`, `column`, `captureGroup` и `raw`.
+
+Anchor extraction работает по tracked repository files и по changed files из diff, чтобы global requirement IDs и новые references были доступны в одной facts model. Если JSON не парсится, field отсутствует или source file не читается, check `anchor-extraction` завершается `FAIL` с диагностикой вида `[requirement_id json_field source 0] requirements/fr-001.json: field "id" not found`.
+
 ### 4. Пример failure
 
 Если в PR затронут файл `schemas/repo-policy.schema.json`, который указан в `must_not_touch`:
@@ -978,7 +1006,7 @@ The self-hosted governance surface is declared in `repo-policy.json` under `path
 
 - `governance_paths` — информационное поле, не проверяется в runtime. Документирует, какие файлы управляют governance.
 - `public_api` — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
-- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой, но runtime extraction/enforcement для anchors зарезервирован для будущих версий.
+- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой, но runtime trace enforcement для anchors зарезервирован для будущих версий.
 - `overrides` (в change contract) — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
 - `repo-guard` пока не публикует комментарии к PR.
 - Паттерны `forbid_regex` компилируются и проверяются до начала enforcement — ошибки в regex выявляются на этапе загрузки policy.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
+    "test:anchors": "node tests/test-anchor-extractors.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
     "test:diff": "node tests/test-diff-rules.mjs",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -272,7 +272,7 @@
     },
     "anchors": {
       "type": "object",
-      "description": "Named anchor types and extractors used as shared trace vocabulary. Runtime extraction is reserved for future versions.",
+      "description": "Named anchor types and extractors used as shared trace vocabulary. Runtime extraction records normalized anchor facts; trace enforcement is reserved for future versions.",
       "required": ["types"],
       "additionalProperties": false,
       "properties": {

--- a/src/checks/orchestrator.mjs
+++ b/src/checks/orchestrator.mjs
@@ -14,6 +14,7 @@ import {
   checkRegistryRules,
   checkAdvisoryTextRules,
 } from "../diff-checker.mjs";
+import { checkAnchorExtraction } from "../extractors/anchors.mjs";
 
 export function runPolicyChecks(facts, reporter) {
   const policy = facts.policy;
@@ -49,6 +50,9 @@ export function runPolicyChecks(facts, reporter) {
       allFiles: facts.trackedFiles,
     })
   );
+  if (policy.anchors) {
+    reporter.report("anchor-extraction", checkAnchorExtraction(facts.anchors));
+  }
 
   if (policy.change_type_rules) {
     reporter.report("change-type-rules", checkChangeTypeRules(files, policy, contract?.change_type));

--- a/src/extractors/anchors.mjs
+++ b/src/extractors/anchors.mjs
@@ -1,0 +1,217 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { minimatch } from "minimatch";
+
+function matchesAny(filePath, patterns) {
+  return patterns.some((pattern) => minimatch(filePath, pattern, { dot: true }));
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function readRepositoryFile(filePath, options) {
+  if (options.readFile) {
+    const content = options.readFile(filePath);
+    if (content === undefined || content === null) {
+      throw new Error(`cannot read ${filePath}`);
+    }
+    return String(content);
+  }
+  return readFileSync(resolve(options.repoRoot || process.cwd(), filePath), "utf-8");
+}
+
+function candidateAnchorFiles(options) {
+  const changedPaths = (options.changedFiles || [])
+    .filter((file) => file.status !== "deleted")
+    .map((file) => file.path);
+  return uniqueSorted([...(options.trackedFiles || []), ...changedPaths].filter(Boolean));
+}
+
+function buildLineStarts(content) {
+  const starts = [0];
+  for (let i = 0; i < content.length; i++) {
+    if (content[i] === "\n") starts.push(i + 1);
+  }
+  return starts;
+}
+
+function positionAt(lineStarts, index) {
+  let low = 0;
+  let high = lineStarts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (lineStarts[mid] <= index) low = mid + 1;
+    else high = mid - 1;
+  }
+  const lineIndex = Math.max(0, high);
+  return {
+    line: lineIndex + 1,
+    column: index - lineStarts[lineIndex] + 1,
+  };
+}
+
+function makeRegex(pattern) {
+  const compiled = new RegExp(pattern);
+  let flags = compiled.flags;
+  for (const flag of ["g", "d"]) {
+    if (!flags.includes(flag)) flags += flag;
+  }
+  return new RegExp(compiled.source, flags);
+}
+
+function firstDefinedCapture(match) {
+  for (let i = 1; i < match.length; i++) {
+    if (match[i] !== undefined) return i;
+  }
+  return null;
+}
+
+function extractRegexAnchors(anchorType, source, file, content) {
+  const instances = [];
+  const regex = makeRegex(source.pattern);
+  const lineStarts = buildLineStarts(content);
+
+  for (const match of content.matchAll(regex)) {
+    const captureGroup = firstDefinedCapture(match);
+    const value = captureGroup ? match[captureGroup] : match[0];
+    const index = captureGroup && match.indices?.[captureGroup]
+      ? match.indices[captureGroup][0]
+      : match.index;
+    const position = positionAt(lineStarts, index);
+    const instance = {
+      anchorType,
+      value: String(value),
+      file,
+      sourceKind: "regex",
+      line: position.line,
+      column: position.column,
+      raw: match[0],
+    };
+
+    if (captureGroup) instance.captureGroup = captureGroup;
+    instances.push(instance);
+  }
+
+  return instances;
+}
+
+function extractJsonFieldAnchor(anchorType, source, file, content) {
+  let data;
+  try {
+    data = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`invalid JSON: ${e.message}`);
+  }
+  if (data === null || Array.isArray(data) || typeof data !== "object") {
+    throw new Error("json_field extractor requires a top-level JSON object");
+  }
+  if (!Object.hasOwn(data, source.field)) {
+    throw new Error(`field "${source.field}" not found`);
+  }
+
+  const value = data[source.field];
+  if (value === null || typeof value === "object") {
+    throw new Error(`field "${source.field}" must be a string, number, or boolean`);
+  }
+
+  return [{
+    anchorType,
+    value: String(value),
+    file,
+    sourceKind: "json_field",
+    raw: String(value),
+  }];
+}
+
+function compareInstances(a, b) {
+  return a.file.localeCompare(b.file) ||
+    (a.line || 0) - (b.line || 0) ||
+    (a.column || 0) - (b.column || 0) ||
+    a.anchorType.localeCompare(b.anchorType) ||
+    a.value.localeCompare(b.value);
+}
+
+function compareErrors(a, b) {
+  return (a.file || "").localeCompare(b.file || "") ||
+    a.anchorType.localeCompare(b.anchorType) ||
+    a.sourceIndex - b.sourceIndex ||
+    a.message.localeCompare(b.message);
+}
+
+function groupByType(anchorTypes, instances) {
+  const byType = {};
+  for (const anchorType of Object.keys(anchorTypes).sort()) {
+    byType[anchorType] = [];
+  }
+  for (const instance of instances) {
+    if (!byType[instance.anchorType]) byType[instance.anchorType] = [];
+    byType[instance.anchorType].push(instance);
+  }
+  return byType;
+}
+
+export function extractAnchors(policy, options = {}) {
+  const anchorTypes = policy.anchors?.types || {};
+  const files = candidateAnchorFiles(options);
+  const instances = [];
+  const errors = [];
+  const contentCache = new Map();
+
+  function contentFor(file) {
+    if (!contentCache.has(file)) {
+      contentCache.set(file, readRepositoryFile(file, options));
+    }
+    return contentCache.get(file);
+  }
+
+  for (const [anchorType, config] of Object.entries(anchorTypes)) {
+    for (const [sourceIndex, source] of (config.sources || []).entries()) {
+      const sourceFiles = files.filter((file) => matchesAny(file, [source.glob]));
+      for (const file of sourceFiles) {
+        try {
+          const content = contentFor(file);
+          if (source.kind === "regex") {
+            instances.push(...extractRegexAnchors(anchorType, source, file, content));
+          } else if (source.kind === "json_field") {
+            instances.push(...extractJsonFieldAnchor(anchorType, source, file, content));
+          } else {
+            throw new Error(`unsupported anchor source kind "${source.kind}"`);
+          }
+        } catch (e) {
+          errors.push({
+            anchorType,
+            sourceKind: source.kind,
+            sourceIndex,
+            file,
+            message: e.message,
+          });
+        }
+      }
+    }
+  }
+
+  instances.sort(compareInstances);
+  errors.sort(compareErrors);
+
+  return {
+    instances,
+    byType: groupByType(anchorTypes, instances),
+    errors,
+  };
+}
+
+export function formatAnchorExtractionError(error) {
+  const source = `${error.sourceKind} source ${error.sourceIndex}`;
+  const file = error.file ? `${error.file}: ` : "";
+  return `[${error.anchorType} ${source}] ${file}${error.message}`;
+}
+
+export function checkAnchorExtraction(anchorExtraction) {
+  const errors = anchorExtraction?.errors || [];
+  return {
+    ok: errors.length === 0,
+    message: errors.length > 0 ? "anchor extraction failed" : undefined,
+    errors: errors.map(formatAnchorExtractionError),
+  };
+}

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -5,6 +5,7 @@ import {
   detectTouchedSurfaces,
   classifyNewFiles,
 } from "../diff-checker.mjs";
+import { extractAnchors } from "../extractors/anchors.mjs";
 
 export function listTrackedFiles(repoRoot) {
   return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
@@ -23,6 +24,7 @@ export function buildPolicyFacts({
   trackedFiles = null,
   declaredChangeClass = null,
   diagnostics = {},
+  readFile = null,
 }) {
   const allFiles = parseDiff(diffText);
   const checkedFiles = filterOperationalPaths(allFiles, policy.paths.operational_paths);
@@ -35,6 +37,12 @@ export function buildPolicyFacts({
   const newFileClasses = policy.new_file_classes
     ? classifyNewFiles(checkedFiles, policy.new_file_classes)
     : null;
+  const anchors = extractAnchors(policy, {
+    repoRoot: repositoryRoot,
+    trackedFiles: resolvedTrackedFiles,
+    changedFiles: checkedFiles,
+    readFile,
+  });
 
   return {
     mode,
@@ -51,6 +59,7 @@ export function buildPolicyFacts({
         skippedOperational: skippedOperationalFiles,
       },
     },
+    anchors,
     trackedFiles: resolvedTrackedFiles,
     derived: {
       changedPaths,

--- a/tests/test-anchor-extractors.mjs
+++ b/tests/test-anchor-extractors.mjs
@@ -1,0 +1,222 @@
+import { strict as assert } from "node:assert";
+import { buildPolicyFacts } from "../src/facts/input.mjs";
+import { extractAnchors } from "../src/extractors/anchors.mjs";
+import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (e) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, value, substring) {
+  const actual = String(value || "");
+  const passed = actual.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected ${JSON.stringify(actual)} to include ${JSON.stringify(substring)}`);
+  }
+}
+
+function makeReadFile(files) {
+  return (file) => {
+    if (!Object.hasOwn(files, file)) {
+      throw new Error(`missing fixture ${file}`);
+    }
+    return files[file];
+  };
+}
+
+function makePolicy(anchorTypes) {
+  return {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      operational_paths: [],
+      governance_paths: [],
+    },
+    diff_rules: {
+      max_new_docs: 10,
+      max_new_files: 10,
+      max_net_added_lines: 1000,
+    },
+    anchors: {
+      types: anchorTypes,
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+}
+
+console.log("\n--- anchor extractors return normalized instances ---");
+{
+  const policy = makePolicy({
+    requirement_id: {
+      sources: [
+        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+      ],
+    },
+    code_req_ref: {
+      sources: [
+        { kind: "regex", glob: "src/**", pattern: "@req\\s+((FR|SR)-[0-9]{3})" },
+      ],
+    },
+  });
+  const files = {
+    "requirements/fr-001.json": JSON.stringify({ id: "FR-001", title: "Login" }),
+    "src/feature.mjs": "export function feature() {} // @req FR-001\n// @req SR-002\n",
+  };
+
+  const extraction = extractAnchors(policy, {
+    repoRoot: "/tmp/repo",
+    trackedFiles: Object.keys(files),
+    readFile: makeReadFile(files),
+  });
+
+  expect("extractors produce no errors", extraction.errors, []);
+  expect("extractors group instances by anchor type", Object.keys(extraction.byType).sort(), [
+    "code_req_ref",
+    "requirement_id",
+  ]);
+
+  const requirement = extraction.instances.find((instance) => instance.anchorType === "requirement_id");
+  expect("json_field instance is normalized", requirement, {
+    anchorType: "requirement_id",
+    value: "FR-001",
+    file: "requirements/fr-001.json",
+    sourceKind: "json_field",
+    raw: "FR-001",
+  });
+
+  const codeRef = extraction.instances.find((instance) =>
+    instance.anchorType === "code_req_ref" && instance.value === "FR-001"
+  );
+  expect("regex instance uses first capture group as value", {
+    anchorType: codeRef?.anchorType,
+    value: codeRef?.value,
+    file: codeRef?.file,
+    sourceKind: codeRef?.sourceKind,
+    captureGroup: codeRef?.captureGroup,
+    raw: codeRef?.raw,
+    line: codeRef?.line,
+  }, {
+    anchorType: "code_req_ref",
+    value: "FR-001",
+    file: "src/feature.mjs",
+    sourceKind: "regex",
+    captureGroup: 1,
+    raw: "@req FR-001",
+    line: 1,
+  });
+  expect("regex extractor reports one-based column for captured value", codeRef?.column > 1, true);
+}
+
+console.log("\n--- normalized facts include repository and changed anchor files ---");
+{
+  const policy = makePolicy({
+    requirement_id: {
+      sources: [
+        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+      ],
+    },
+    test_req_ref: {
+      sources: [
+        { kind: "regex", glob: "tests/**", pattern: "\\[REQ-([0-9]+)\\]" },
+      ],
+    },
+  });
+  const files = {
+    "requirements/req-42.json": JSON.stringify({ id: "REQ-42" }),
+    "tests/new.test.mjs": "test('new behavior [REQ-42]', () => {});\n",
+  };
+  const diffText = [
+    "diff --git a/tests/new.test.mjs b/tests/new.test.mjs",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/tests/new.test.mjs",
+    "+test('new behavior [REQ-42]', () => {});",
+  ].join("\n");
+
+  const facts = buildPolicyFacts({
+    mode: "check-diff",
+    repositoryRoot: "/tmp/repo",
+    policy,
+    contract: null,
+    contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles: ["requirements/req-42.json"],
+    readFile: makeReadFile(files),
+  });
+
+  expect("facts expose anchor instances from tracked and changed files",
+    facts.anchors.instances.map((instance) => `${instance.anchorType}:${instance.file}:${instance.value}`),
+    [
+      "requirement_id:requirements/req-42.json:REQ-42",
+      "test_req_ref:tests/new.test.mjs:42",
+    ]);
+  expect("facts expose anchor extraction errors", facts.anchors.errors, []);
+}
+
+console.log("\n--- anchor extraction errors are predictable and reported by pipeline ---");
+{
+  const policy = makePolicy({
+    requirement_id: {
+      sources: [
+        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+      ],
+    },
+  });
+  const files = {
+    "requirements/bad.json": "{",
+    "requirements/missing.json": JSON.stringify({ title: "No id" }),
+  };
+  const extraction = extractAnchors(policy, {
+    repoRoot: "/tmp/repo",
+    trackedFiles: Object.keys(files),
+    readFile: makeReadFile(files),
+  });
+
+  expect("json_field extractor records both errors", extraction.errors.map((error) => ({
+    anchorType: error.anchorType,
+    sourceKind: error.sourceKind,
+    file: error.file,
+  })), [
+    { anchorType: "requirement_id", sourceKind: "json_field", file: "requirements/bad.json" },
+    { anchorType: "requirement_id", sourceKind: "json_field", file: "requirements/missing.json" },
+  ]);
+  expectIncludes("json parse error is stable", extraction.errors[0]?.message, "invalid JSON");
+  expectIncludes("missing field error identifies the field", extraction.errors[1]?.message, "field \"id\"");
+
+  const result = runPolicyPipeline({
+    mode: "check-diff",
+    repositoryRoot: "/tmp/repo",
+    policy,
+    contract: null,
+    contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText: "",
+    trackedFiles: Object.keys(files),
+    readFile: makeReadFile(files),
+    initialChecks: [],
+  }, { quiet: true });
+
+  const violation = result.violations.find((item) => item.rule === "anchor-extraction");
+  expect("pipeline reports anchor extraction as a policy violation", Boolean(violation), true);
+  expect("pipeline exposes formatted extraction errors",
+    violation?.errors.some((error) => error.includes("requirements/bad.json")),
+    true);
+}
+
+console.log(`\n${failures === 0 ? "All anchor extractor tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- add runtime anchor extraction for policy `regex` and `json_field` sources
- expose normalized anchor instances and extraction errors on the shared facts model
- report malformed anchor extraction through an `anchor-extraction` policy check
- add regression coverage, CI wiring, and README/schema documentation

Fixes netkeep80/repo-guard#52

## Reproduce
Before this change, policies could declare anchor sources, but runtime facts did not extract anchors from repository files or changed files. `regex` capture groups and `json_field` values were therefore unavailable to later anchor-aware checks.

## Tests
- `npm run test:anchors`
- `npm run test:pipeline`
- `npm run test:schemas`
- `npm run test:hardening`
- `npm test`
- `npm run validate`
- `git diff --cached --check`
- package smoke: `npm pack`, install the tarball into a temp prefix, and run the installed `repo-guard` against this repo
- local policy simulation: `node src/repo-guard.mjs --enforcement blocking check-diff --contract <temp-json-contract>`

## repo-guard contract

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - src/extractors/anchors.mjs
  - src/facts/input.mjs
  - src/checks/orchestrator.mjs
  - tests/test-anchor-extractors.mjs
  - package.json
  - .github/workflows/ci.yml
  - schemas/repo-policy.schema.json
  - README.md
  - .gitkeep
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 600
anchors:
  affects:
    - FR-014
  implements:
    - FR-014
  verifies:
    - FR-014
must_touch:
  - src/extractors/anchors.mjs
  - src/facts/input.mjs
  - tests/test-anchor-extractors.mjs
must_not_touch:
  - LICENSE
expected_effects:
  - repo-guard extracts normalized anchor facts from regex and json_field policy sources.
  - anchor extraction reads tracked repository files and changed files in the facts pipeline.
  - malformed anchor sources are reported as anchor-extraction violations.
```
