### PR TITLE
Add anchor-aware structured output diagnostics

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T20:10:09.476Z for PR creation at branch issue-53-d65132f4bcdd for issue https://github.com/netkeep80/repo-guard/issues/53

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T20:10:09.476Z for PR creation at branch issue-53-d65132f4bcdd for issue https://github.com/netkeep80/repo-guard/issues/53

--- a/README.md
+++ b/README.md
@@ -256,7 +256,98 @@ The JSON result is intended as an API surface. Field names are stable and intent
 }
 ```
 
+When `repo-policy.json` declares `anchors`, the JSON result keeps the same
+top-level semantics and adds anchor diagnostics:
+
+```json
+{
+  "anchors": {
+    "detected": [
+      { "anchorType": "requirement_id", "value": "FR-001", "file": "requirements/fr-001.json", "sourceKind": "json_field" }
+    ],
+    "changed": [
+      { "anchorType": "code_req_ref", "value": "FR-999", "file": "src/feature.mjs", "sourceKind": "regex", "line": 4, "column": 9 }
+    ],
+    "declaredByContract": {
+      "affects": ["FR-001"],
+      "implements": ["FR-999"],
+      "verifies": [],
+      "all": [
+        { "relation": "affects", "value": "FR-001" },
+        { "relation": "implements", "value": "FR-999" }
+      ]
+    },
+    "unresolved": [
+      {
+        "rule": "code-refs-must-resolve",
+        "kind": "must_resolve",
+        "fromAnchorType": "code_req_ref",
+        "toAnchorType": "requirement_id",
+        "value": "FR-999",
+        "instances": [
+          { "anchorType": "code_req_ref", "value": "FR-999", "file": "src/feature.mjs", "sourceKind": "regex", "line": 4, "column": 9 }
+        ]
+      }
+    ],
+    "stats": {
+      "detected": 3,
+      "changed": 2,
+      "declaredByContract": 2,
+      "unresolved": 1,
+      "extractionErrors": 0,
+      "byType": {
+        "code_req_ref": { "detected": 2, "changed": 2 },
+        "requirement_id": { "detected": 1, "changed": 0 }
+      }
+    }
+  },
+  "traceRuleResults": [
+    {
+      "id": "code-refs-must-resolve",
+      "kind": "must_resolve",
+      "fromAnchorType": "code_req_ref",
+      "toAnchorType": "requirement_id",
+      "ok": false,
+      "resolved": [
+        {
+          "value": "FR-001",
+          "from": [
+            { "anchorType": "code_req_ref", "value": "FR-001", "file": "src/feature.mjs", "sourceKind": "regex", "line": 2, "column": 24 }
+          ],
+          "to": [
+            { "anchorType": "requirement_id", "value": "FR-001", "file": "requirements/fr-001.json", "sourceKind": "json_field" }
+          ]
+        }
+      ],
+      "unresolved": [
+        {
+          "value": "FR-999",
+          "instances": [
+            { "anchorType": "code_req_ref", "value": "FR-999", "file": "src/feature.mjs", "sourceKind": "regex", "line": 4, "column": 9 }
+          ]
+        }
+      ],
+      "stats": { "fromInstances": 2, "fromValues": 2, "toInstances": 1, "toValues": 1, "resolved": 1, "unresolved": 1 }
+    }
+  ]
+}
+```
+
+`anchors.detected` contains all normalized anchor instances found from tracked
+repository files and changed files. `anchors.changed` is the subset located in
+checked diff files. `anchors.declaredByContract` mirrors contract
+`anchors.affects`, `anchors.implements`, and `anchors.verifies`, with `all` as a
+relation/value list for tooling that does not want to inspect each relation.
+`anchors.unresolved` is an aggregate of unresolved trace diagnostics. In this
+version trace diagnostics are report-only: they do not change `ok`, `result`, or
+`exitCode`.
+
 Exit behavior is unchanged: in `blocking` mode violations exit `1`; in `advisory` mode violations are reported but the command exits `0`. Consumers should read both `ok` and `exitCode`: `ok` describes policy result, while `exitCode` describes command exit semantics for the active enforcement mode.
+
+`--format summary` also includes one concise anchor line when anchors are
+enabled, for example `Anchors: 3 detected, 2 changed, 2 declared, 1 unresolved`.
+When unresolved trace diagnostics exist, the summary adds a short table with the
+rule id, anchor value, and source locations.
 
 Example GitHub Actions usage:
 
@@ -300,6 +391,11 @@ repo-guard check-pr
     }
   },
   trackedFiles: ["README.md"],
+  anchors: {
+    instances: [/* normalized anchor instances */],
+    byType: { /* instances grouped by anchor type */ },
+    errors: [/* extraction diagnostics */]
+  },
   derived: {
     changedPaths: ["src/example.mjs"],
     touchedSurfaces: { /* surface detection result */ } | null,
@@ -554,6 +650,12 @@ Result: passed (mode: blocking; exit code 0)
 `json_field` читает top-level JSON field и нормализует scalar value в строку. `regex` сканирует matching files и, если pattern содержит capture group, берёт value из первого matched group; без capture group value равен полной matched строке. Каждый instance содержит `anchorType`, `value`, `file`, `sourceKind`, а regex instances также получают `line`, `column`, `captureGroup` и `raw`.
 
 Anchor extraction работает по tracked repository files и по changed files из diff, чтобы global requirement IDs и новые references были доступны в одной facts model. Если JSON не парсится, field отсутствует или source file не читается, check `anchor-extraction` завершается `FAIL` с диагностикой вида `[requirement_id json_field source 0] requirements/fr-001.json: field "id" not found`.
+
+Если policy содержит `trace_rules.kind = "must_resolve"`, structured output
+добавляет diagnostic-only `traceRuleResults`: для каждого значения from-anchor
+проверяется наличие matching value среди to-anchor instances. Эти diagnostics
+видны в JSON и summary output, но enforcement для trace rules зарезервирован для
+следующего runtime шага.
 
 ### 4. Пример failure
 
@@ -1006,7 +1108,8 @@ The self-hosted governance surface is declared in `repo-policy.json` under `path
 
 - `governance_paths` — информационное поле, не проверяется в runtime. Документирует, какие файлы управляют governance.
 - `public_api` — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
-- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой, но runtime trace enforcement для anchors зарезервирован для будущих версий.
+- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой и выводится в structured output как `anchors.declaredByContract`, но runtime trace enforcement для anchors зарезервирован для будущих версий.
+- `trace_rules.kind = "must_resolve"` — выводится в structured output как diagnostic-only `traceRuleResults`; unresolved diagnostics не меняют `ok`, `result` или `exitCode`.
 - `overrides` (в change contract) — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
 - `repo-guard` пока не публикует комментарии к PR.
 - Паттерны `forbid_regex` компилируются и проверяются до начала enforcement — ошибки в regex выявляются на этапе загрузки policy.

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -230,6 +230,12 @@ function renderMarkdownTableCell(value) {
     .replaceAll("\n", "<br>");
 }
 
+function formatAnchorLocation(instance) {
+  const line = instance.line ? `:${instance.line}` : "";
+  const column = instance.column ? `:${instance.column}` : "";
+  return `${instance.file}${line}${column}`;
+}
+
 export function createCheckReporter(mode, options = {}) {
   let passed = 0;
   let violations = 0;
@@ -323,6 +329,23 @@ export function renderCheckSummary(result) {
 
   if (result.diff) {
     lines.push(`- Diff: ${result.diff.changedFiles} file(s) changed${result.diff.skippedOperationalFiles ? `, ${result.diff.skippedOperationalFiles} operational skipped` : ""}`);
+  }
+
+  if (result.anchors) {
+    const stats = result.anchors.stats;
+    lines.push(`- Anchors: ${stats.detected} detected, ${stats.changed} changed, ${stats.declaredByContract} declared, ${stats.unresolved} unresolved`);
+
+    if (result.anchors.unresolved.length > 0) {
+      lines.push("", "| Trace rule | Anchor | Locations |", "|---|---|---|");
+      for (const unresolved of result.anchors.unresolved.slice(0, 10)) {
+        const anchor = `${unresolved.fromAnchorType} -> ${unresolved.toAnchorType}: ${unresolved.value}`;
+        const locations = unresolved.instances.map(formatAnchorLocation).join(", ");
+        lines.push(`| ${renderMarkdownTableCell(unresolved.rule)} | ${renderMarkdownTableCell(anchor)} | ${renderMarkdownTableCell(locations)} |`);
+      }
+      if (result.anchors.unresolved.length > 10) {
+        lines.push(`| ... | ... | ${result.anchors.unresolved.length - 10} more unresolved anchor(s) |`);
+      }
+    }
   }
 
   if (result.violations.length > 0) {

--- a/src/reporting/anchor-diagnostics.mjs
+++ b/src/reporting/anchor-diagnostics.mjs
@@ -1,0 +1,162 @@
+const CONTRACT_ANCHOR_FIELDS = ["affects", "implements", "verifies"];
+
+function cloneAnchorInstance(instance) {
+  return { ...instance };
+}
+
+function sortedUnique(values) {
+  return [...new Set((values || []).map((value) => String(value)))].sort();
+}
+
+function groupByValue(instances) {
+  const grouped = new Map();
+  for (const instance of instances || []) {
+    if (!grouped.has(instance.value)) grouped.set(instance.value, []);
+    grouped.get(instance.value).push(cloneAnchorInstance(instance));
+  }
+  return grouped;
+}
+
+function groupByType(anchorTypes, instances) {
+  const byType = {};
+  for (const anchorType of Object.keys(anchorTypes || {}).sort()) {
+    byType[anchorType] = { detected: 0, changed: 0 };
+  }
+  for (const instance of instances.detected) {
+    if (!byType[instance.anchorType]) byType[instance.anchorType] = { detected: 0, changed: 0 };
+    byType[instance.anchorType].detected++;
+  }
+  for (const instance of instances.changed) {
+    if (!byType[instance.anchorType]) byType[instance.anchorType] = { detected: 0, changed: 0 };
+    byType[instance.anchorType].changed++;
+  }
+  return byType;
+}
+
+function declaredContractAnchors(contract) {
+  const contractAnchors = contract?.anchors || {};
+  const declared = {};
+  const all = [];
+
+  for (const field of CONTRACT_ANCHOR_FIELDS) {
+    const values = sortedUnique(contractAnchors[field]);
+    declared[field] = values;
+    for (const value of values) {
+      all.push({ relation: field, value });
+    }
+  }
+
+  declared.all = all;
+  return declared;
+}
+
+function buildMustResolveDiagnostics(rule, anchorExtraction) {
+  const fromInstances = anchorExtraction.byType?.[rule.from_anchor_type] || [];
+  const toInstances = anchorExtraction.byType?.[rule.to_anchor_type] || [];
+  const fromByValue = groupByValue(fromInstances);
+  const toByValue = groupByValue(toInstances);
+  const resolved = [];
+  const unresolved = [];
+
+  for (const value of [...fromByValue.keys()].sort()) {
+    const from = fromByValue.get(value);
+    const to = toByValue.get(value) || [];
+    if (to.length > 0) {
+      resolved.push({ value, from, to });
+    } else {
+      unresolved.push({ value, instances: from });
+    }
+  }
+
+  return {
+    id: rule.id,
+    kind: rule.kind,
+    fromAnchorType: rule.from_anchor_type,
+    toAnchorType: rule.to_anchor_type,
+    ok: unresolved.length === 0,
+    resolved,
+    unresolved,
+    stats: {
+      fromInstances: fromInstances.length,
+      fromValues: fromByValue.size,
+      toInstances: toInstances.length,
+      toValues: toByValue.size,
+      resolved: resolved.length,
+      unresolved: unresolved.length,
+    },
+  };
+}
+
+function buildTraceRuleDiagnostics(policy, anchorExtraction) {
+  return (policy.trace_rules || []).map((rule) => {
+    if (rule.kind === "must_resolve") {
+      return buildMustResolveDiagnostics(rule, anchorExtraction);
+    }
+
+    return {
+      id: rule.id,
+      kind: rule.kind,
+      fromAnchorType: rule.from_anchor_type,
+      toAnchorType: rule.to_anchor_type,
+      ok: true,
+      resolved: [],
+      unresolved: [],
+      stats: {
+        fromInstances: 0,
+        fromValues: 0,
+        toInstances: 0,
+        toValues: 0,
+        resolved: 0,
+        unresolved: 0,
+      },
+    };
+  });
+}
+
+function flattenUnresolved(traceRuleResults) {
+  const unresolved = [];
+  for (const result of traceRuleResults) {
+    for (const item of result.unresolved) {
+      unresolved.push({
+        rule: result.id,
+        kind: result.kind,
+        fromAnchorType: result.fromAnchorType,
+        toAnchorType: result.toAnchorType,
+        value: item.value,
+        instances: item.instances,
+      });
+    }
+  }
+  return unresolved;
+}
+
+export function buildAnchorDiagnostics(facts) {
+  if (!facts.policy.anchors) return {};
+
+  const detected = (facts.anchors?.instances || []).map(cloneAnchorInstance);
+  const changedPaths = new Set(facts.derived.changedPaths || []);
+  const changed = detected
+    .filter((instance) => changedPaths.has(instance.file))
+    .map(cloneAnchorInstance);
+  const declaredByContract = declaredContractAnchors(facts.contract);
+  const traceRuleResults = buildTraceRuleDiagnostics(facts.policy, facts.anchors || {});
+  const unresolved = flattenUnresolved(traceRuleResults);
+
+  return {
+    anchors: {
+      detected,
+      changed,
+      declaredByContract,
+      unresolved,
+      stats: {
+        detected: detected.length,
+        changed: changed.length,
+        declaredByContract: declaredByContract.all.length,
+        unresolved: unresolved.length,
+        extractionErrors: (facts.anchors?.errors || []).length,
+        byType: groupByType(facts.policy.anchors.types, { detected, changed }),
+      },
+    },
+    traceRuleResults,
+  };
+}

--- a/src/runtime/pipeline.mjs
+++ b/src/runtime/pipeline.mjs
@@ -1,6 +1,7 @@
 import { createCheckReporter, printEnforcementMode } from "../enforcement.mjs";
 import { buildPolicyFacts } from "../facts/input.mjs";
 import { runPolicyChecks } from "../checks/orchestrator.mjs";
+import { buildAnchorDiagnostics } from "../reporting/anchor-diagnostics.mjs";
 
 export function runPolicyPipeline(input, options = {}) {
   const quiet = options.quiet || false;
@@ -21,6 +22,7 @@ export function runPolicyPipeline(input, options = {}) {
   }
 
   runPolicyChecks(facts, reporter);
+  const anchorDiagnostics = buildAnchorDiagnostics(facts);
 
   return reporter.finish({
     repositoryRoot: facts.repositoryRoot,
@@ -29,5 +31,6 @@ export function runPolicyPipeline(input, options = {}) {
       checkedFiles: facts.diff.files.checked.length,
       skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
     },
+    ...anchorDiagnostics,
   });
 }

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -363,6 +363,89 @@ function makeRegistryRepo() {
   };
 }
 
+function makeAnchorAwareRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-anchors-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    anchors: {
+      types: {
+        requirement_id: {
+          sources: [
+            { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+          ],
+        },
+        code_req_ref: {
+          sources: [
+            { kind: "regex", glob: "src/**", pattern: "@req\\s+([A-Z]+-[0-9]+)" },
+          ],
+        },
+      },
+    },
+    trace_rules: [
+      {
+        id: "code-refs-must-resolve",
+        kind: "must_resolve",
+        from_anchor_type: "code_req_ref",
+        to_anchor_type: "requirement_id",
+      },
+    ],
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  const contract = {
+    change_type: "feature",
+    scope: ["src/**"],
+    budgets: {},
+    anchors: {
+      affects: ["FR-001"],
+      implements: ["FR-999"],
+    },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["Add anchor diagnostics to structured output"],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(dir, "contract.json"), JSON.stringify(contract, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("mkdir -p requirements", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "requirements", "fr-001.json"), JSON.stringify({ id: "FR-001", title: "Login" }));
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  execSync("mkdir -p src", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "src", "feature.mjs"), [
+    "export function feature() {",
+    "  return true; // @req FR-001",
+    "}",
+    "// @req FR-999",
+    "",
+  ].join("\n"));
+  execSync("git add -A && git commit -m feature", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    contractPath: "contract.json",
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
 console.log("\n--- check-diff --format json emits stable machine-readable result ---");
 {
   const repo = makeRepo();
@@ -413,6 +496,74 @@ console.log("\n--- check-diff --format json emits stable machine-readable result
   expect("cochange violation is detailed",
     parsed?.violations.some((v) => v.rule.startsWith("cochange:") && v.must_touch.includes("tests/**")),
     true);
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff reports anchor diagnostics in JSON and summary output ---");
+{
+  const repo = makeAnchorAwareRepo();
+  const result = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+    "--contract", repo.contractPath,
+  ]);
+
+  expect("anchor diagnostics do not change exit semantics before trace enforcement", result.code, 0);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("anchor diagnostics stdout is valid json", true, true);
+  } catch (e) {
+    expect("anchor diagnostics stdout is valid json", e.message, "valid json");
+  }
+  expectTopLevelKeys("anchor-aware json shape adds diagnostics without removing stable fields", parsed, [
+    "advisoryWarnings",
+    "anchors",
+    "diff",
+    "exitCode",
+    "failed",
+    "hints",
+    "mode",
+    "ok",
+    "passed",
+    "repositoryRoot",
+    "result",
+    "ruleResults",
+    "traceRuleResults",
+    "violationCount",
+    "violations",
+    "warnings",
+  ]);
+  expect("anchor diagnostics count detected anchors", parsed?.anchors?.stats?.detected, 3);
+  expect("anchor diagnostics count changed anchors", parsed?.anchors?.stats?.changed, 2);
+  expect("anchor diagnostics count declared contract anchors", parsed?.anchors?.stats?.declaredByContract, 2);
+  expect("anchor diagnostics count unresolved anchors", parsed?.anchors?.stats?.unresolved, 1);
+  expect("anchor diagnostics expose declared contract affects", parsed?.anchors?.declaredByContract?.affects[0], "FR-001");
+  expect("anchor diagnostics expose changed anchor file",
+    parsed?.anchors?.changed.every((anchor) => anchor.file === "src/feature.mjs"),
+    true);
+  expect("trace rule diagnostics include one result", parsed?.traceRuleResults?.length, 1);
+  expect("trace rule diagnostics report non-enforced unresolved status", parsed?.traceRuleResults?.[0]?.ok, false);
+  expect("trace rule diagnostics report resolved value", parsed?.traceRuleResults?.[0]?.resolved[0]?.value, "FR-001");
+  expect("trace rule diagnostics report unresolved value", parsed?.traceRuleResults?.[0]?.unresolved[0]?.value, "FR-999");
+  expect("anchor unresolved list links back to rule", parsed?.anchors?.unresolved[0]?.rule, "code-refs-must-resolve");
+
+  const summary = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "summary",
+    "--base", repo.base,
+    "--head", repo.head,
+    "--contract", repo.contractPath,
+  ]);
+  expect("anchor summary exit semantics", summary.code, 0);
+  expectIncludes("summary reports anchor totals", summary.output, "- Anchors: 3 detected, 2 changed, 2 declared, 1 unresolved");
+  expectIncludes("summary reports unresolved trace rule", summary.output, "code-refs-must-resolve");
+  expectIncludes("summary reports unresolved anchor value", summary.output, "FR-999");
 
   rmSync(repo.dir, { recursive: true });
 }


### PR DESCRIPTION
## Summary

Adds anchor-aware diagnostics to `check-diff --format json` when `repo-policy.json` declares `anchors`, while preserving the existing top-level `ok`, `result`, and `exitCode` semantics for older policies.

The new structured fields are:

- `anchors.detected`, `anchors.changed`, `anchors.declaredByContract`, `anchors.unresolved`, and `anchors.stats`
- `traceRuleResults` with diagnostic-only `must_resolve` resolution details

Summary output now includes concise anchor totals and a short unresolved trace table when anchor diagnostics are present. README documents the compatibility policy and field meanings.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/reporting/
  - src/runtime/
  - src/enforcement.mjs
  - tests/test-structured-output.mjs
  - README.md
budgets: {}
anchors:
  affects:
    - issue-53
  implements:
    - issue-53
  verifies:
    - issue-53
must_touch:
  - src/reporting/anchor-diagnostics.mjs
  - tests/test-structured-output.mjs
must_not_touch: []
expected_effects:
  - Anchor-aware policies expose detected, changed, declared, and unresolved anchor diagnostics in JSON output.
  - Summary output reports anchor totals and unresolved trace diagnostics without changing enforcement exit semantics.
```

## Reproduction And Verification

The regression test in `tests/test-structured-output.mjs` builds an anchor-aware fixture with one resolved and one unresolved `must_resolve` reference. Before the implementation it failed because `anchors` and `traceRuleResults` were absent from JSON output and summary output had no anchor diagnostics.

Local checks run:

- `npm run test:structured-output`
- `npm test`
- `npm run validate`
- package smoke equivalent to CI `smoke-pack`
- `node src/repo-guard.mjs check-diff`

Fixes netkeep80/repo-guard#53
