### PR TITLE
Add evidence trace rule enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run anchor extraction tests
         run: npm run test:anchors
 
+      - name: Run trace evidence rule tests
+        run: npm run test:trace-evidence
+
       - name: Run repo-root separation tests
         run: npm run test:repo-root
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T20:49:28.454Z for PR creation at branch issue-55-d76b364ce59d for issue https://github.com/netkeep80/repo-guard/issues/55

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T20:49:28.454Z for PR creation at branch issue-55-d76b364ce59d for issue https://github.com/netkeep80/repo-guard/issues/55

--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ make `ok: false` and `result: "failed"`. In `blocking` mode they exit `1`; in
 Structured violations include `unresolved_anchors` with the offending anchor
 value, source instances, and file/line/column locations. Their rule names use
 the `trace-rule: <id>` form, for example `trace-rule: code-refs-must-resolve`.
+Evidence trace rules use the same `trace-rule: <id>` violation shape but report
+`trace_kind`, `must_touch_any`, `changed_files`, `evidence_files`, and, for
+contract anchor declarations, `contract_field` plus `declared_anchors`; this
+keeps missing evidence diagnostics distinct from missing anchor resolution.
 
 Exit behavior follows the active enforcement mode: in `blocking` mode
 violations exit `1`; in `advisory` mode violations are reported but the command
@@ -664,6 +668,37 @@ Anchor extraction работает по tracked repository files и по changed
 наличие matching value среди to-anchor instances. Unresolved references также
 становятся policy violations вида `trace-rule: <id>` и наследуют обычную
 семантику `blocking`/`advisory`.
+
+Evidence rules добавляют второй класс `trace_rules`, который не требует anchor
+extractors:
+
+```json
+{
+  "trace_rules": [
+    {
+      "id": "changed-requirements-need-evidence",
+      "kind": "changed_files_require_evidence",
+      "if_changed": ["requirements/**"],
+      "must_touch_any": ["src/**", "tests/**", "docs/**"]
+    },
+    {
+      "id": "declared-anchors-need-evidence",
+      "kind": "declared_anchors_require_evidence",
+      "contract_field": "anchors.affects",
+      "must_touch_any": ["src/**", "tests/**", "docs/**"]
+    }
+  ]
+}
+```
+
+`changed_files_require_evidence` срабатывает, когда diff затрагивает хотя бы
+один путь из `if_changed`, и требует хотя бы один changed file из
+`must_touch_any`. `declared_anchors_require_evidence` срабатывает, когда change
+contract объявляет values в `anchors.affects`, `anchors.implements` или
+`anchors.verifies`, и требует такой же evidence surface в diff. Missing evidence
+становится policy violation с `trace_kind`, отличным от `must_resolve`, чтобы
+потребители structured output могли различать нерешённые anchors и отсутствие
+причинно-следственного следа в diff.
 
 ### 4. Пример failure
 
@@ -1116,8 +1151,9 @@ The self-hosted governance surface is declared in `repo-policy.json` under `path
 
 - `governance_paths` — информационное поле, не проверяется в runtime. Документирует, какие файлы управляют governance.
 - `public_api` — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
-- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой и выводится в structured output как `anchors.declaredByContract`; сами contract anchors не являются отдельным enforcement rule.
+- `anchors` (в change contract) — декларативный intent на уровне anchors. Принимается схемой и выводится в structured output как `anchors.declaredByContract`; evidence trace rules can enforce that declared contract anchors are backed by changed evidence surfaces.
 - `trace_rules.kind = "must_resolve"` — enforced runtime rule: unresolved from-anchor values must resolve to at least one matching to-anchor value and are reported in `traceRuleResults`, `anchors.unresolved`, and structured violations.
+- `trace_rules.kind = "changed_files_require_evidence"` and `trace_rules.kind = "declared_anchors_require_evidence"` — enforced runtime evidence rules: changed requirement artifacts or declared contract anchors must be accompanied by at least one changed file in a configured evidence surface.
 - `overrides` (в change contract) — зарезервировано для будущего использования. Принимается схемой, но не применяется; непустые значения выводят предупреждение.
 - `repo-guard` пока не публикует комментарии к PR.
 - Паттерны `forbid_regex` компилируются и проверяются до начала enforcement — ошибки в regex выявляются на этапе загрузки policy.

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:anchors": "node tests/test-anchor-extractors.mjs",
+    "test:trace-evidence": "node tests/test-trace-evidence-rules.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
     "test:diff": "node tests/test-diff-rules.mjs",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -296,18 +296,8 @@
     },
     "trace_rules": {
       "type": "array",
-      "description": "Trace/evidence rules between declared anchor types. must_resolve rules enforce that from-anchor values resolve to matching to-anchor values.",
-      "items": {
-        "type": "object",
-        "required": ["id", "kind", "from_anchor_type", "to_anchor_type"],
-        "additionalProperties": false,
-        "properties": {
-          "id": { "type": "string", "minLength": 1 },
-          "kind": { "type": "string", "enum": ["must_resolve"] },
-          "from_anchor_type": { "type": "string", "minLength": 1 },
-          "to_anchor_type": { "type": "string", "minLength": 1 }
-        }
-      }
+      "description": "Trace/evidence rules. must_resolve rules enforce that from-anchor values resolve to matching to-anchor values. Evidence rules enforce that changed requirement artifacts or declared contract anchors are backed by configured evidence surfaces.",
+      "items": { "$ref": "#/definitions/trace_rule" }
     },
     "content_rules": {
       "type": "array",
@@ -352,6 +342,51 @@
     }
   },
   "definitions": {
+    "non_empty_string_array": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "trace_rule": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["id", "kind", "from_anchor_type", "to_anchor_type"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "kind": { "const": "must_resolve" },
+            "from_anchor_type": { "type": "string", "minLength": 1 },
+            "to_anchor_type": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["id", "kind", "if_changed", "must_touch_any"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "kind": { "const": "changed_files_require_evidence" },
+            "if_changed": { "$ref": "#/definitions/non_empty_string_array" },
+            "must_touch_any": { "$ref": "#/definitions/non_empty_string_array" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["id", "kind", "contract_field", "must_touch_any"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "kind": { "const": "declared_anchors_require_evidence" },
+            "contract_field": {
+              "type": "string",
+              "enum": ["anchors.affects", "anchors.implements", "anchors.verifies"]
+            },
+            "must_touch_any": { "$ref": "#/definitions/non_empty_string_array" }
+          }
+        }
+      ]
+    },
     "anchor_source": {
       "oneOf": [
         {

--- a/src/checks/trace-rules.mjs
+++ b/src/checks/trace-rules.mjs
@@ -1,3 +1,11 @@
+import { matchesAny } from "../diff-checker.mjs";
+
+const CONTRACT_ANCHOR_FIELDS = new Map([
+  ["anchors.affects", ["anchors", "affects"]],
+  ["anchors.implements", ["anchors", "implements"]],
+  ["anchors.verifies", ["anchors", "verifies"]],
+]);
+
 function formatAnchorLocation(instance) {
   const line = instance.line ? `:${instance.line}` : "";
   const column = instance.column ? `:${instance.column}` : "";
@@ -8,7 +16,138 @@ function uniqueSorted(values) {
   return [...new Set(values)].sort();
 }
 
-export function checkTraceRuleResult(result) {
+function cloneAnchorInstance(instance) {
+  return { ...instance };
+}
+
+function groupByValue(instances) {
+  const grouped = new Map();
+  for (const instance of instances || []) {
+    if (!grouped.has(instance.value)) grouped.set(instance.value, []);
+    grouped.get(instance.value).push(cloneAnchorInstance(instance));
+  }
+  return grouped;
+}
+
+function changedPaths(facts) {
+  return (facts.diff?.files?.checked || []).map((file) => file.path);
+}
+
+function matchingPaths(paths, patterns) {
+  return uniqueSorted(paths.filter((path) => matchesAny(path, patterns || [])));
+}
+
+function contractFieldValues(contract, field) {
+  const path = CONTRACT_ANCHOR_FIELDS.get(field);
+  if (!path) return [];
+
+  let current = contract || {};
+  for (const segment of path) {
+    current = current?.[segment];
+  }
+  if (!Array.isArray(current)) return [];
+  return uniqueSorted(current.map((value) => String(value)));
+}
+
+function buildMustResolveDiagnostics(rule, anchorExtraction) {
+  const fromInstances = anchorExtraction.byType?.[rule.from_anchor_type] || [];
+  const toInstances = anchorExtraction.byType?.[rule.to_anchor_type] || [];
+  const fromByValue = groupByValue(fromInstances);
+  const toByValue = groupByValue(toInstances);
+  const resolved = [];
+  const unresolved = [];
+
+  for (const value of [...fromByValue.keys()].sort()) {
+    const from = fromByValue.get(value);
+    const to = toByValue.get(value) || [];
+    if (to.length > 0) {
+      resolved.push({ value, from, to });
+    } else {
+      unresolved.push({ value, instances: from });
+    }
+  }
+
+  return {
+    id: rule.id,
+    kind: rule.kind,
+    fromAnchorType: rule.from_anchor_type,
+    toAnchorType: rule.to_anchor_type,
+    ok: unresolved.length === 0,
+    resolved,
+    unresolved,
+    stats: {
+      fromInstances: fromInstances.length,
+      fromValues: fromByValue.size,
+      toInstances: toInstances.length,
+      toValues: toByValue.size,
+      resolved: resolved.length,
+      unresolved: unresolved.length,
+    },
+  };
+}
+
+function buildChangedFilesRequireEvidenceDiagnostics(rule, facts) {
+  const paths = changedPaths(facts);
+  const changedFiles = matchingPaths(paths, rule.if_changed);
+  const evidenceFiles = matchingPaths(paths, rule.must_touch_any);
+
+  return {
+    id: rule.id,
+    kind: rule.kind,
+    ok: changedFiles.length === 0 || evidenceFiles.length > 0,
+    ifChanged: [...(rule.if_changed || [])],
+    mustTouchAny: [...(rule.must_touch_any || [])],
+    changedFiles,
+    evidenceFiles,
+    stats: {
+      changedFiles: changedFiles.length,
+      evidenceFiles: evidenceFiles.length,
+    },
+  };
+}
+
+function buildDeclaredAnchorsRequireEvidenceDiagnostics(rule, facts) {
+  const paths = changedPaths(facts);
+  const declaredAnchors = contractFieldValues(facts.contract, rule.contract_field);
+  const evidenceFiles = matchingPaths(paths, rule.must_touch_any);
+
+  return {
+    id: rule.id,
+    kind: rule.kind,
+    ok: declaredAnchors.length === 0 || evidenceFiles.length > 0,
+    contractField: rule.contract_field,
+    mustTouchAny: [...(rule.must_touch_any || [])],
+    declaredAnchors,
+    evidenceFiles,
+    stats: {
+      declaredAnchors: declaredAnchors.length,
+      evidenceFiles: evidenceFiles.length,
+    },
+  };
+}
+
+export function buildTraceRuleDiagnostics(facts) {
+  return (facts.policy.trace_rules || []).map((rule) => {
+    if (rule.kind === "must_resolve") {
+      return buildMustResolveDiagnostics(rule, facts.anchors || {});
+    }
+    if (rule.kind === "changed_files_require_evidence") {
+      return buildChangedFilesRequireEvidenceDiagnostics(rule, facts);
+    }
+    if (rule.kind === "declared_anchors_require_evidence") {
+      return buildDeclaredAnchorsRequireEvidenceDiagnostics(rule, facts);
+    }
+
+    return {
+      id: rule.id,
+      kind: rule.kind,
+      ok: true,
+      stats: {},
+    };
+  });
+}
+
+function checkMustResolveTraceRuleResult(result) {
   const unresolvedAnchors = (result.unresolved || []).map((item) => {
     const instances = item.instances || [];
     return {
@@ -41,5 +180,51 @@ export function checkTraceRuleResult(result) {
       anchor.instances.map((instance) => instance.file)
     )),
     details,
+  };
+}
+
+function evidenceDetails(result) {
+  const details = [];
+  if (result.changedFiles) details.push(`changed_files: ${result.changedFiles.join(", ")}`);
+  if (result.contractField) details.push(`contract_field: ${result.contractField}`);
+  if (result.declaredAnchors) details.push(`declared_anchors: ${result.declaredAnchors.join(", ")}`);
+  details.push(`must_touch_any: ${result.mustTouchAny.join(", ")}`);
+  details.push(`evidence_files: ${result.evidenceFiles.length > 0 ? result.evidenceFiles.join(", ") : "(none)"}`);
+  return details;
+}
+
+function checkEvidenceTraceRuleResult(result) {
+  return {
+    ok: result.ok,
+    message: result.ok ? undefined : `missing evidence for trace rule "${result.id}"`,
+    trace_rule: result.id,
+    trace_kind: result.kind,
+    if_changed: result.ifChanged,
+    must_touch_any: result.mustTouchAny,
+    changed_files: result.changedFiles,
+    contract_field: result.contractField,
+    declared_anchors: result.declaredAnchors,
+    evidence_files: result.evidenceFiles,
+    files: uniqueSorted([...(result.changedFiles || []), ...(result.evidenceFiles || [])]),
+    details: evidenceDetails(result),
+  };
+}
+
+export function checkTraceRuleResult(result) {
+  if (result.kind === "must_resolve") {
+    return checkMustResolveTraceRuleResult(result);
+  }
+  if (
+    result.kind === "changed_files_require_evidence" ||
+    result.kind === "declared_anchors_require_evidence"
+  ) {
+    return checkEvidenceTraceRuleResult(result);
+  }
+
+  return {
+    ok: true,
+    trace_rule: result.id,
+    trace_kind: result.kind,
+    details: [],
   };
 }

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -77,6 +77,24 @@ function printCheckDetails(mode, check) {
   if (check.must_not_touch) {
     write(`    must_not_touch: ${check.must_not_touch.join(", ")}`);
   }
+  if (check.if_changed) {
+    write(`    if_changed: ${formatList(check.if_changed)}`);
+  }
+  if (check.must_touch_any) {
+    write(`    must_touch_any: ${formatList(check.must_touch_any)}`);
+  }
+  if (check.changed_files) {
+    write(`    changed_files: ${formatList(check.changed_files)}`);
+  }
+  if (check.evidence_files) {
+    write(`    evidence_files: ${formatList(check.evidence_files)}`);
+  }
+  if (check.contract_field) {
+    write(`    contract_field: ${check.contract_field}`);
+  }
+  if (check.declared_anchors) {
+    write(`    declared_anchors: ${formatList(check.declared_anchors)}`);
+  }
   if (hasOwn(check, "change_class")) {
     write(`    change_class: ${check.change_class || "(missing)"}`);
   }
@@ -149,6 +167,12 @@ function detailFromCheck(check) {
   if (check.touched) details.push(...check.touched.map((f) => `touched: ${f}`));
   if (check.must_touch) details.push(`must_touch: ${check.must_touch.join(", ")}`);
   if (check.must_not_touch) details.push(`must_not_touch: ${check.must_not_touch.join(", ")}`);
+  if (check.if_changed) details.push(`if_changed: ${formatList(check.if_changed)}`);
+  if (check.must_touch_any) details.push(`must_touch_any: ${formatList(check.must_touch_any)}`);
+  if (check.changed_files) details.push(`changed_files: ${formatList(check.changed_files)}`);
+  if (check.evidence_files) details.push(`evidence_files: ${formatList(check.evidence_files)}`);
+  if (check.contract_field) details.push(`contract_field: ${check.contract_field}`);
+  if (check.declared_anchors) details.push(`declared_anchors: ${formatList(check.declared_anchors)}`);
   if (hasOwn(check, "change_class")) details.push(`change_class: ${check.change_class || "(missing)"}`);
   if (hasOwn(check, "change_type")) details.push(`change_type: ${check.change_type || "(missing)"}`);
   if (check.touched_surfaces) details.push(`touched_surfaces: ${formatList(check.touched_surfaces)}`);
@@ -197,6 +221,12 @@ function violationFromCheck(name, check) {
     hint: check.hint,
   };
 
+  if (check.if_changed) violation.if_changed = check.if_changed;
+  if (check.must_touch_any) violation.must_touch_any = check.must_touch_any;
+  if (check.changed_files) violation.changed_files = check.changed_files;
+  if (check.evidence_files) violation.evidence_files = check.evidence_files;
+  if (check.contract_field) violation.contract_field = check.contract_field;
+  if (check.declared_anchors) violation.declared_anchors = check.declared_anchors;
   if (check.status) violation.status = check.status;
   if (check.growth) violation.growth = check.growth;
   if (check.surface_debt) violation.surface_debt = check.surface_debt;

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -198,11 +198,12 @@ export function compileAnchorPolicy(policy) {
   const anchorTypes = anchors?.types || {};
   const anchorTypeNames = new Set(Object.keys(anchorTypes));
   const traceRuleIds = new Set();
+  const contractAnchorFields = new Set(["anchors.affects", "anchors.implements", "anchors.verifies"]);
 
   if (!anchors && traceRules.length === 0) return errors;
 
-  if (traceRules.length > 0 && anchorTypeNames.size === 0) {
-    errors.push({ message: "trace_rules requires anchor types in anchors.types" });
+  if (traceRules.some((rule) => rule.kind === "must_resolve") && anchorTypeNames.size === 0) {
+    errors.push({ message: "trace_rules.kind = \"must_resolve\" requires anchor types in anchors.types" });
   }
 
   for (const [anchorType, config] of Object.entries(anchorTypes)) {
@@ -231,13 +232,23 @@ export function compileAnchorPolicy(policy) {
     }
     traceRuleIds.add(rule.id);
 
-    for (const field of ["from_anchor_type", "to_anchor_type"]) {
-      const anchorType = rule[field];
-      if (!anchorTypeNames.has(anchorType)) {
+    if (rule.kind === "must_resolve") {
+      for (const field of ["from_anchor_type", "to_anchor_type"]) {
+        const anchorType = rule[field];
+        if (!anchorTypeNames.has(anchorType)) {
+          errors.push({
+            trace_rule: rule.id,
+            anchor_type: anchorType,
+            message: `trace_rules[${index}].${field} references unknown anchor type "${anchorType}"`,
+          });
+        }
+      }
+    } else if (rule.kind === "declared_anchors_require_evidence") {
+      if (!contractAnchorFields.has(rule.contract_field)) {
         errors.push({
           trace_rule: rule.id,
-          anchor_type: anchorType,
-          message: `trace_rules[${index}].${field} references unknown anchor type "${anchorType}"`,
+          contract_field: rule.contract_field,
+          message: `trace_rules[${index}].contract_field must be one of ${[...contractAnchorFields].join(", ")}`,
         });
       }
     }

--- a/src/reporting/anchor-diagnostics.mjs
+++ b/src/reporting/anchor-diagnostics.mjs
@@ -1,3 +1,5 @@
+import { buildTraceRuleDiagnostics } from "../checks/trace-rules.mjs";
+
 const CONTRACT_ANCHOR_FIELDS = ["affects", "implements", "verifies"];
 
 function cloneAnchorInstance(instance) {
@@ -6,15 +8,6 @@ function cloneAnchorInstance(instance) {
 
 function sortedUnique(values) {
   return [...new Set((values || []).map((value) => String(value)))].sort();
-}
-
-function groupByValue(instances) {
-  const grouped = new Map();
-  for (const instance of instances || []) {
-    if (!grouped.has(instance.value)) grouped.set(instance.value, []);
-    grouped.get(instance.value).push(cloneAnchorInstance(instance));
-  }
-  return grouped;
 }
 
 function groupByType(anchorTypes, instances) {
@@ -50,73 +43,10 @@ function declaredContractAnchors(contract) {
   return declared;
 }
 
-function buildMustResolveDiagnostics(rule, anchorExtraction) {
-  const fromInstances = anchorExtraction.byType?.[rule.from_anchor_type] || [];
-  const toInstances = anchorExtraction.byType?.[rule.to_anchor_type] || [];
-  const fromByValue = groupByValue(fromInstances);
-  const toByValue = groupByValue(toInstances);
-  const resolved = [];
-  const unresolved = [];
-
-  for (const value of [...fromByValue.keys()].sort()) {
-    const from = fromByValue.get(value);
-    const to = toByValue.get(value) || [];
-    if (to.length > 0) {
-      resolved.push({ value, from, to });
-    } else {
-      unresolved.push({ value, instances: from });
-    }
-  }
-
-  return {
-    id: rule.id,
-    kind: rule.kind,
-    fromAnchorType: rule.from_anchor_type,
-    toAnchorType: rule.to_anchor_type,
-    ok: unresolved.length === 0,
-    resolved,
-    unresolved,
-    stats: {
-      fromInstances: fromInstances.length,
-      fromValues: fromByValue.size,
-      toInstances: toInstances.length,
-      toValues: toByValue.size,
-      resolved: resolved.length,
-      unresolved: unresolved.length,
-    },
-  };
-}
-
-function buildTraceRuleDiagnostics(policy, anchorExtraction) {
-  return (policy.trace_rules || []).map((rule) => {
-    if (rule.kind === "must_resolve") {
-      return buildMustResolveDiagnostics(rule, anchorExtraction);
-    }
-
-    return {
-      id: rule.id,
-      kind: rule.kind,
-      fromAnchorType: rule.from_anchor_type,
-      toAnchorType: rule.to_anchor_type,
-      ok: true,
-      resolved: [],
-      unresolved: [],
-      stats: {
-        fromInstances: 0,
-        fromValues: 0,
-        toInstances: 0,
-        toValues: 0,
-        resolved: 0,
-        unresolved: 0,
-      },
-    };
-  });
-}
-
 function flattenUnresolved(traceRuleResults) {
   const unresolved = [];
   for (const result of traceRuleResults) {
-    for (const item of result.unresolved) {
+    for (const item of result.unresolved || []) {
       unresolved.push({
         rule: result.id,
         kind: result.kind,
@@ -131,7 +61,10 @@ function flattenUnresolved(traceRuleResults) {
 }
 
 export function buildAnchorDiagnostics(facts) {
-  if (!facts.policy.anchors) return {};
+  const traceRuleResults = buildTraceRuleDiagnostics(facts);
+  if (!facts.policy.anchors) {
+    return traceRuleResults.length > 0 ? { traceRuleResults } : {};
+  }
 
   const detected = (facts.anchors?.instances || []).map(cloneAnchorInstance);
   const changedPaths = new Set(facts.derived.changedPaths || []);
@@ -139,7 +72,6 @@ export function buildAnchorDiagnostics(facts) {
     .filter((instance) => changedPaths.has(instance.file))
     .map(cloneAnchorInstance);
   const declaredByContract = declaredContractAnchors(facts.contract);
-  const traceRuleResults = buildTraceRuleDiagnostics(facts.policy, facts.anchors || {});
   const unresolved = flattenUnresolved(traceRuleResults);
 
   return {

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -305,6 +305,26 @@ describe("anchor policy compilation", () => {
     assert.ok(errors[0].message.includes("pattern is invalid"));
   });
 
+  it("accepts evidence trace rules without anchor extractors", () => {
+    const errors = compileAnchorPolicy({
+      trace_rules: [
+        {
+          id: "changed-requirements-need-evidence",
+          kind: "changed_files_require_evidence",
+          if_changed: ["requirements/**"],
+          must_touch_any: ["src/**", "tests/**", "docs/**"],
+        },
+        {
+          id: "declared-anchors-need-evidence",
+          kind: "declared_anchors_require_evidence",
+          contract_field: "anchors.affects",
+          must_touch_any: ["src/**", "tests/**", "docs/**"],
+        },
+      ],
+    });
+    assert.equal(errors.length, 0);
+  });
+
   it("keeps policies without anchors and trace_rules compatible", () => {
     const errors = compileAnchorPolicy({});
     assert.equal(errors.length, 0);

--- a/tests/test-trace-evidence-rules.mjs
+++ b/tests/test-trace-evidence-rules.mjs
@@ -1,0 +1,206 @@
+import { strict as assert } from "node:assert";
+import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (e) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, value, substring) {
+  const actual = String(value || "");
+  const passed = actual.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected ${JSON.stringify(actual)} to include ${JSON.stringify(substring)}`);
+  }
+}
+
+function makePolicy(traceRules) {
+  return {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      operational_paths: [],
+      governance_paths: [],
+    },
+    diff_rules: {
+      max_new_docs: 10,
+      max_new_files: 10,
+      max_net_added_lines: 1000,
+    },
+    trace_rules: traceRules,
+    content_rules: [],
+    cochange_rules: [],
+  };
+}
+
+function runTracePolicy({ traceRules, diffText, contract = null }) {
+  return runPolicyPipeline({
+    mode: "check-diff",
+    repositoryRoot: "/tmp/repo",
+    policy: makePolicy(traceRules),
+    contract,
+    contractSource: contract ? "test" : "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles: [],
+    readFile: () => "",
+    initialChecks: [],
+  }, { quiet: true });
+}
+
+const evidenceSurfaces = ["src/**", "tests/**", "docs/**"];
+
+console.log("\n--- changed requirement files require evidence ---");
+{
+  const traceRules = [
+    {
+      id: "changed-requirements-need-evidence",
+      kind: "changed_files_require_evidence",
+      if_changed: ["requirements/**"],
+      must_touch_any: evidenceSurfaces,
+    },
+  ];
+  const missingEvidenceDiff = [
+    "diff --git a/requirements/fr-001.json b/requirements/fr-001.json",
+    "--- a/requirements/fr-001.json",
+    "+++ b/requirements/fr-001.json",
+    "-{\"id\":\"FR-001\",\"title\":\"Old\"}",
+    "+{\"id\":\"FR-001\",\"title\":\"New\"}",
+  ].join("\n");
+  const result = runTracePolicy({ traceRules, diffText: missingEvidenceDiff });
+
+  expect("requirement-only diff fails", result.ok, false);
+  expect("requirement-only diff sets blocking exit code", result.exitCode, 1);
+
+  const violation = result.violations.find((item) => item.trace_rule === "changed-requirements-need-evidence");
+  expect("missing evidence violation is reported as a trace rule", Boolean(violation), true);
+  expect("missing evidence violation has evidence trace kind", violation?.trace_kind, "changed_files_require_evidence");
+  expect("missing evidence violation keeps changed requirement path", violation?.changed_files, ["requirements/fr-001.json"]);
+  expect("missing evidence violation keeps required evidence surfaces", violation?.must_touch_any, evidenceSurfaces);
+  expectIncludes("missing evidence message is distinct", violation?.message, "missing evidence");
+}
+
+console.log("\n--- evidence surfaces satisfy changed requirement rule ---");
+{
+  const traceRules = [
+    {
+      id: "changed-requirements-need-evidence",
+      kind: "changed_files_require_evidence",
+      if_changed: ["requirements/**"],
+      must_touch_any: evidenceSurfaces,
+    },
+  ];
+  const diffText = [
+    "diff --git a/requirements/fr-001.json b/requirements/fr-001.json",
+    "--- a/requirements/fr-001.json",
+    "+++ b/requirements/fr-001.json",
+    "-{\"id\":\"FR-001\",\"title\":\"Old\"}",
+    "+{\"id\":\"FR-001\",\"title\":\"New\"}",
+    "diff --git a/tests/fr-001.test.mjs b/tests/fr-001.test.mjs",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/tests/fr-001.test.mjs",
+    "+test('FR-001 behavior', () => {});",
+  ].join("\n");
+  const result = runTracePolicy({ traceRules, diffText });
+
+  expect("requirement diff with test evidence passes", result.ok, true);
+  expect("evidence trace result records touched evidence",
+    result.traceRuleResults.find((item) => item.id === "changed-requirements-need-evidence")?.evidenceFiles,
+    ["tests/fr-001.test.mjs"]);
+}
+
+console.log("\n--- declared contract anchors require evidence ---");
+{
+  const traceRules = [
+    {
+      id: "declared-anchors-need-evidence",
+      kind: "declared_anchors_require_evidence",
+      contract_field: "anchors.affects",
+      must_touch_any: evidenceSurfaces,
+    },
+  ];
+  const contract = {
+    change_type: "feature",
+    scope: ["requirements/**"],
+    budgets: {},
+    anchors: {
+      affects: ["FR-001"],
+    },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["Update affected requirement"],
+  };
+  const missingEvidenceDiff = [
+    "diff --git a/requirements/fr-001.json b/requirements/fr-001.json",
+    "--- a/requirements/fr-001.json",
+    "+++ b/requirements/fr-001.json",
+    "-{\"id\":\"FR-001\",\"title\":\"Old\"}",
+    "+{\"id\":\"FR-001\",\"title\":\"New\"}",
+  ].join("\n");
+  const result = runTracePolicy({ traceRules, diffText: missingEvidenceDiff, contract });
+
+  expect("declared affects without evidence fails", result.ok, false);
+  const violation = result.violations.find((item) => item.trace_rule === "declared-anchors-need-evidence");
+  expect("declared anchor evidence violation is reported", Boolean(violation), true);
+  expect("declared anchor evidence violation has distinct kind", violation?.trace_kind, "declared_anchors_require_evidence");
+  expect("declared anchor evidence violation keeps contract field", violation?.contract_field, "anchors.affects");
+  expect("declared anchor evidence violation keeps declared anchors", violation?.declared_anchors, ["FR-001"]);
+  expectIncludes("declared anchor evidence message is distinct", violation?.message, "missing evidence");
+}
+
+console.log("\n--- evidence surfaces satisfy declared anchor rule ---");
+{
+  const traceRules = [
+    {
+      id: "declared-anchors-need-evidence",
+      kind: "declared_anchors_require_evidence",
+      contract_field: "anchors.affects",
+      must_touch_any: evidenceSurfaces,
+    },
+  ];
+  const contract = {
+    change_type: "feature",
+    scope: ["requirements/**", "docs/**"],
+    budgets: {},
+    anchors: {
+      affects: ["FR-001"],
+    },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["Update affected requirement and docs"],
+  };
+  const diffText = [
+    "diff --git a/requirements/fr-001.json b/requirements/fr-001.json",
+    "--- a/requirements/fr-001.json",
+    "+++ b/requirements/fr-001.json",
+    "-{\"id\":\"FR-001\",\"title\":\"Old\"}",
+    "+{\"id\":\"FR-001\",\"title\":\"New\"}",
+    "diff --git a/docs/fr-001.md b/docs/fr-001.md",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/docs/fr-001.md",
+    "+# FR-001",
+  ].join("\n");
+  const result = runTracePolicy({ traceRules, diffText, contract });
+
+  expect("declared affects with docs evidence passes", result.ok, true);
+  expect("declared anchor trace result records declared anchors",
+    result.traceRuleResults.find((item) => item.id === "declared-anchors-need-evidence")?.declaredAnchors,
+    ["FR-001"]);
+}
+
+console.log(`\n${failures === 0 ? "All trace evidence rule tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -68,6 +68,25 @@ const policyWithAnchors = {
 };
 expect("policy with anchors and trace_rules passes schema", validatePolicy(policyWithAnchors), true);
 
+const policyWithEvidenceRules = {
+  ...validPolicy,
+  trace_rules: [
+    {
+      id: "changed-requirements-need-evidence",
+      kind: "changed_files_require_evidence",
+      if_changed: ["requirements/**"],
+      must_touch_any: ["src/**", "tests/**", "docs/**"],
+    },
+    {
+      id: "declared-anchors-need-evidence",
+      kind: "declared_anchors_require_evidence",
+      contract_field: "anchors.affects",
+      must_touch_any: ["src/**", "tests/**", "docs/**"],
+    },
+  ],
+};
+expect("policy with evidence trace_rules passes schema", validatePolicy(policyWithEvidenceRules), true);
+
 // Content rules normalization tests
 const oldFormPolicy = loadJSON(resolve(root, "tests/fixtures/invalid-content-rule-old-form.json"));
 expect("old-form content_rules (pattern/severity/message) fails schema", validatePolicy(oldFormPolicy), false);


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#55.

Adds evidence trace rules so policies can require a real implementation, test, or documentation footprint when requirement artifacts or declared contract anchors change:

- `changed_files_require_evidence` triggers when changed files match `if_changed` and requires at least one changed file matching `must_touch_any`.
- `declared_anchors_require_evidence` triggers when a contract field such as `anchors.affects` declares anchors and requires at least one changed evidence surface.
- Evidence failures are reported as `trace-rule: <id>` violations with `trace_kind`, `must_touch_any`, `changed_files`, `evidence_files`, and contract-anchor fields, distinct from `must_resolve` unresolved-anchor diagnostics.

## How to Reproduce

1. Add a policy trace rule like `changed_files_require_evidence` for `requirements/**` with evidence surfaces `src/**`, `tests/**`, or `docs/**`.
2. Change only a `requirements/**` file.
3. Run `repo-guard check-diff`; the evidence trace rule fails with a missing evidence diagnostic.

For declared contract anchors, add `declared_anchors_require_evidence` with `contract_field: "anchors.affects"`, declare `anchors.affects` in the contract, and run with a diff that does not touch any configured evidence surface.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/checks/trace-rules.mjs
  - src/reporting/anchor-diagnostics.mjs
  - schemas/repo-policy.schema.json
  - tests/test-trace-evidence-rules.mjs
budgets:
  max_new_files: 2
  max_new_docs: 2
  max_net_added_lines: 1200
must_touch:
  - tests/test-trace-evidence-rules.mjs
must_not_touch:
  - LICENSE
expected_effects:
  - Evidence trace rules fail requirement-only changes without configured evidence surfaces.
  - Evidence trace rules fail declared contract anchors without configured evidence surfaces.
  - Missing evidence diagnostics remain distinct from unresolved anchor diagnostics.
```

## Tests

- `npm run test:trace-evidence`
- `npm run test:schemas`
- `npm run test:hardening`
- `npm run test:structured-output`
- `npx repo-guard`
- `npm test`
- Local package smoke path: `npm pack`, install the tarball into a fresh temp directory, then run the installed `repo-guard` against this repository
