### PR TITLE
Add integration fact extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Run anchor extraction tests
         run: npm run test:anchors
 
+      - name: Run integration extraction tests
+        run: npm run test:integration
+
       - name: Run trace evidence rule tests
         run: npm run test:trace-evidence
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T09:07:10.800Z for PR creation at branch issue-65-bfcf5b6445b3 for issue https://github.com/netkeep80/repo-guard/issues/65

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T09:07:10.800Z for PR creation at branch issue-65-bfcf5b6445b3 for issue https://github.com/netkeep80/repo-guard/issues/65

--- a/README.md
+++ b/README.md
@@ -280,9 +280,19 @@ jobs:
 `integration` описывает, как downstream-репозиторий должен подключать
 `repo-guard`: какой workflow запускает проверку, какие шаблоны содержат
 contract block, какие документы объясняют contract/profile/anchor-практики и
-где описаны профили. Это декларативный слой политики. Текущая версия принимает
-и валидирует форму секции, но не читает YAML/Markdown-файлы и не применяет эти
-правила как runtime enforcement.
+где описаны профили. Это декларативный слой политики: `repo-guard` читает
+перечисленные YAML/Markdown-файлы и строит normalized facts, но не применяет
+их как runtime enforcement rules.
+
+`buildPolicyFacts(...).integration` содержит:
+
+| Факт | Что извлекается |
+| --- | --- |
+| `workflows` | GitHub Actions events, permissions, `uses`, `with`, `env`, `if` и публикация в `$GITHUB_STEP_SUMMARY` |
+| `templates` | Наличие fenced `repo-guard-yaml` / `repo-guard-json` blocks и поля контракта |
+| `docs` | Markdown headings, code blocks и упоминания из `must_mention` |
+| `profiles` | Идентификаторы профилей, migration target mentions и ссылки на имя профиля |
+| `errors` | Явные ошибки чтения, malformed YAML, malformed contract blocks и незакрытые Markdown fences |
 
 Пример:
 
@@ -499,7 +509,7 @@ node src/repo-guard.mjs check-diff --format summary
 | `src/markdown-contract.mjs` | Извлечение контракта из Markdown |
 | `src/runtime/` | Валидация и общий конвейер политики |
 | `src/checks/` | Оркестрация проверок политики |
-| `src/extractors/` | Извлекатели якорей |
+| `src/extractors/` | Извлекатели якорей и integration facts |
 | `schemas/` | JSON Schemas для политики и контракта |
 | `templates/` | Примеры политики, рабочего процесса и контрактов |
 | `tests/` | Модульные и интеграционные тесты |
@@ -511,7 +521,7 @@ node src/repo-guard.mjs check-diff --format summary
   Markdown-блоках PR или issue.
 - `paths.governance_paths`, `paths.public_api` и `contract.overrides` не
   изменяют поведение применения правил.
-- `integration` описывает ожидаемую интеграцию, но не проверяет содержимое
-  workflow, template или docs файлов.
+- `integration` извлекает факты из workflow, template, docs и profile files,
+  но не применяет их как blocking enforcement.
 - Проверки работают по git diff и метаданным политики; корректность продукта
   остается задачей тестов, review и специализированных анализаторов.

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:anchors": "node tests/test-anchor-extractors.mjs",
+    "test:integration": "node tests/test-integration-extractors.mjs",
     "test:trace-evidence": "node tests/test-trace-evidence-rules.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",

--- a/src/extractors/integration.mjs
+++ b/src/extractors/integration.mjs
@@ -1,0 +1,598 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseDocument } from "yaml";
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort();
+}
+
+function readRepositoryFile(filePath, options) {
+  if (options.readFile) {
+    const content = options.readFile(filePath);
+    if (content === undefined || content === null) {
+      throw new Error(`cannot read ${filePath}`);
+    }
+    return String(content);
+  }
+  return readFileSync(resolve(options.repoRoot || process.cwd(), filePath), "utf-8");
+}
+
+function collapseMessage(message) {
+  return String(message || "").replace(/\s+/g, " ").trim();
+}
+
+function parseYamlFile(content) {
+  const doc = parseDocument(content, { prettyErrors: false });
+  if (doc.errors.length > 0) {
+    throw new Error(`invalid YAML: ${doc.errors.map((error) => collapseMessage(error.message)).join("; ")}`);
+  }
+  return doc.toJSON();
+}
+
+function normalizeValue(value) {
+  if (value === undefined) return "";
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeMap(value) {
+  if (!isPlainObject(value)) return null;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => [key, normalizeValue(item)])
+  );
+}
+
+function extractTriggerEvents(onValue) {
+  if (typeof onValue === "string") return [onValue];
+  if (Array.isArray(onValue)) {
+    return onValue
+      .filter((item) => item !== null && item !== undefined)
+      .map((item) => normalizeValue(item));
+  }
+  if (isPlainObject(onValue)) return Object.keys(onValue);
+  return [];
+}
+
+function collectEnvVars(envValue, scope, extra = {}) {
+  const env = normalizeMap(envValue);
+  if (!env) return [];
+  return Object.entries(env).map(([name, value]) => ({
+    scope,
+    ...extra,
+    name,
+    value,
+  }));
+}
+
+function collectWorkflowFacts(entry, content) {
+  const data = parseYamlFile(content);
+  if (!isPlainObject(data)) {
+    throw new Error("workflow YAML must be a mapping");
+  }
+
+  const jobs = isPlainObject(data.jobs) ? data.jobs : {};
+  const actionUses = [];
+  const stepInputs = [];
+  const envVars = collectEnvVars(data.env, "workflow");
+  const ifConditions = [];
+  const summaryPublishing = [];
+  const jobPermissions = [];
+
+  for (const [jobId, job] of Object.entries(jobs)) {
+    if (!isPlainObject(job)) continue;
+
+    const jobPermission = normalizeMap(job.permissions);
+    if (jobPermission) {
+      jobPermissions.push({ jobId, permissions: jobPermission });
+    } else if (typeof job.permissions === "string") {
+      jobPermissions.push({ jobId, permissions: job.permissions });
+    }
+
+    envVars.push(...collectEnvVars(job.env, "job", { jobId }));
+
+    if (job.if !== undefined) {
+      ifConditions.push({
+        scope: "job",
+        jobId,
+        condition: normalizeValue(job.if),
+      });
+    }
+
+    if (job.uses !== undefined) {
+      const uses = normalizeValue(job.uses);
+      actionUses.push({ scope: "job", jobId, uses });
+      const inputs = normalizeMap(job.with);
+      if (inputs) {
+        stepInputs.push({ scope: "job", jobId, uses, inputs });
+      }
+    }
+
+    if (!Array.isArray(job.steps)) continue;
+
+    for (const [stepOffset, step] of job.steps.entries()) {
+      if (!isPlainObject(step)) continue;
+      const stepIndex = stepOffset + 1;
+      const stepName = step.name ? normalizeValue(step.name) : undefined;
+      const stepBase = { jobId, stepIndex };
+      if (stepName) stepBase.stepName = stepName;
+
+      if (step.uses !== undefined) {
+        const uses = normalizeValue(step.uses);
+        actionUses.push({ ...stepBase, uses });
+        const inputs = normalizeMap(step.with);
+        if (inputs) {
+          stepInputs.push({ ...stepBase, uses, inputs });
+        }
+      }
+
+      envVars.push(...collectEnvVars(step.env, "step", stepBase));
+
+      if (step.if !== undefined) {
+        ifConditions.push({
+          scope: "step",
+          ...stepBase,
+          condition: normalizeValue(step.if),
+        });
+      }
+
+      const summaryMode = detectSummaryPublishingMode(step.run);
+      if (summaryMode) {
+        summaryPublishing.push({
+          ...stepBase,
+          mode: summaryMode,
+        });
+      }
+    }
+  }
+
+  const workflowPermission = normalizeMap(data.permissions) ||
+    (typeof data.permissions === "string" ? data.permissions : null);
+
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    path: entry.path,
+    role: entry.role,
+    triggerEvents: extractTriggerEvents(data.on),
+    permissions: {
+      workflow: workflowPermission,
+      jobs: jobPermissions,
+    },
+    actionUses,
+    stepInputs,
+    envVars,
+    ifConditions,
+    summaryPublishing,
+  };
+}
+
+function detectSummaryPublishingMode(run) {
+  if (run === undefined || run === null) return null;
+  const text = String(run);
+  if (!text.includes("GITHUB_STEP_SUMMARY")) return null;
+  const summaryTarget = String.raw`["']?\$?\{?GITHUB_STEP_SUMMARY\}?["']?`;
+  const appendBeforeTarget = new RegExp(`>>\\s*${summaryTarget}`).test(text);
+  const appendAfterTarget = new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*>>`).test(text);
+  if (appendBeforeTarget || appendAfterTarget) return "append";
+  const writeBeforeTarget = new RegExp(`(^|[^>])>\\s*${summaryTarget}`).test(text);
+  const writeAfterTarget = new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*(^|[^>])>`).test(text);
+  if (writeBeforeTarget || writeAfterTarget) return "write";
+  return "mentions";
+}
+
+function parseMarkdown(content) {
+  const lines = String(content || "").split(/\r?\n/);
+  const headings = [];
+  const codeBlocks = [];
+  const errors = [];
+  let fence = null;
+
+  for (const [offset, line] of lines.entries()) {
+    const lineNumber = offset + 1;
+
+    if (!fence) {
+      const heading = line.match(/^[ \t]{0,3}(#{1,6})(?:[ \t]+|$)(.*)$/);
+      if (heading) {
+        const text = heading[2].replace(/[ \t]+#+[ \t]*$/, "").trim();
+        if (text) headings.push({ level: heading[1].length, text, line: lineNumber });
+      }
+
+      const openingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+      if (openingFence) {
+        fence = {
+          marker: openingFence[1][0],
+          length: openingFence[1].length,
+          infoString: openingFence[2].trim(),
+          startLine: lineNumber,
+          contentLines: [],
+        };
+      }
+      continue;
+    }
+
+    const closingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
+    if (
+      closingFence &&
+      closingFence[1][0] === fence.marker &&
+      closingFence[1].length >= fence.length
+    ) {
+      const language = fence.infoString.split(/\s+/).filter(Boolean)[0] || "";
+      codeBlocks.push({
+        language,
+        infoString: fence.infoString,
+        startLine: fence.startLine,
+        endLine: lineNumber,
+        content: fence.contentLines.join("\n"),
+      });
+      fence = null;
+      continue;
+    }
+
+    fence.contentLines.push(line);
+  }
+
+  if (fence) {
+    errors.push({
+      message: `unclosed Markdown fence starting at line ${fence.startLine}`,
+    });
+  }
+
+  return { headings, codeBlocks, errors };
+}
+
+function publicCodeBlock(block) {
+  return {
+    language: block.language,
+    infoString: block.infoString,
+    startLine: block.startLine,
+    endLine: block.endLine,
+  };
+}
+
+function fieldPathsFromObject(value, prefix = "") {
+  if (!isPlainObject(value)) return [];
+  const paths = [];
+  for (const key of Object.keys(value).sort()) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    paths.push(path);
+    paths.push(...fieldPathsFromObject(value[key], path));
+  }
+  return paths;
+}
+
+function parseContractBlock(block) {
+  try {
+    let data;
+    if (block.language === "repo-guard-json") {
+      data = JSON.parse(block.content);
+    } else {
+      data = parseYamlFile(block.content);
+    }
+    const fieldPaths = uniqueSorted(fieldPathsFromObject(data));
+    return {
+      ok: true,
+      fieldNames: isPlainObject(data) ? Object.keys(data).sort() : [],
+      fieldPaths,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      message: `invalid ${block.language} block at line ${block.startLine}: ${e.message}`,
+    };
+  }
+}
+
+function extractContractBlocks(markdown) {
+  const blocks = [];
+  const errors = [];
+
+  for (const block of markdown.codeBlocks) {
+    if (block.language !== "repo-guard-yaml" && block.language !== "repo-guard-json") {
+      continue;
+    }
+
+    const parsed = parseContractBlock(block);
+    const fact = {
+      format: block.language,
+      startLine: block.startLine,
+      endLine: block.endLine,
+      ok: parsed.ok,
+      fieldNames: parsed.fieldNames || [],
+      fieldPaths: parsed.fieldPaths || [],
+    };
+    blocks.push(fact);
+
+    if (!parsed.ok) {
+      errors.push({ message: parsed.message });
+    }
+  }
+
+  return { blocks, errors };
+}
+
+function templateFactFromMarkdown(entry, markdown) {
+  const { blocks, errors } = extractContractBlocks(markdown);
+  return {
+    fact: {
+      id: entry.id,
+      kind: entry.kind,
+      path: entry.path,
+      requiresContractBlock: Boolean(entry.requires_contract_block),
+      hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
+      hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
+      contractBlocks: blocks,
+      contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
+      headings: markdown.headings,
+      codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+    },
+    errors,
+  };
+}
+
+function collectStringValues(value, sourcePath = "$") {
+  if (typeof value === "string") return [{ sourcePath, value }];
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => collectStringValues(item, `${sourcePath}[${index}]`));
+  }
+  if (isPlainObject(value)) {
+    return Object.entries(value).flatMap(([key, item]) => collectStringValues(item, `${sourcePath}.${key}`));
+  }
+  return [];
+}
+
+function collectIssueFormTemplateFacts(entry, content) {
+  const data = parseYamlFile(content);
+  const blocks = [];
+  const errors = [];
+
+  for (const source of collectStringValues(data)) {
+    const markdown = parseMarkdown(source.value);
+    errors.push(...markdown.errors.map((error) => ({
+      message: `${source.sourcePath}: ${error.message}`,
+    })));
+
+    const extracted = extractContractBlocks(markdown);
+    blocks.push(...extracted.blocks.map((block) => ({
+      ...block,
+      sourcePath: source.sourcePath,
+    })));
+    errors.push(...extracted.errors.map((error) => ({
+      message: `${source.sourcePath}: ${error.message}`,
+    })));
+  }
+
+  return {
+    fact: {
+      id: entry.id,
+      kind: entry.kind,
+      path: entry.path,
+      requiresContractBlock: Boolean(entry.requires_contract_block),
+      hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
+      hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
+      contractBlocks: blocks,
+      contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
+    },
+    errors,
+  };
+}
+
+function collectTemplateFacts(entry, content) {
+  if (entry.kind === "github_issue_form") {
+    return collectIssueFormTemplateFacts(entry, content);
+  }
+
+  const markdown = parseMarkdown(content);
+  const result = templateFactFromMarkdown(entry, markdown);
+  result.errors.push(...markdown.errors);
+  return result;
+}
+
+function findLiteralOccurrences(content, term) {
+  if (!term) return [];
+  const needle = String(term).toLowerCase();
+  const locations = [];
+
+  for (const [offset, line] of String(content || "").split(/\r?\n/).entries()) {
+    const haystack = line.toLowerCase();
+    let index = 0;
+    while ((index = haystack.indexOf(needle, index)) !== -1) {
+      locations.push({ line: offset + 1, column: index + 1 });
+      index += Math.max(needle.length, 1);
+    }
+  }
+
+  return locations;
+}
+
+function mentionFact(content, term) {
+  const locations = findLiteralOccurrences(content, term);
+  return {
+    term,
+    present: locations.length > 0,
+    count: locations.length,
+    locations,
+  };
+}
+
+function collectDocFacts(entry, content) {
+  const markdown = parseMarkdown(content);
+  return {
+    fact: {
+      id: entry.id,
+      path: entry.path,
+      headings: markdown.headings,
+      codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+      hasCodeBlocks: markdown.codeBlocks.length > 0,
+      mentions: (entry.must_mention || []).map((term) => mentionFact(content, term)),
+    },
+    errors: markdown.errors,
+  };
+}
+
+function collectRegexFacts(content, regexes) {
+  const facts = [];
+  const seen = new Set();
+  const lines = String(content || "").split(/\r?\n/);
+
+  for (const [offset, line] of lines.entries()) {
+    for (const sourceRegex of regexes) {
+      const regex = new RegExp(sourceRegex.source, sourceRegex.flags.includes("g")
+        ? sourceRegex.flags
+        : `${sourceRegex.flags}g`);
+      let match;
+      while ((match = regex.exec(line)) !== null) {
+        const value = match[1];
+        if (!value) continue;
+        const column = match.index + match[0].lastIndexOf(value) + 1;
+        const key = `${value}:${offset + 1}:${column}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          facts.push({ value, line: offset + 1, column });
+        }
+      }
+    }
+  }
+
+  return facts;
+}
+
+function profileReferenceFacts(content, profileId) {
+  const values = uniqueSorted([
+    profileId,
+    String(profileId || "").replace(/[-_.]+/g, " ").trim(),
+  ].filter(Boolean));
+  const facts = [];
+  const seen = new Set();
+
+  for (const value of values) {
+    for (const location of findLiteralOccurrences(content, value)) {
+      const key = `${profileId}:${location.line}:${location.column}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      facts.push({ value: profileId, ...location });
+    }
+  }
+
+  facts.sort((left, right) => left.line - right.line || left.column - right.column || left.value.localeCompare(right.value));
+  return facts;
+}
+
+function collectProfileFacts(entry, content) {
+  const markdown = parseMarkdown(content);
+  const identifiers = collectRegexFacts(content, [
+    /\bprofile[ _-]?id\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+    /\bprofile\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+  ]);
+  const migrationTargets = collectRegexFacts(content, [
+    /\bmigration[ _-]?target\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+    /\bmigrat(?:e|es|ed|ing)\s+to\s+`?([A-Za-z0-9_.-]+)/i,
+  ]);
+
+  return {
+    fact: {
+      id: entry.id,
+      docPath: entry.doc_path,
+      headings: markdown.headings,
+      codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+      identifiers,
+      migrationTargets,
+      profileNameReferences: profileReferenceFacts(content, entry.id),
+    },
+    errors: markdown.errors,
+  };
+}
+
+function compareErrors(left, right) {
+  return left.section.localeCompare(right.section) ||
+    (left.path || "").localeCompare(right.path || "") ||
+    (left.id || "").localeCompare(right.id || "") ||
+    left.message.localeCompare(right.message);
+}
+
+function withErrorContext(section, entry, message) {
+  return {
+    section,
+    id: entry.id,
+    kind: entry.kind,
+    path: entry.path || entry.doc_path,
+    message,
+  };
+}
+
+export function extractIntegration(policy, options = {}) {
+  const integration = policy.integration;
+  const result = {
+    workflows: [],
+    templates: [],
+    docs: [],
+    profiles: [],
+    errors: [],
+  };
+
+  if (!integration) return result;
+
+  const contentCache = new Map();
+  function contentFor(file) {
+    if (!contentCache.has(file)) {
+      contentCache.set(file, readRepositoryFile(file, options));
+    }
+    return contentCache.get(file);
+  }
+
+  for (const entry of integration.workflows || []) {
+    try {
+      result.workflows.push(collectWorkflowFacts(entry, contentFor(entry.path)));
+    } catch (e) {
+      result.errors.push(withErrorContext("workflows", entry, e.message));
+    }
+  }
+
+  for (const entry of integration.templates || []) {
+    try {
+      const extracted = collectTemplateFacts(entry, contentFor(entry.path));
+      result.templates.push(extracted.fact);
+      result.errors.push(...extracted.errors.map((error) =>
+        withErrorContext("templates", entry, error.message)
+      ));
+    } catch (e) {
+      result.errors.push(withErrorContext("templates", entry, e.message));
+    }
+  }
+
+  for (const entry of integration.docs || []) {
+    try {
+      const extracted = collectDocFacts(entry, contentFor(entry.path));
+      result.docs.push(extracted.fact);
+      result.errors.push(...extracted.errors.map((error) =>
+        withErrorContext("docs", entry, error.message)
+      ));
+    } catch (e) {
+      result.errors.push(withErrorContext("docs", entry, e.message));
+    }
+  }
+
+  for (const entry of integration.profiles || []) {
+    try {
+      const extracted = collectProfileFacts(entry, contentFor(entry.doc_path));
+      result.profiles.push(extracted.fact);
+      result.errors.push(...extracted.errors.map((error) =>
+        withErrorContext("profiles", entry, error.message)
+      ));
+    } catch (e) {
+      result.errors.push(withErrorContext("profiles", entry, e.message));
+    }
+  }
+
+  result.errors.sort(compareErrors);
+  return result;
+}

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -6,6 +6,7 @@ import {
   classifyNewFiles,
 } from "../diff-checker.mjs";
 import { extractAnchors } from "../extractors/anchors.mjs";
+import { extractIntegration } from "../extractors/integration.mjs";
 
 export function listTrackedFiles(repoRoot) {
   return execSync("git ls-files", { encoding: "utf-8", cwd: repoRoot })
@@ -43,6 +44,12 @@ export function buildPolicyFacts({
     changedFiles: checkedFiles,
     readFile,
   });
+  const integration = extractIntegration(policy, {
+    repoRoot: repositoryRoot,
+    trackedFiles: resolvedTrackedFiles,
+    changedFiles: checkedFiles,
+    readFile,
+  });
 
   return {
     mode,
@@ -60,6 +67,7 @@ export function buildPolicyFacts({
       },
     },
     anchors,
+    integration,
     trackedFiles: resolvedTrackedFiles,
     derived: {
       changedPaths,

--- a/tests/test-integration-extractors.mjs
+++ b/tests/test-integration-extractors.mjs
@@ -1,0 +1,326 @@
+import { strict as assert } from "node:assert";
+import { buildPolicyFacts } from "../src/facts/input.mjs";
+import { extractIntegration } from "../src/extractors/integration.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (e) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, value, substring) {
+  const actual = String(value || "");
+  const passed = actual.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected ${JSON.stringify(actual)} to include ${JSON.stringify(substring)}`);
+  }
+}
+
+function makeReadFile(files) {
+  return (file) => {
+    if (!Object.hasOwn(files, file)) {
+      throw new Error(`missing fixture ${file}`);
+    }
+    return files[file];
+  };
+}
+
+function makePolicy(overrides = {}) {
+  return {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    integration: {
+      workflows: [
+        {
+          id: "pr-gate",
+          kind: "github_actions",
+          path: ".github/workflows/repo-guard.yml",
+          role: "repo_guard_pr_gate",
+        },
+      ],
+      templates: [
+        {
+          id: "pull-request-template",
+          kind: "markdown",
+          path: ".github/PULL_REQUEST_TEMPLATE.md",
+          requires_contract_block: true,
+        },
+        {
+          id: "change-contract-issue-form",
+          kind: "github_issue_form",
+          path: ".github/ISSUE_TEMPLATE/change-contract.yml",
+          requires_contract_block: true,
+        },
+      ],
+      docs: [
+        {
+          id: "readme",
+          path: "README.md",
+          must_mention: ["repo-guard", "contract", "integration", "anchors.affects"],
+        },
+      ],
+      profiles: [
+        {
+          id: "self-hosting",
+          doc_path: "README.md",
+        },
+      ],
+      ...overrides.integration,
+    },
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      operational_paths: [],
+      governance_paths: [],
+    },
+    diff_rules: {
+      max_new_docs: 10,
+      max_new_files: 10,
+      max_net_added_lines: 1000,
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+}
+
+const files = {
+  ".github/workflows/repo-guard.yml": [
+    "name: repo guard",
+    "on:",
+    "  pull_request:",
+    "    types: [opened, synchronize]",
+    "  push:",
+    "permissions:",
+    "  contents: read",
+    "env:",
+    "  RG_MODE: blocking",
+    "jobs:",
+    "  validate:",
+    "    if: github.event.pull_request.draft == false",
+    "    permissions:",
+    "      pull-requests: write",
+    "    runs-on: ubuntu-latest",
+    "    env:",
+    "      JOB_ENV: job-value",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          fetch-depth: 0",
+    "      - name: Run repo-guard",
+    "        if: always()",
+    "        env:",
+    "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+    "        run: |",
+    "          node src/repo-guard.mjs check-pr",
+    "          echo \"### repo-guard\" >> \"$GITHUB_STEP_SUMMARY\"",
+    "      - uses: ./",
+    "        with:",
+    "          mode: check-pr",
+  ].join("\n"),
+  ".github/PULL_REQUEST_TEMPLATE.md": [
+    "# Change Contract",
+    "",
+    "```repo-guard-yaml",
+    "change_type: feature",
+    "scope:",
+    "  - src/**",
+    "anchors:",
+    "  affects:",
+    "    - FR-001",
+    "```",
+  ].join("\n"),
+  ".github/ISSUE_TEMPLATE/change-contract.yml": [
+    "name: Change contract",
+    "body:",
+    "  - type: markdown",
+    "    attributes:",
+    "      value: |",
+    "        ```repo-guard-yaml",
+    "        change_type: docs",
+    "        expected_effects:",
+    "          - README explains the contract",
+    "        ```",
+  ].join("\n"),
+  "README.md": [
+    "# Repo Guard",
+    "",
+    "Uses repo-guard contract and integration policy.",
+    "",
+    "```bash",
+    "repo-guard check-pr",
+    "```",
+    "",
+    "Profile id: self-hosting",
+    "Migration target: requirements-strict",
+    "The self-hosting profile is the default profile name.",
+  ].join("\n"),
+};
+
+console.log("\n--- integration extractor builds normalized workflow, template, doc, and profile facts ---");
+{
+  const policy = makePolicy();
+  const extraction = extractIntegration(policy, {
+    repoRoot: "/tmp/repo",
+    trackedFiles: Object.keys(files),
+    readFile: makeReadFile(files),
+  });
+
+  expect("integration extraction reports no errors", extraction.errors, []);
+
+  const workflow = extraction.workflows[0];
+  expect("workflow trigger events are normalized", workflow.triggerEvents, ["pull_request", "push"]);
+  expect("workflow permissions are normalized", workflow.permissions.workflow, { contents: "read" });
+  expect("job permissions are normalized", workflow.permissions.jobs, [
+    { jobId: "validate", permissions: { "pull-requests": "write" } },
+  ]);
+  expect("action uses are collected from steps", workflow.actionUses.map((fact) => fact.uses), [
+    "actions/checkout@v4",
+    "./",
+  ]);
+  expect("step inputs keep scalar values as strings",
+    workflow.stepInputs.find((fact) => fact.uses === "actions/checkout@v4")?.inputs,
+    { "fetch-depth": "0" });
+  expect("env vars include workflow, job, and step scopes",
+    workflow.envVars.map((fact) => `${fact.scope}:${fact.name}`).sort(),
+    ["job:JOB_ENV", "step:GH_TOKEN", "workflow:RG_MODE"]);
+  expect("if conditions include job and step scopes",
+    workflow.ifConditions.map((fact) => `${fact.scope}:${fact.condition}`),
+    ["job:github.event.pull_request.draft == false", "step:always()"]);
+  expect("summary publishing behavior is detected", workflow.summaryPublishing, [
+    {
+      jobId: "validate",
+      stepIndex: 2,
+      stepName: "Run repo-guard",
+      mode: "append",
+    },
+  ]);
+
+  const prTemplate = extraction.templates.find((template) => template.id === "pull-request-template");
+  const issueTemplate = extraction.templates.find((template) => template.id === "change-contract-issue-form");
+  expect("markdown template detects repo-guard-yaml block", prTemplate?.hasRepoGuardYamlBlock, true);
+  expect("markdown template extracts nested contract field names", prTemplate?.contractFieldNames, [
+    "anchors",
+    "anchors.affects",
+    "change_type",
+    "scope",
+  ]);
+  expect("issue form template extracts markdown contract blocks from YAML string fields",
+    issueTemplate?.contractFieldNames,
+    ["change_type", "expected_effects"]);
+
+  const doc = extraction.docs[0];
+  expect("docs expose headings", doc.headings, [{ level: 1, text: "Repo Guard", line: 1 }]);
+  expect("docs expose code block presence", doc.codeBlocks, [
+    { language: "bash", infoString: "bash", startLine: 5, endLine: 7 },
+  ]);
+  expect("docs expose text mention facts",
+    doc.mentions.map((mention) => `${mention.term}:${mention.present}:${mention.count}`),
+    ["repo-guard:true:2", "contract:true:1", "integration:true:1", "anchors.affects:false:0"]);
+
+  const profile = extraction.profiles[0];
+  expect("profile docs expose configured profile identifiers",
+    profile.identifiers.map((fact) => fact.value),
+    ["self-hosting"]);
+  expect("profile docs expose migration target mentions",
+    profile.migrationTargets.map((fact) => fact.value),
+    ["requirements-strict"]);
+  expect("profile docs expose profile name references",
+    profile.profileNameReferences.map((fact) => fact.value),
+    ["self-hosting", "self-hosting"]);
+}
+
+console.log("\n--- policy facts expose integration extraction independently from enforcement ---");
+{
+  const facts = buildPolicyFacts({
+    mode: "check-diff",
+    repositoryRoot: "/tmp/repo",
+    policy: makePolicy(),
+    contract: null,
+    contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText: "",
+    trackedFiles: Object.keys(files),
+    readFile: makeReadFile(files),
+  });
+
+  expect("facts expose integration workflow facts", facts.integration.workflows[0].triggerEvents, [
+    "pull_request",
+    "push",
+  ]);
+  expect("facts expose integration extraction errors", facts.integration.errors, []);
+}
+
+console.log("\n--- malformed integration artifacts produce explicit diagnostics ---");
+{
+  const policy = makePolicy({
+    integration: {
+      workflows: [
+        {
+          id: "bad-workflow",
+          kind: "github_actions",
+          path: ".github/workflows/bad.yml",
+          role: "repo_guard_pr_gate",
+        },
+      ],
+      templates: [
+        {
+          id: "bad-template",
+          kind: "markdown",
+          path: ".github/PULL_REQUEST_TEMPLATE.md",
+          requires_contract_block: true,
+        },
+      ],
+      docs: [
+        {
+          id: "bad-doc",
+          path: "README.md",
+          must_mention: ["repo-guard"],
+        },
+      ],
+      profiles: [],
+    },
+  });
+  const malformedFiles = {
+    ".github/workflows/bad.yml": "name: bad\non: [",
+    ".github/PULL_REQUEST_TEMPLATE.md": [
+      "```repo-guard-yaml",
+      "change_type: [",
+      "```",
+    ].join("\n"),
+    "README.md": [
+      "# Bad Doc",
+      "",
+      "```bash",
+      "repo-guard check-pr",
+    ].join("\n"),
+  };
+
+  const extraction = extractIntegration(policy, {
+    repoRoot: "/tmp/repo",
+    trackedFiles: Object.keys(malformedFiles),
+    readFile: makeReadFile(malformedFiles),
+  });
+
+  expect("malformed extraction records one error per artifact", extraction.errors.length, 3);
+  expectIncludes("workflow error identifies invalid YAML",
+    extraction.errors.find((error) => error.section === "workflows")?.message,
+    "invalid YAML");
+  expectIncludes("template error identifies invalid contract block",
+    extraction.errors.find((error) => error.section === "templates")?.message,
+    "invalid repo-guard-yaml block");
+  expectIncludes("doc error identifies unclosed Markdown fence",
+    extraction.errors.find((error) => error.section === "docs")?.message,
+    "unclosed Markdown fence");
+}
+
+console.log(`\n${failures === 0 ? "All integration extractor tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#65.

Adds a reusable integration extraction layer that reads downstream workflow, template, docs, and profile files into normalized facts without adding enforcement rules.

## What changed

- Adds `src/extractors/integration.mjs` for GitHub Actions workflow YAML, Markdown templates, docs, and profile docs.
- Wires `buildPolicyFacts(...).integration` so future checks can reuse the extracted facts.
- Extracts workflow trigger events, permissions, action `uses`, step inputs, env vars, `if` conditions, and `$GITHUB_STEP_SUMMARY` publishing.
- Extracts `repo-guard-yaml` / `repo-guard-json` contract blocks and contract field paths from Markdown templates and GitHub issue forms.
- Extracts Markdown headings, code blocks, configured text mention facts, profile identifiers, migration targets, and profile name references.
- Reports explicit diagnostics for invalid YAML, malformed contract blocks, unreadable files, and unclosed Markdown fences.
- Adds integration extractor tests and runs them in CI.
- Removes the generated PR bootstrap `.gitkeep`.

## Reproduction

Before this change, `repo-policy.json` could declare `integration` metadata, but there was no runtime extraction API to read the referenced YAML/Markdown files. A caller of `buildPolicyFacts()` had anchors, diff facts, and derived facts, but no normalized integration facts for reusable checks.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/extractors/integration.mjs
  - src/facts/input.mjs
  - tests/test-integration-extractors.mjs
  - package.json
  - .github/workflows/ci.yml
  - README.md
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 1200
must_touch:
  - src/extractors/integration.mjs
  - tests/test-integration-extractors.mjs
must_not_touch:
  - schemas/**
expected_effects:
  - repo-guard builds normalized integration facts from declared workflow, template, docs, and profile files.
  - Malformed YAML and Markdown artifacts produce explicit extraction diagnostics.
  - Integration extraction remains reusable facts, not runtime enforcement.
```

## Verification

- `node tests/test-integration-extractors.mjs` first failed with the missing extractor module.
- `npm run test:integration`
- `npm test`
- `npm run validate`
- `git diff --check`
- `node --check src/extractors/integration.mjs`
- `node --check tests/test-integration-extractors.mjs`
- Package smoke: `npm pack`, install the tarball into a fresh temp prefix, run installed `.bin/repo-guard --repo-root "$PWD"`
- `node src/repo-guard.mjs check-diff --enforcement blocking` after staging the intended test/source files
