### PR TITLE
Add integration policy schema

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-19T23:00:02.379Z for PR creation at branch issue-63-51053d39efe9 for issue https://github.com/netkeep80/repo-guard/issues/63

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-19T23:00:02.379Z for PR creation at branch issue-63-51053d39efe9 for issue https://github.com/netkeep80/repo-guard/issues/63

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ jobs:
 | `advisory_text_rules` | Предупреждает о похожей Markdown-документации, но не блокирует |
 | `anchors` | Извлекает якоря трассировки из regex или источников JSON-полей |
 | `trace_rules` | Проверяет разрешение якорей и наличие файлов-подтверждений |
+| `integration` | Декларативно описывает downstream-интеграцию: workflows, templates, docs и profiles |
 
 Зарезервированные или информационные поля:
 
@@ -273,6 +274,53 @@ jobs:
 областям, файл без подходящей области по умолчанию считается нарушением. Для
 `surface_matrix` можно явно разрешить частичное покрытие через
 `allow_unclassified_files: true`.
+
+## Интеграционный слой
+
+`integration` описывает, как downstream-репозиторий должен подключать
+`repo-guard`: какой workflow запускает проверку, какие шаблоны содержат
+contract block, какие документы объясняют contract/profile/anchor-практики и
+где описаны профили. Это декларативный слой политики. Текущая версия принимает
+и валидирует форму секции, но не читает YAML/Markdown-файлы и не применяет эти
+правила как runtime enforcement.
+
+Пример:
+
+```json
+{
+  "integration": {
+    "workflows": [
+      {
+        "id": "pr-gate",
+        "kind": "github_actions",
+        "path": ".github/workflows/repo-guard.yml",
+        "role": "repo_guard_pr_gate"
+      }
+    ],
+    "templates": [
+      {
+        "id": "pull-request-template",
+        "kind": "markdown",
+        "path": ".github/PULL_REQUEST_TEMPLATE.md",
+        "requires_contract_block": true
+      }
+    ],
+    "docs": [
+      {
+        "id": "readme",
+        "path": "README.md",
+        "must_mention": ["repo-guard", "anchors.affects"]
+      }
+    ],
+    "profiles": [
+      {
+        "id": "requirements-strict",
+        "doc_path": "docs/requirements-strict-profile.md"
+      }
+    ]
+  }
+}
+```
 
 ## Контракт изменения
 
@@ -463,5 +511,7 @@ node src/repo-guard.mjs check-diff --format summary
   Markdown-блоках PR или issue.
 - `paths.governance_paths`, `paths.public_api` и `contract.overrides` не
   изменяют поведение применения правил.
+- `integration` описывает ожидаемую интеграцию, но не проверяет содержимое
+  workflow, template или docs файлов.
 - Проверки работают по git diff и метаданным политики; корректность продукта
   остается задачей тестов, review и специализированных анализаторов.

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -4,6 +4,43 @@
   "enforcement": {
     "mode": "blocking"
   },
+  "integration": {
+    "workflows": [
+      {
+        "id": "ci-pr-policy-check",
+        "kind": "github_actions",
+        "path": ".github/workflows/ci.yml",
+        "role": "repo_guard_pr_gate"
+      }
+    ],
+    "templates": [
+      {
+        "id": "pull-request-template",
+        "kind": "markdown",
+        "path": ".github/PULL_REQUEST_TEMPLATE.md",
+        "requires_contract_block": true
+      },
+      {
+        "id": "change-contract-issue-form",
+        "kind": "github_issue_form",
+        "path": ".github/ISSUE_TEMPLATE/change-contract.yml",
+        "requires_contract_block": true
+      }
+    ],
+    "docs": [
+      {
+        "id": "readme",
+        "path": "README.md",
+        "must_mention": ["repo-guard", "contract", "integration"]
+      }
+    ],
+    "profiles": [
+      {
+        "id": "self-hosting",
+        "doc_path": "README.md"
+      }
+    ]
+  },
   "paths": {
     "forbidden": [
       "docs/phase-*",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -37,6 +37,33 @@
         }
       }
     },
+    "integration": {
+      "type": "object",
+      "description": "Declarative downstream integration layer for documenting which workflows run repo-guard, which templates carry contract blocks, which docs explain the contract, and which profiles are documented. Accepted as policy metadata; file parsing and enforcement are outside this schema layer.",
+      "additionalProperties": false,
+      "properties": {
+        "workflows": {
+          "type": "array",
+          "description": "Expected automation entry points that invoke repo-guard.",
+          "items": { "$ref": "#/definitions/integration_workflow" }
+        },
+        "templates": {
+          "type": "array",
+          "description": "Expected repository templates that carry or require repo-guard contract blocks.",
+          "items": { "$ref": "#/definitions/integration_template" }
+        },
+        "docs": {
+          "type": "array",
+          "description": "Documentation files that should explain repo-guard workflows, contracts, anchors, or profiles.",
+          "items": { "$ref": "#/definitions/integration_doc" }
+        },
+        "profiles": {
+          "type": "array",
+          "description": "Documented policy/profile contracts exposed to downstream contributors.",
+          "items": { "$ref": "#/definitions/integration_profile" }
+        }
+      }
+    },
     "paths": {
       "type": "object",
       "required": ["forbidden", "canonical_docs", "governance_paths"],
@@ -342,10 +369,68 @@
     }
   },
   "definitions": {
+    "non_empty_string": {
+      "type": "string",
+      "minLength": 1
+    },
     "non_empty_string_array": {
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "minItems": 1
+    },
+    "integration_workflow": {
+      "type": "object",
+      "required": ["id", "kind", "path", "role"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/definitions/non_empty_string" },
+        "kind": {
+          "type": "string",
+          "enum": ["github_actions"]
+        },
+        "path": { "$ref": "#/definitions/non_empty_string" },
+        "role": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository-local role for this workflow, for example repo_guard_pr_gate."
+        }
+      }
+    },
+    "integration_template": {
+      "type": "object",
+      "required": ["id", "kind", "path", "requires_contract_block"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/definitions/non_empty_string" },
+        "kind": {
+          "type": "string",
+          "enum": ["markdown", "github_issue_form"]
+        },
+        "path": { "$ref": "#/definitions/non_empty_string" },
+        "requires_contract_block": {
+          "type": "boolean",
+          "description": "Whether the template is expected to include a repo-guard contract block."
+        }
+      }
+    },
+    "integration_doc": {
+      "type": "object",
+      "required": ["id", "path", "must_mention"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/definitions/non_empty_string" },
+        "path": { "$ref": "#/definitions/non_empty_string" },
+        "must_mention": { "$ref": "#/definitions/non_empty_string_array" }
+      }
+    },
+    "integration_profile": {
+      "type": "object",
+      "required": ["id", "doc_path"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/definitions/non_empty_string" },
+        "doc_path": { "$ref": "#/definitions/non_empty_string" }
+      }
     },
     "trace_rule": {
       "oneOf": [

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -2,7 +2,7 @@ import { readFileSync, existsSync, statSync, readdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import { compileAnchorPolicy, compileForbidRegex } from "./policy-compiler.mjs";
+import { compileAnchorPolicy, compileForbidRegex, compileIntegrationPolicy } from "./policy-compiler.mjs";
 
 const PASS = "PASS";
 const WARN = "WARN";
@@ -101,6 +101,12 @@ function checkPolicyDiscovery(repoRoot, packageRoot) {
     if (anchorErrors.length > 0) {
       const details = anchorErrors.map(e => e.message).join("; ");
       return { name: "repo-policy.json", status: FAIL, message: `Invalid anchor policy: ${details}`, hint: "Fix anchors and trace_rules references in repo-policy.json" };
+    }
+
+    const integrationErrors = compileIntegrationPolicy(policy);
+    if (integrationErrors.length > 0) {
+      const details = integrationErrors.map(e => e.message).join("; ");
+      return { name: "repo-policy.json", status: FAIL, message: `Invalid integration policy: ${details}`, hint: "Fix duplicate integration ids in repo-policy.json" };
     }
 
     return { name: "repo-policy.json", status: PASS, message: `Valid (${policy.repository_kind}, format ${policy.policy_format_version})` };

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -257,6 +257,35 @@ export function compileAnchorPolicy(policy) {
   return errors;
 }
 
+export function compileIntegrationPolicy(policy) {
+  const errors = [];
+  const integration = policy.integration;
+
+  if (!integration) return errors;
+
+  for (const section of ["workflows", "templates", "docs", "profiles"]) {
+    const seen = new Map();
+    const entries = Array.isArray(integration[section]) ? integration[section] : [];
+    for (const [index, entry] of entries.entries()) {
+      if (!entry || typeof entry !== "object") continue;
+      if (!entry.id) continue;
+
+      if (seen.has(entry.id)) {
+        errors.push({
+          section,
+          id: entry.id,
+          index,
+          message: `integration.${section}[${index}].id duplicates integration.${section}[${seen.get(entry.id)}].id "${entry.id}"`,
+        });
+      } else {
+        seen.set(entry.id, index);
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function warnReservedContractFields(contract) {
   const warnings = [];
   if (contract.overrides && contract.overrides.length > 0) {

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -9,6 +9,7 @@ import {
   compileAnchorPolicy,
   compileChangeTypePolicy,
   compileForbidRegex,
+  compileIntegrationPolicy,
   compileNewFilePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
@@ -183,6 +184,7 @@ function runValidate(roots, args) {
     ["new file policy compilation", compileNewFilePolicy(policy), (e) => e.message],
     ["change type policy compilation", compileChangeTypePolicy(policy), (e) => e.message],
     ["anchor policy compilation", compileAnchorPolicy(policy), (e) => e.message],
+    ["integration policy compilation", compileIntegrationPolicy(policy), (e) => e.message],
   ];
 
   for (const [label, errors, format] of compileGroups) {

--- a/src/runtime/validation.mjs
+++ b/src/runtime/validation.mjs
@@ -5,6 +5,7 @@ import { ajvErrors } from "../enforcement.mjs";
 import {
   compileAnchorPolicy,
   compileForbidRegex,
+  compileIntegrationPolicy,
   compileNewFilePolicy,
   compileChangeTypePolicy,
   compileSurfacePolicy,
@@ -60,6 +61,7 @@ export function loadPolicyRuntime(roots, options = {}) {
     ["new file policy compilation", compileNewFilePolicy(policy), (e) => e.message],
     ["change type policy compilation", compileChangeTypePolicy(policy), (e) => e.message],
     ["anchor policy compilation", compileAnchorPolicy(policy), (e) => e.message],
+    ["integration policy compilation", compileIntegrationPolicy(policy), (e) => e.message],
   ];
 
   for (const [label, errors, format] of compileGroups) {

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   compileAnchorPolicy,
   compileForbidRegex,
+  compileIntegrationPolicy,
   compileNewFilePolicy,
   compileSurfacePolicy,
   warnReservedContractFields,
@@ -327,6 +328,83 @@ describe("anchor policy compilation", () => {
 
   it("keeps policies without anchors and trace_rules compatible", () => {
     const errors = compileAnchorPolicy({});
+    assert.equal(errors.length, 0);
+  });
+});
+
+describe("integration policy compilation", () => {
+  it("keeps policies without integration compatible", () => {
+    const errors = compileIntegrationPolicy({});
+    assert.equal(errors.length, 0);
+  });
+
+  it("accepts unique ids within each integration section", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: [
+          {
+            id: "pr-gate",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard.yml",
+            role: "repo_guard_pr_gate",
+          },
+        ],
+        templates: [
+          {
+            id: "pull-request-template",
+            kind: "markdown",
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+            requires_contract_block: true,
+          },
+        ],
+        docs: [
+          {
+            id: "readme",
+            path: "README.md",
+            must_mention: ["repo-guard"],
+          },
+        ],
+        profiles: [
+          {
+            id: "requirements-strict",
+            doc_path: "docs/requirements-strict-profile.md",
+          },
+        ],
+      },
+    });
+    assert.equal(errors.length, 0);
+  });
+
+  it("rejects duplicate ids within an integration section", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: [
+          {
+            id: "pr-gate",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard.yml",
+            role: "repo_guard_pr_gate",
+          },
+          {
+            id: "pr-gate",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard-advisory.yml",
+            role: "repo_guard_advisory",
+          },
+        ],
+      },
+    });
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].section, "workflows");
+    assert.ok(errors[0].message.includes("duplicates"));
+  });
+
+  it("leaves malformed integration shapes to schema validation", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: [null, "invalid"],
+      },
+    });
     assert.equal(errors.length, 0);
   });
 });

--- a/tests/test-self-hosting.mjs
+++ b/tests/test-self-hosting.mjs
@@ -73,6 +73,25 @@ describe("repo-guard self-hosting policy", () => {
 
     assert.equal(operational.some((path) => path.startsWith(".github/")), false);
   });
+
+  it("declares its own repo-guard integration surface", () => {
+    const policy = loadPolicy();
+    const integration = policy.integration;
+
+    assert.ok(integration, "self policy should declare integration metadata");
+    assert.equal(integration.workflows[0].path, ".github/workflows/ci.yml");
+    assert.equal(integration.workflows[0].role, "repo_guard_pr_gate");
+    assert.ok(
+      integration.templates.some((template) => template.path === ".github/PULL_REQUEST_TEMPLATE.md"),
+      "expected PR template to be declared",
+    );
+    assert.ok(
+      integration.templates.some((template) => template.path === ".github/ISSUE_TEMPLATE/change-contract.yml"),
+      "expected issue form to be declared",
+    );
+    assert.equal(integration.docs[0].path, "README.md");
+    assert.equal(integration.profiles[0].id, "self-hosting");
+  });
 });
 
 describe("repo-guard self-hosting templates and docs", () => {

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -87,6 +87,57 @@ const policyWithEvidenceRules = {
 };
 expect("policy with evidence trace_rules passes schema", validatePolicy(policyWithEvidenceRules), true);
 
+const policyWithIntegration = {
+  ...validPolicy,
+  integration: {
+    workflows: [
+      {
+        id: "pr-gate",
+        kind: "github_actions",
+        path: ".github/workflows/repo-guard.yml",
+        role: "repo_guard_pr_gate",
+      },
+    ],
+    templates: [
+      {
+        id: "pull-request-template",
+        kind: "markdown",
+        path: ".github/PULL_REQUEST_TEMPLATE.md",
+        requires_contract_block: true,
+      },
+    ],
+    docs: [
+      {
+        id: "readme",
+        path: "README.md",
+        must_mention: ["repo-guard", "anchors.affects"],
+      },
+    ],
+    profiles: [
+      {
+        id: "requirements-strict",
+        doc_path: "docs/requirements-strict-profile.md",
+      },
+    ],
+  },
+};
+expect("policy with integration section passes schema", validatePolicy(policyWithIntegration), true);
+
+const invalidIntegrationPolicy = {
+  ...validPolicy,
+  integration: {
+    workflows: [
+      {
+        id: "pr-gate",
+        kind: "cron",
+        path: ".github/workflows/repo-guard.yml",
+        role: "repo_guard_pr_gate",
+      },
+    ],
+  },
+};
+expect("policy with unknown integration workflow kind fails schema", validatePolicy(invalidIntegrationPolicy), false);
+
 // Content rules normalization tests
 const oldFormPolicy = loadJSON(resolve(root, "tests/fixtures/invalid-content-rule-old-form.json"));
 expect("old-form content_rules (pattern/severity/message) fails schema", validatePolicy(oldFormPolicy), false);


### PR DESCRIPTION
## Summary

Adds a first-class top-level `integration` policy section for declaratively describing downstream repo-guard integration.

## What changed

- Extends `schemas/repo-policy.schema.json` with `integration.workflows`, `integration.templates`, `integration.docs`, and `integration.profiles`.
- Adds compiler validation for duplicate ids within each integration subsection.
- Wires the integration compiler into CLI validation, shared runtime validation, and `doctor` diagnostics.
- Documents the integration layer in README, including the current boundary: schema/compiler metadata validation only, no runtime YAML/Markdown parsing or enforcement.
- Declares repo-guard's own self-hosted workflow, contract templates, README doc, and self-hosting profile in `repo-policy.json`.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - schemas/repo-policy.schema.json
  - repo-policy.json
  - src/policy-compiler.mjs
  - src/runtime/validation.mjs
  - src/repo-guard.mjs
  - src/doctor.mjs
  - tests/validate-schemas.mjs
  - tests/test-hardening.mjs
  - tests/test-self-hosting.mjs
  - README.md
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 500
must_touch:
  - schemas/repo-policy.schema.json
  - tests/**
must_not_touch: []
expected_effects:
  - repo-policy schema accepts integration metadata without requiring it
  - repo-guard validates duplicate integration ids during policy compilation
```

## Reproduction

Before the schema change, a policy containing the issue's proposed `integration` shape failed schema validation because the top-level schema has `additionalProperties: false`.

## Verification

- `npm run test:schemas`
- `npm run test:hardening`
- `npm run test:self-hosting`
- `npm test`
- `node src/repo-guard.mjs`

Fixes netkeep80/repo-guard#63
