### PR TITLE
Add must_resolve trace rule enforcement

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T20:27:59.814Z for PR creation at branch issue-54-3c71ca5448e1 for issue https://github.com/netkeep80/repo-guard/issues/54

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T20:27:59.814Z for PR creation at branch issue-54-3c71ca5448e1 for issue https://github.com/netkeep80/repo-guard/issues/54

--- a/README.md
+++ b/README.md
@@ -338,11 +338,19 @@ repository files and changed files. `anchors.changed` is the subset located in
 checked diff files. `anchors.declaredByContract` mirrors contract
 `anchors.affects`, `anchors.implements`, and `anchors.verifies`, with `all` as a
 relation/value list for tooling that does not want to inspect each relation.
-`anchors.unresolved` is an aggregate of unresolved trace diagnostics. In this
-version trace diagnostics are report-only: they do not change `ok`, `result`, or
-`exitCode`.
+`anchors.unresolved` is an aggregate of unresolved trace diagnostics.
+`must_resolve` trace rules are enforced as policy checks: unresolved references
+make `ok: false` and `result: "failed"`. In `blocking` mode they exit `1`; in
+`advisory` mode they are reported as warnings and the command exits `0`.
+Structured violations include `unresolved_anchors` with the offending anchor
+value, source instances, and file/line/column locations. Their rule names use
+the `trace-rule: <id>` form, for example `trace-rule: code-refs-must-resolve`.
 
-Exit behavior is unchanged: in `blocking` mode violations exit `1`; in `advisory` mode violations are reported but the command exits `0`. Consumers should read both `ok` and `exitCode`: `ok` describes policy result, while `exitCode` describes command exit semantics for the active enforcement mode.
+Exit behavior follows the active enforcement mode: in `blocking` mode
+violations exit `1`; in `advisory` mode violations are reported but the command
+exits `0`. Consumers should read both `ok` and `exitCode`: `ok` describes
+policy result, while `exitCode` describes command exit semantics for the active
+enforcement mode.
 
 `--format summary` also includes one concise anchor line when anchors are
 enabled, for example `Anchors: 3 detected, 2 changed, 2 declared, 1 unresolved`.
@@ -652,10 +660,10 @@ Result: passed (mode: blocking; exit code 0)
 Anchor extraction работает по tracked repository files и по changed files из diff, чтобы global requirement IDs и новые references были доступны в одной facts model. Если JSON не парсится, field отсутствует или source file не читается, check `anchor-extraction` завершается `FAIL` с диагностикой вида `[requirement_id json_field source 0] requirements/fr-001.json: field "id" not found`.
 
 Если policy содержит `trace_rules.kind = "must_resolve"`, structured output
-добавляет diagnostic-only `traceRuleResults`: для каждого значения from-anchor
-проверяется наличие matching value среди to-anchor instances. Эти diagnostics
-видны в JSON и summary output, но enforcement для trace rules зарезервирован для
-следующего runtime шага.
+добавляет `traceRuleResults`: для каждого значения from-anchor проверяется
+наличие matching value среди to-anchor instances. Unresolved references также
+становятся policy violations вида `trace-rule: <id>` и наследуют обычную
+семантику `blocking`/`advisory`.
 
 ### 4. Пример failure
 
@@ -1108,8 +1116,8 @@ The self-hosted governance surface is declared in `repo-policy.json` under `path
 
 - `governance_paths` — информационное поле, не проверяется в runtime. Документирует, какие файлы управляют governance.
 - `public_api` — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
-- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой и выводится в structured output как `anchors.declaredByContract`, но runtime trace enforcement для anchors зарезервирован для будущих версий.
-- `trace_rules.kind = "must_resolve"` — выводится в structured output как diagnostic-only `traceRuleResults`; unresolved diagnostics не меняют `ok`, `result` или `exitCode`.
+- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой и выводится в structured output как `anchors.declaredByContract`; сами contract anchors не являются отдельным enforcement rule.
+- `trace_rules.kind = "must_resolve"` — enforced runtime rule: unresolved from-anchor values must resolve to at least one matching to-anchor value and are reported in `traceRuleResults`, `anchors.unresolved`, and structured violations.
 - `overrides` (в change contract) — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
 - `repo-guard` пока не публикует комментарии к PR.
 - Паттерны `forbid_regex` компилируются и проверяются до начала enforcement — ошибки в regex выявляются на этапе загрузки policy.

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -272,7 +272,7 @@
     },
     "anchors": {
       "type": "object",
-      "description": "Named anchor types and extractors used as shared trace vocabulary. Runtime extraction records normalized anchor facts; trace enforcement is reserved for future versions.",
+      "description": "Named anchor types and extractors used as shared trace vocabulary. Runtime extraction records normalized anchor facts for trace rule enforcement and structured diagnostics.",
       "required": ["types"],
       "additionalProperties": false,
       "properties": {
@@ -296,7 +296,7 @@
     },
     "trace_rules": {
       "type": "array",
-      "description": "Trace/evidence rules between declared anchor types. Runtime enforcement is reserved for future versions.",
+      "description": "Trace/evidence rules between declared anchor types. must_resolve rules enforce that from-anchor values resolve to matching to-anchor values.",
       "items": {
         "type": "object",
         "required": ["id", "kind", "from_anchor_type", "to_anchor_type"],

--- a/src/checks/orchestrator.mjs
+++ b/src/checks/orchestrator.mjs
@@ -15,8 +15,9 @@ import {
   checkAdvisoryTextRules,
 } from "../diff-checker.mjs";
 import { checkAnchorExtraction } from "../extractors/anchors.mjs";
+import { checkTraceRuleResult } from "./trace-rules.mjs";
 
-export function runPolicyChecks(facts, reporter) {
+export function runPolicyChecks(facts, reporter, options = {}) {
   const policy = facts.policy;
   const files = facts.diff.files.checked;
   const contract = facts.contract;
@@ -52,6 +53,11 @@ export function runPolicyChecks(facts, reporter) {
   );
   if (policy.anchors) {
     reporter.report("anchor-extraction", checkAnchorExtraction(facts.anchors));
+  }
+  if (policy.trace_rules && policy.trace_rules.length > 0) {
+    for (const traceResult of options.anchorDiagnostics?.traceRuleResults || []) {
+      reporter.report(`trace-rule: ${traceResult.id}`, checkTraceRuleResult(traceResult));
+    }
   }
 
   if (policy.change_type_rules) {

--- a/src/checks/trace-rules.mjs
+++ b/src/checks/trace-rules.mjs
@@ -1,0 +1,45 @@
+function formatAnchorLocation(instance) {
+  const line = instance.line ? `:${instance.line}` : "";
+  const column = instance.column ? `:${instance.column}` : "";
+  return `${instance.file}${line}${column}`;
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+export function checkTraceRuleResult(result) {
+  const unresolvedAnchors = (result.unresolved || []).map((item) => {
+    const instances = item.instances || [];
+    return {
+      value: item.value,
+      fromAnchorType: result.fromAnchorType,
+      toAnchorType: result.toAnchorType,
+      locations: instances.map(formatAnchorLocation),
+      instances,
+    };
+  });
+
+  const details = [];
+  for (const anchor of unresolvedAnchors) {
+    for (const location of anchor.locations) {
+      details.push(`${anchor.value} (${anchor.fromAnchorType} -> ${anchor.toAnchorType}) at ${location}`);
+    }
+  }
+
+  return {
+    ok: unresolvedAnchors.length === 0,
+    message: unresolvedAnchors.length > 0
+      ? `unresolved anchor reference(s) for trace rule "${result.id}"`
+      : undefined,
+    trace_rule: result.id,
+    trace_kind: result.kind,
+    from_anchor_type: result.fromAnchorType,
+    to_anchor_type: result.toAnchorType,
+    unresolved_anchors: unresolvedAnchors,
+    files: uniqueSorted(unresolvedAnchors.flatMap((anchor) =>
+      anchor.instances.map((instance) => instance.file)
+    )),
+    details,
+  };
+}

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -216,6 +216,11 @@ function violationFromCheck(name, check) {
   if (check.failed_rules) violation.failed_rules = check.failed_rules;
   if (check.results) violation.results = check.results;
   if (check.matches) violation.matches = check.matches;
+  if (check.trace_rule) violation.trace_rule = check.trace_rule;
+  if (check.trace_kind) violation.trace_kind = check.trace_kind;
+  if (check.from_anchor_type) violation.from_anchor_type = check.from_anchor_type;
+  if (check.to_anchor_type) violation.to_anchor_type = check.to_anchor_type;
+  if (check.unresolved_anchors) violation.unresolved_anchors = check.unresolved_anchors;
   if (check.advisory) violation.advisory = true;
   if (check.unclassified_files && check.unclassified_files.length > 0) {
     violation.unclassified_files = check.unclassified_files;

--- a/src/runtime/pipeline.mjs
+++ b/src/runtime/pipeline.mjs
@@ -21,8 +21,8 @@ export function runPolicyPipeline(input, options = {}) {
     console.log(`\nDiff analysis: ${facts.diff.files.all.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`);
   }
 
-  runPolicyChecks(facts, reporter);
   const anchorDiagnostics = buildAnchorDiagnostics(facts);
+  runPolicyChecks(facts, reporter, { anchorDiagnostics });
 
   return reporter.finish({
     repositoryRoot: facts.repositoryRoot,

--- a/tests/test-anchor-extractors.mjs
+++ b/tests/test-anchor-extractors.mjs
@@ -35,8 +35,8 @@ function makeReadFile(files) {
   };
 }
 
-function makePolicy(anchorTypes) {
-  return {
+function makePolicy(anchorTypes, traceRules = []) {
+  const policy = {
     policy_format_version: "0.3.0",
     repository_kind: "tooling",
     paths: {
@@ -56,6 +56,8 @@ function makePolicy(anchorTypes) {
     content_rules: [],
     cochange_rules: [],
   };
+  if (traceRules.length > 0) policy.trace_rules = traceRules;
+  return policy;
 }
 
 console.log("\n--- anchor extractors return normalized instances ---");
@@ -216,6 +218,173 @@ console.log("\n--- anchor extraction errors are predictable and reported by pipe
   expect("pipeline exposes formatted extraction errors",
     violation?.errors.some((error) => error.includes("requirements/bad.json")),
     true);
+}
+
+console.log("\n--- must_resolve trace rules enforce code and doc anchors ---");
+{
+  const traceRules = [
+    {
+      id: "code-refs-must-resolve",
+      kind: "must_resolve",
+      from_anchor_type: "code_req_ref",
+      to_anchor_type: "requirement_id",
+    },
+    {
+      id: "doc-refs-must-resolve",
+      kind: "must_resolve",
+      from_anchor_type: "doc_req_ref",
+      to_anchor_type: "requirement_id",
+    },
+  ];
+  const policy = makePolicy({
+    requirement_id: {
+      sources: [
+        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+      ],
+    },
+    code_req_ref: {
+      sources: [
+        { kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]+)" },
+      ],
+    },
+    doc_req_ref: {
+      sources: [
+        { kind: "regex", glob: "docs/**/*.md", pattern: "\\[(FR-[0-9]+)\\]" },
+      ],
+    },
+  }, traceRules);
+  const files = {
+    "requirements/fr-001.json": JSON.stringify({ id: "FR-001" }),
+    "requirements/fr-002.json": JSON.stringify({ id: "FR-002" }),
+    "src/feature.mjs": "export const feature = true; // @req FR-001\n// @req FR-404\n",
+    "docs/feature.md": "Covers [FR-002] and [FR-405].\n",
+  };
+  const diffText = [
+    "diff --git a/src/feature.mjs b/src/feature.mjs",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/src/feature.mjs",
+    "+export const feature = true; // @req FR-001",
+    "+// @req FR-404",
+    "diff --git a/docs/feature.md b/docs/feature.md",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/docs/feature.md",
+    "+Covers [FR-002] and [FR-405].",
+  ].join("\n");
+
+  const input = {
+    mode: "check-diff",
+    repositoryRoot: "/tmp/repo",
+    policy,
+    contract: null,
+    contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles: ["requirements/fr-001.json", "requirements/fr-002.json"],
+    readFile: makeReadFile(files),
+    initialChecks: [],
+  };
+  const result = runPolicyPipeline(input, { quiet: true });
+
+  expect("unresolved trace anchors fail blocking mode", result.ok, false);
+  expect("unresolved trace anchors set blocking exit code", result.exitCode, 1);
+  expect("multiple trace rule violations coexist",
+    result.violations
+      .filter((violation) => violation.rule.startsWith("trace-rule:"))
+      .map((violation) => violation.trace_rule)
+      .sort(),
+    ["code-refs-must-resolve", "doc-refs-must-resolve"]);
+
+  const codeViolation = result.violations.find((violation) => violation.trace_rule === "code-refs-must-resolve");
+  const docViolation = result.violations.find((violation) => violation.trace_rule === "doc-refs-must-resolve");
+  expect("code violation lists unresolved anchor value", codeViolation?.unresolved_anchors[0]?.value, "FR-404");
+  expect("code violation lists offending source file", codeViolation?.unresolved_anchors[0]?.locations[0], "src/feature.mjs:2:9");
+  expect("doc violation lists unresolved anchor value", docViolation?.unresolved_anchors[0]?.value, "FR-405");
+  expect("doc violation lists offending source file", docViolation?.unresolved_anchors[0]?.locations[0], "docs/feature.md:1:22");
+  expect("resolved trace values remain visible in diagnostics",
+    result.traceRuleResults.map((traceResult) => traceResult.resolved[0]?.value).sort(),
+    ["FR-001", "FR-002"]);
+
+  const advisoryResult = runPolicyPipeline({
+    ...input,
+    enforcement: { ok: true, mode: "advisory", source: "test", requested: "advisory" },
+  }, { quiet: true });
+  expect("unresolved trace anchors still mark advisory result failed", advisoryResult.ok, false);
+  expect("unresolved trace anchors keep advisory exit code zero", advisoryResult.exitCode, 0);
+  expect("unresolved trace anchors keep advisory enforced failures zero", advisoryResult.failed, 0);
+  expect("unresolved trace anchors remain counted as advisory violations", advisoryResult.violationCount, 2);
+}
+
+console.log("\n--- resolved must_resolve refs pass cleanly ---");
+{
+  const policy = makePolicy({
+    requirement_id: {
+      sources: [
+        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
+      ],
+    },
+    code_req_ref: {
+      sources: [
+        { kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]+)" },
+      ],
+    },
+    doc_req_ref: {
+      sources: [
+        { kind: "regex", glob: "docs/**/*.md", pattern: "\\[(FR-[0-9]+)\\]" },
+      ],
+    },
+  }, [
+    {
+      id: "code-refs-must-resolve",
+      kind: "must_resolve",
+      from_anchor_type: "code_req_ref",
+      to_anchor_type: "requirement_id",
+    },
+    {
+      id: "doc-refs-must-resolve",
+      kind: "must_resolve",
+      from_anchor_type: "doc_req_ref",
+      to_anchor_type: "requirement_id",
+    },
+  ]);
+  const files = {
+    "requirements/fr-001.json": JSON.stringify({ id: "FR-001" }),
+    "requirements/fr-002.json": JSON.stringify({ id: "FR-002" }),
+    "src/feature.mjs": "export const feature = true; // @req FR-001\n",
+    "docs/feature.md": "Covers [FR-002].\n",
+  };
+  const diffText = [
+    "diff --git a/src/feature.mjs b/src/feature.mjs",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/src/feature.mjs",
+    "+export const feature = true; // @req FR-001",
+    "diff --git a/docs/feature.md b/docs/feature.md",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/docs/feature.md",
+    "+Covers [FR-002].",
+  ].join("\n");
+
+  const result = runPolicyPipeline({
+    mode: "check-diff",
+    repositoryRoot: "/tmp/repo",
+    policy,
+    contract: null,
+    contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles: ["requirements/fr-001.json", "requirements/fr-002.json"],
+    readFile: makeReadFile(files),
+    initialChecks: [],
+  }, { quiet: true });
+
+  expect("resolved trace anchors keep the run passing", result.ok, true);
+  expect("resolved trace anchors keep exit code zero", result.exitCode, 0);
+  expect("resolved trace anchors produce no trace violations",
+    result.violations.some((violation) => violation.rule.startsWith("trace-rule:")),
+    false);
 }
 
 console.log(`\n${failures === 0 ? "All anchor extractor tests passed" : `${failures} test(s) failed`}`);

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -394,6 +394,11 @@ function makeAnchorAwareRepo() {
             { kind: "regex", glob: "src/**", pattern: "@req\\s+([A-Z]+-[0-9]+)" },
           ],
         },
+        doc_req_ref: {
+          sources: [
+            { kind: "regex", glob: "docs/**/*.md", pattern: "\\[([A-Z]+-[0-9]+)\\]" },
+          ],
+        },
       },
     },
     trace_rules: [
@@ -401,6 +406,12 @@ function makeAnchorAwareRepo() {
         id: "code-refs-must-resolve",
         kind: "must_resolve",
         from_anchor_type: "code_req_ref",
+        to_anchor_type: "requirement_id",
+      },
+      {
+        id: "doc-refs-must-resolve",
+        kind: "must_resolve",
+        from_anchor_type: "doc_req_ref",
         to_anchor_type: "requirement_id",
       },
     ],
@@ -415,6 +426,7 @@ function makeAnchorAwareRepo() {
     anchors: {
       affects: ["FR-001"],
       implements: ["FR-999"],
+      verifies: ["FR-404"],
     },
     must_touch: [],
     must_not_touch: [],
@@ -426,9 +438,10 @@ function makeAnchorAwareRepo() {
   writeFileSync(join(dir, "README.md"), "# Test\n");
   execSync("mkdir -p requirements", { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "requirements", "fr-001.json"), JSON.stringify({ id: "FR-001", title: "Login" }));
+  writeFileSync(join(dir, "requirements", "fr-002.json"), JSON.stringify({ id: "FR-002", title: "Docs" }));
   execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
 
-  execSync("mkdir -p src", { cwd: dir, stdio: "pipe" });
+  execSync("mkdir -p docs src", { cwd: dir, stdio: "pipe" });
   writeFileSync(join(dir, "src", "feature.mjs"), [
     "export function feature() {",
     "  return true; // @req FR-001",
@@ -436,6 +449,7 @@ function makeAnchorAwareRepo() {
     "// @req FR-999",
     "",
   ].join("\n"));
+  writeFileSync(join(dir, "docs", "feature.md"), "Covers [FR-002] and [FR-404].\n");
   execSync("git add -A && git commit -m feature", { cwd: dir, stdio: "pipe" });
 
   return {
@@ -512,7 +526,7 @@ console.log("\n--- check-diff reports anchor diagnostics in JSON and summary out
     "--contract", repo.contractPath,
   ]);
 
-  expect("anchor diagnostics do not change exit semantics before trace enforcement", result.code, 0);
+  expect("unresolved trace diagnostics fail in blocking mode", result.code, 1);
   let parsed = null;
   try {
     parsed = JSON.parse(result.stdout);
@@ -538,19 +552,33 @@ console.log("\n--- check-diff reports anchor diagnostics in JSON and summary out
     "violations",
     "warnings",
   ]);
-  expect("anchor diagnostics count detected anchors", parsed?.anchors?.stats?.detected, 3);
-  expect("anchor diagnostics count changed anchors", parsed?.anchors?.stats?.changed, 2);
-  expect("anchor diagnostics count declared contract anchors", parsed?.anchors?.stats?.declaredByContract, 2);
-  expect("anchor diagnostics count unresolved anchors", parsed?.anchors?.stats?.unresolved, 1);
+  expect("anchor diagnostics count detected anchors", parsed?.anchors?.stats?.detected, 6);
+  expect("anchor diagnostics count changed anchors", parsed?.anchors?.stats?.changed, 4);
+  expect("anchor diagnostics count declared contract anchors", parsed?.anchors?.stats?.declaredByContract, 3);
+  expect("anchor diagnostics count unresolved anchors", parsed?.anchors?.stats?.unresolved, 2);
   expect("anchor diagnostics expose declared contract affects", parsed?.anchors?.declaredByContract?.affects[0], "FR-001");
   expect("anchor diagnostics expose changed anchor file",
-    parsed?.anchors?.changed.every((anchor) => anchor.file === "src/feature.mjs"),
-    true);
-  expect("trace rule diagnostics include one result", parsed?.traceRuleResults?.length, 1);
-  expect("trace rule diagnostics report non-enforced unresolved status", parsed?.traceRuleResults?.[0]?.ok, false);
+    JSON.stringify(parsed?.anchors?.changed.map((anchor) => anchor.file).sort()),
+    JSON.stringify(["docs/feature.md", "docs/feature.md", "src/feature.mjs", "src/feature.mjs"]));
+  expect("trace rule diagnostics include both results", parsed?.traceRuleResults?.length, 2);
+  expect("trace rule diagnostics report unresolved status", parsed?.traceRuleResults?.[0]?.ok, false);
   expect("trace rule diagnostics report resolved value", parsed?.traceRuleResults?.[0]?.resolved[0]?.value, "FR-001");
   expect("trace rule diagnostics report unresolved value", parsed?.traceRuleResults?.[0]?.unresolved[0]?.value, "FR-999");
   expect("anchor unresolved list links back to rule", parsed?.anchors?.unresolved[0]?.rule, "code-refs-must-resolve");
+  expect("violations include code trace rule",
+    parsed?.violations.some((violation) =>
+      violation.rule === "trace-rule: code-refs-must-resolve" &&
+      violation.unresolved_anchors[0]?.value === "FR-999" &&
+      violation.unresolved_anchors[0]?.locations[0] === "src/feature.mjs:4:9"
+    ),
+    true);
+  expect("violations include doc trace rule",
+    parsed?.violations.some((violation) =>
+      violation.rule === "trace-rule: doc-refs-must-resolve" &&
+      violation.unresolved_anchors[0]?.value === "FR-404" &&
+      violation.unresolved_anchors[0]?.locations[0] === "docs/feature.md:1:22"
+    ),
+    true);
 
   const summary = runGuard([
     "--repo-root", repo.dir,
@@ -560,10 +588,12 @@ console.log("\n--- check-diff reports anchor diagnostics in JSON and summary out
     "--head", repo.head,
     "--contract", repo.contractPath,
   ]);
-  expect("anchor summary exit semantics", summary.code, 0);
-  expectIncludes("summary reports anchor totals", summary.output, "- Anchors: 3 detected, 2 changed, 2 declared, 1 unresolved");
+  expect("anchor summary exit semantics", summary.code, 1);
+  expectIncludes("summary reports anchor totals", summary.output, "- Anchors: 6 detected, 4 changed, 3 declared, 2 unresolved");
   expectIncludes("summary reports unresolved trace rule", summary.output, "code-refs-must-resolve");
   expectIncludes("summary reports unresolved anchor value", summary.output, "FR-999");
+  expectIncludes("summary reports doc trace rule", summary.output, "doc-refs-must-resolve");
+  expectIncludes("summary reports doc anchor value", summary.output, "FR-404");
 
   rmSync(repo.dir, { recursive: true });
 }


### PR DESCRIPTION
## Summary

- Enforce `trace_rules.kind = must_resolve` as runtime policy checks.
- Report one violation per trace rule with `unresolved_anchors` containing the offending anchor value, source instances, and file/line/column locations.
- Keep `traceRuleResults` and `anchors.unresolved` diagnostics in structured output, and update schema/README wording from diagnostic-only to enforced behavior.

## Reproduction and Verification

The reproducing tests add code and doc references where one value resolves and one value is missing. Before the fix, those diagnostics existed but did not affect `ok` or `exitCode`; after the fix, blocking mode fails and advisory mode reports the violation while exiting 0.

Automated coverage:
- `tests/test-anchor-extractors.mjs` covers code refs, doc refs, multiple coexisting `must_resolve` rules, resolved refs passing cleanly, and advisory/blocking behavior.
- `tests/test-structured-output.mjs` covers JSON and summary output for enforced trace-rule violations.

Tests run locally:
- `npm test`

Fixes netkeep80/repo-guard#54

## Change Contract

```repo-guard-yaml
change_type: feature
change_class: kernel-hardening
scope:
  - src/
  - tests/
  - schemas/
  - README.md
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 500
anchors:
  affects:
    - issue-54
  implements:
    - issue-54
  verifies:
    - issue-54
must_touch:
  - src/checks/trace-rules.mjs
  - tests/test-anchor-extractors.mjs
must_not_touch: []
expected_effects:
  - Unresolved code anchor references fail must_resolve trace rules.
  - Unresolved documentation anchor references fail must_resolve trace rules.
  - Resolved anchor references pass cleanly.
  - Advisory mode reports trace violations without a nonzero exit code.
```