### PR TITLE
Add integration policy compile validation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T11:10:27.930Z for PR creation at branch issue-67-55b03ded384e for issue https://github.com/netkeep80/repo-guard/issues/67

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T11:10:27.930Z for PR creation at branch issue-67-55b03ded384e for issue https://github.com/netkeep80/repo-guard/issues/67

--- a/README.md
+++ b/README.md
@@ -284,6 +284,18 @@ contract block, какие документы объясняют contract/profil
 перечисленные YAML/Markdown-файлы и строит normalized facts, но не применяет
 их как runtime enforcement rules.
 
+Во время компиляции политики `repo-guard` проверяет, что ids уникальны во всей
+`integration` секции, обязательные поля заполнены, workflow/template/doc kinds
+и workflow roles известны, а поля `profiles` ссылаются на объявленные
+`integration.profiles[].id`. Сейчас поддерживаются:
+
+| Поле | Допустимые значения |
+| --- | --- |
+| `workflows[].kind` | `github_actions` |
+| `workflows[].role` | `repo_guard_pr_gate`, `repo_guard_advisory`, `repo_guard_policy_validation` |
+| `templates[].kind` | `markdown`, `github_issue_form` |
+| `docs[].kind` | `markdown` |
+
 `buildPolicyFacts(...).integration` содержит:
 
 | Факт | Что извлекается |
@@ -304,7 +316,8 @@ contract block, какие документы объясняют contract/profil
         "id": "pr-gate",
         "kind": "github_actions",
         "path": ".github/workflows/repo-guard.yml",
-        "role": "repo_guard_pr_gate"
+        "role": "repo_guard_pr_gate",
+        "profiles": ["requirements-strict"]
       }
     ],
     "templates": [
@@ -312,14 +325,17 @@ contract block, какие документы объясняют contract/profil
         "id": "pull-request-template",
         "kind": "markdown",
         "path": ".github/PULL_REQUEST_TEMPLATE.md",
-        "requires_contract_block": true
+        "requires_contract_block": true,
+        "profiles": ["requirements-strict"]
       }
     ],
     "docs": [
       {
         "id": "readme",
+        "kind": "markdown",
         "path": "README.md",
-        "must_mention": ["repo-guard", "anchors.affects"]
+        "must_mention": ["repo-guard", "anchors.affects"],
+        "profiles": ["requirements-strict"]
       }
     ],
     "profiles": [

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -391,9 +391,10 @@
         "path": { "$ref": "#/definitions/non_empty_string" },
         "role": {
           "type": "string",
-          "minLength": 1,
-          "description": "Repository-local role for this workflow, for example repo_guard_pr_gate."
-        }
+          "enum": ["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"],
+          "description": "Supported repo-guard role for this workflow."
+        },
+        "profiles": { "$ref": "#/definitions/non_empty_string_array" }
       }
     },
     "integration_template": {
@@ -410,7 +411,8 @@
         "requires_contract_block": {
           "type": "boolean",
           "description": "Whether the template is expected to include a repo-guard contract block."
-        }
+        },
+        "profiles": { "$ref": "#/definitions/non_empty_string_array" }
       }
     },
     "integration_doc": {
@@ -419,8 +421,13 @@
       "additionalProperties": false,
       "properties": {
         "id": { "$ref": "#/definitions/non_empty_string" },
+        "kind": {
+          "type": "string",
+          "enum": ["markdown"]
+        },
         "path": { "$ref": "#/definitions/non_empty_string" },
-        "must_mention": { "$ref": "#/definitions/non_empty_string_array" }
+        "must_mention": { "$ref": "#/definitions/non_empty_string_array" },
+        "profiles": { "$ref": "#/definitions/non_empty_string_array" }
       }
     },
     "integration_profile": {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -88,7 +88,11 @@ function checkPolicyDiscovery(repoRoot, packageRoot) {
     const valid = ajv.validate(schema, policy);
     if (!valid) {
       const errors = ajv.errors.map(e => `${e.instancePath || "/"} ${e.message}`).join("; ");
-      return { name: "repo-policy.json", status: FAIL, message: `Schema validation failed: ${errors}`, hint: "Fix the policy to match the schema — see schemas/repo-policy.schema.json" };
+      const integrationErrors = compileIntegrationPolicy(policy);
+      const integrationDetails = integrationErrors.length > 0
+        ? `; Invalid integration policy: ${integrationErrors.map(e => e.message).join("; ")}`
+        : "";
+      return { name: "repo-policy.json", status: FAIL, message: `Schema validation failed: ${errors}${integrationDetails}`, hint: "Fix the policy to match the schema — see schemas/repo-policy.schema.json" };
     }
 
     const regexErrors = compileForbidRegex(policy.content_rules || []);
@@ -106,7 +110,7 @@ function checkPolicyDiscovery(repoRoot, packageRoot) {
     const integrationErrors = compileIntegrationPolicy(policy);
     if (integrationErrors.length > 0) {
       const details = integrationErrors.map(e => e.message).join("; ");
-      return { name: "repo-policy.json", status: FAIL, message: `Invalid integration policy: ${details}`, hint: "Fix duplicate integration ids in repo-policy.json" };
+      return { name: "repo-policy.json", status: FAIL, message: `Invalid integration policy: ${details}`, hint: "Fix integration ids, kinds, roles, required fields, and profile references in repo-policy.json" };
     }
 
     return { name: "repo-policy.json", status: PASS, message: `Valid (${policy.repository_kind}, format ${policy.policy_format_version})` };

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -257,18 +257,278 @@ export function compileAnchorPolicy(policy) {
   return errors;
 }
 
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+const integrationSectionRules = {
+  workflows: {
+    requiredStrings: ["id", "kind", "path", "role"],
+    requiredBooleans: [],
+    requiredStringArrays: [],
+    optionalStringArrays: ["profiles"],
+    allowedFields: new Set(["id", "kind", "path", "role", "profiles"]),
+    kinds: new Set(["github_actions"]),
+    roles: new Set(["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"]),
+  },
+  templates: {
+    requiredStrings: ["id", "kind", "path"],
+    requiredBooleans: ["requires_contract_block"],
+    requiredStringArrays: [],
+    optionalStringArrays: ["profiles"],
+    allowedFields: new Set(["id", "kind", "path", "requires_contract_block", "profiles"]),
+    kinds: new Set(["github_issue_form", "markdown"]),
+  },
+  docs: {
+    requiredStrings: ["id", "path"],
+    optionalStrings: ["kind"],
+    requiredBooleans: [],
+    requiredStringArrays: ["must_mention"],
+    optionalStringArrays: ["profiles"],
+    allowedFields: new Set(["id", "kind", "path", "must_mention", "profiles"]),
+    kinds: new Set(["markdown"]),
+  },
+  profiles: {
+    requiredStrings: ["id", "doc_path"],
+    requiredBooleans: [],
+    requiredStringArrays: [],
+    optionalStringArrays: [],
+    allowedFields: new Set(["id", "doc_path"]),
+  },
+};
+
+function formatAllowed(values) {
+  return [...values].sort().join(", ");
+}
+
+function compileIntegrationError(section, index, field, message, extra = {}) {
+  return {
+    section,
+    ...(index !== null && index !== undefined ? { index } : {}),
+    ...(field ? { field } : {}),
+    ...extra,
+    message,
+  };
+}
+
+function hasNonEmptyString(entry, field) {
+  return typeof entry[field] === "string" && entry[field].trim().length > 0;
+}
+
+function validateIntegrationString(errors, section, index, entry, field, { required = true } = {}) {
+  if (!Object.hasOwn(entry, field)) {
+    if (required) {
+      errors.push(compileIntegrationError(
+        section,
+        index,
+        field,
+        `integration.${section}[${index}].${field} is required`
+      ));
+    }
+    return false;
+  }
+
+  if (!hasNonEmptyString(entry, field)) {
+    errors.push(compileIntegrationError(
+      section,
+      index,
+      field,
+      `integration.${section}[${index}].${field} is required and must be a non-empty string`,
+      { value: entry[field] }
+    ));
+    return false;
+  }
+
+  return true;
+}
+
+function validateIntegrationBoolean(errors, section, index, entry, field) {
+  if (!Object.hasOwn(entry, field)) {
+    errors.push(compileIntegrationError(
+      section,
+      index,
+      field,
+      `integration.${section}[${index}].${field} is required`
+    ));
+    return false;
+  }
+
+  if (typeof entry[field] !== "boolean") {
+    errors.push(compileIntegrationError(
+      section,
+      index,
+      field,
+      `integration.${section}[${index}].${field} must be a boolean`,
+      { value: entry[field] }
+    ));
+    return false;
+  }
+
+  return true;
+}
+
+function validateIntegrationStringArray(errors, section, index, entry, field, { required = true } = {}) {
+  if (!Object.hasOwn(entry, field)) {
+    if (required) {
+      errors.push(compileIntegrationError(
+        section,
+        index,
+        field,
+        `integration.${section}[${index}].${field} is required`
+      ));
+    }
+    return [];
+  }
+
+  const value = entry[field];
+  if (!Array.isArray(value)) {
+    errors.push(compileIntegrationError(
+      section,
+      index,
+      field,
+      `integration.${section}[${index}].${field} must be an array of non-empty strings`,
+      { value }
+    ));
+    return [];
+  }
+
+  const validValues = [];
+  for (const [itemIndex, item] of value.entries()) {
+    if (typeof item === "string" && item.trim().length > 0) {
+      validValues.push(item);
+      continue;
+    }
+
+    errors.push(compileIntegrationError(
+      section,
+      index,
+      field,
+      `integration.${section}[${index}].${field}[${itemIndex}] must be a non-empty string`,
+      { value: item }
+    ));
+  }
+
+  if (validValues.length === 0) {
+    errors.push(compileIntegrationError(
+      section,
+      index,
+      field,
+      `integration.${section}[${index}].${field} must contain at least one non-empty string`
+    ));
+  }
+
+  return validValues;
+}
+
 export function compileIntegrationPolicy(policy) {
   const errors = [];
   const integration = policy.integration;
 
   if (!integration) return errors;
 
-  for (const section of ["workflows", "templates", "docs", "profiles"]) {
+  if (!isPlainObject(integration)) {
+    return [compileIntegrationError(null, null, null, "integration must be an object")];
+  }
+
+  const sectionNames = Object.keys(integrationSectionRules);
+  const profileReferences = [];
+  const profileIds = new Set();
+  const globalIds = new Map();
+
+  for (const section of Object.keys(integration)) {
+    if (!Object.hasOwn(integrationSectionRules, section)) {
+      errors.push(compileIntegrationError(
+        section,
+        null,
+        null,
+        `integration.${section} is not supported; use ${sectionNames.join(", ")}`
+      ));
+    }
+  }
+
+  for (const section of sectionNames) {
+    const rules = integrationSectionRules[section];
     const seen = new Map();
-    const entries = Array.isArray(integration[section]) ? integration[section] : [];
+    const sectionValue = integration[section];
+    if (sectionValue === undefined) continue;
+
+    if (!Array.isArray(sectionValue)) {
+      errors.push(compileIntegrationError(
+        section,
+        null,
+        null,
+        `integration.${section} must be an array`
+      ));
+      continue;
+    }
+
+    const entries = sectionValue;
     for (const [index, entry] of entries.entries()) {
-      if (!entry || typeof entry !== "object") continue;
-      if (!entry.id) continue;
+      if (!isPlainObject(entry)) {
+        errors.push(compileIntegrationError(
+          section,
+          index,
+          null,
+          `integration.${section}[${index}] must be an object`
+        ));
+        continue;
+      }
+
+      for (const field of Object.keys(entry)) {
+        if (!rules.allowedFields.has(field)) {
+          errors.push(compileIntegrationError(
+            section,
+            index,
+            field,
+            `integration.${section}[${index}].${field} is not supported`
+          ));
+        }
+      }
+
+      for (const field of rules.requiredStrings || []) {
+        validateIntegrationString(errors, section, index, entry, field);
+      }
+
+      for (const field of rules.optionalStrings || []) {
+        validateIntegrationString(errors, section, index, entry, field, { required: false });
+      }
+
+      for (const field of rules.requiredBooleans || []) {
+        validateIntegrationBoolean(errors, section, index, entry, field);
+      }
+
+      for (const field of rules.requiredStringArrays || []) {
+        validateIntegrationStringArray(errors, section, index, entry, field);
+      }
+
+      for (const field of rules.optionalStringArrays || []) {
+        const references = validateIntegrationStringArray(errors, section, index, entry, field, { required: false });
+        for (const profileId of references) {
+          profileReferences.push({ section, index, field, profileId });
+        }
+      }
+
+      if (rules.kinds && hasNonEmptyString(entry, "kind") && !rules.kinds.has(entry.kind)) {
+        errors.push(compileIntegrationError(
+          section,
+          index,
+          "kind",
+          `integration.${section}[${index}].kind must be one of ${formatAllowed(rules.kinds)}`,
+          { value: entry.kind }
+        ));
+      }
+
+      if (rules.roles && hasNonEmptyString(entry, "role") && !rules.roles.has(entry.role)) {
+        errors.push(compileIntegrationError(
+          section,
+          index,
+          "role",
+          `integration.${section}[${index}].role must be one of ${formatAllowed(rules.roles)}`,
+          { value: entry.role }
+        ));
+      }
+
+      if (!hasNonEmptyString(entry, "id")) continue;
 
       if (seen.has(entry.id)) {
         errors.push({
@@ -280,7 +540,38 @@ export function compileIntegrationPolicy(policy) {
       } else {
         seen.set(entry.id, index);
       }
+
+      if (globalIds.has(entry.id)) {
+        const previous = globalIds.get(entry.id);
+        if (previous.section !== section) {
+          errors.push({
+            section,
+            id: entry.id,
+            index,
+            previous_section: previous.section,
+            previous_index: previous.index,
+            message: `integration.${section}[${index}].id duplicates integration.${previous.section}[${previous.index}].id "${entry.id}"`,
+          });
+        }
+      } else {
+        globalIds.set(entry.id, { section, index });
+      }
+
+      if (section === "profiles") {
+        profileIds.add(entry.id);
+      }
     }
+  }
+
+  for (const reference of profileReferences) {
+    if (profileIds.has(reference.profileId)) continue;
+    errors.push(compileIntegrationError(
+      reference.section,
+      reference.index,
+      reference.field,
+      `integration.${reference.section}[${reference.index}].${reference.field} references unknown integration.profiles id "${reference.profileId}"`,
+      { profile_id: reference.profileId }
+    ));
   }
 
   return errors;

--- a/tests/test-doctor.mjs
+++ b/tests/test-doctor.mjs
@@ -57,7 +57,7 @@ function validPolicy() {
   });
 }
 
-function runDoctor(args = "", opts = {}) {
+function runRepoGuard(args = "", opts = {}) {
   const cmd = `node ${resolve(projectRoot, "src/repo-guard.mjs")} ${args}`;
   try {
     const stdout = execSync(cmd, { encoding: "utf-8", cwd: opts.cwd || projectRoot, stdio: ["pipe", "pipe", "pipe"] });
@@ -65,6 +65,10 @@ function runDoctor(args = "", opts = {}) {
   } catch (e) {
     return { stdout: e.stdout || "", stderr: e.stderr || "", code: e.status };
   }
+}
+
+function runDoctor(args = "", opts = {}) {
+  return runRepoGuard(args, opts);
 }
 
 // --- self-hosting: doctor runs on this repo ---
@@ -144,6 +148,46 @@ console.log("\n--- schema-invalid repo-policy.json ---");
   expect("exit code 1 for invalid schema", code, 1);
   expectIncludes("policy FAIL with schema error", stdout, "FAIL: repo-policy.json");
   expectIncludes("mentions schema validation", stdout, "Schema validation failed");
+}
+
+// --- integration compile diagnostics surface through validate and doctor ---
+
+console.log("\n--- integration compile diagnostics surface through validate and doctor ---");
+{
+  const dir = makeTmpDir();
+  initGitRepo(dir);
+  writeFileSync(resolve(dir, "repo-policy.json"), JSON.stringify({
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    integration: {
+      workflows: [
+        {
+          id: "pr-gate",
+          kind: "github_actions",
+          path: ".github/workflows/repo-guard.yml",
+          role: "custom_gate",
+          profiles: ["missing-profile"],
+        },
+      ],
+      profiles: [],
+    },
+    paths: { forbidden: [], canonical_docs: ["README.md"], governance_paths: ["repo-policy.json"] },
+    diff_rules: { max_new_docs: 2, max_new_files: 15 },
+    content_rules: [],
+    cochange_rules: [],
+  }));
+
+  const validate = runRepoGuard(`--repo-root ${dir}`);
+  expect("validate exit code 1 for invalid integration", validate.code, 1);
+  expectIncludes("validate reports integration compilation", validate.stderr, "FAIL: integration policy compilation");
+  expectIncludes("validate reports unknown workflow role", validate.stderr, "role must be one of");
+  expectIncludes("validate reports missing profile reference", validate.stderr, "missing-profile");
+
+  const doctor = runDoctor(`--repo-root ${dir} doctor`);
+  expect("doctor exit code 1 for invalid integration", doctor.code, 1);
+  expectIncludes("doctor reports invalid integration policy", doctor.stdout, "Invalid integration policy");
+  expectIncludes("doctor reports unknown workflow role", doctor.stdout, "role must be one of");
+  expectIncludes("doctor reports missing profile reference", doctor.stdout, "missing-profile");
 }
 
 // --- not a git repo ---

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -347,6 +347,7 @@ describe("integration policy compilation", () => {
             kind: "github_actions",
             path: ".github/workflows/repo-guard.yml",
             role: "repo_guard_pr_gate",
+            profiles: ["requirements-strict"],
           },
         ],
         templates: [
@@ -355,13 +356,16 @@ describe("integration policy compilation", () => {
             kind: "markdown",
             path: ".github/PULL_REQUEST_TEMPLATE.md",
             requires_contract_block: true,
+            profiles: ["requirements-strict"],
           },
         ],
         docs: [
           {
             id: "readme",
+            kind: "markdown",
             path: "README.md",
             must_mention: ["repo-guard"],
+            profiles: ["requirements-strict"],
           },
         ],
         profiles: [
@@ -389,7 +393,7 @@ describe("integration policy compilation", () => {
             id: "pr-gate",
             kind: "github_actions",
             path: ".github/workflows/repo-guard-advisory.yml",
-            role: "repo_guard_advisory",
+            role: "repo_guard_pr_gate",
           },
         ],
       },
@@ -399,13 +403,147 @@ describe("integration policy compilation", () => {
     assert.ok(errors[0].message.includes("duplicates"));
   });
 
-  it("leaves malformed integration shapes to schema validation", () => {
+  it("rejects duplicate ids across integration sections", () => {
     const errors = compileIntegrationPolicy({
       integration: {
-        workflows: [null, "invalid"],
+        workflows: [
+          {
+            id: "repo-guard",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard.yml",
+            role: "repo_guard_pr_gate",
+          },
+        ],
+        templates: [
+          {
+            id: "repo-guard",
+            kind: "markdown",
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+            requires_contract_block: true,
+          },
+        ],
       },
     });
-    assert.equal(errors.length, 0);
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].section, "templates");
+    assert.ok(errors[0].message.includes("duplicates"));
+    assert.ok(errors[0].message.includes("integration.workflows[0].id"));
+  });
+
+  it("rejects malformed integration shapes and missing required fields during compilation", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: "not-an-array",
+        templates: [
+          null,
+          {
+            id: "pull-request-template",
+            kind: "markdown",
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+          },
+        ],
+        docs: [
+          {
+            id: "readme",
+            path: "",
+            must_mention: [],
+          },
+        ],
+        profiles: [
+          {
+            id: "requirements-strict",
+          },
+        ],
+      },
+    });
+
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows must be an array")));
+    assert.ok(errors.some((e) => e.message.includes("integration.templates[0] must be an object")));
+    assert.ok(errors.some((e) => e.message.includes("requires_contract_block is required")));
+    assert.ok(errors.some((e) => e.message.includes("integration.docs[0].path is required")));
+    assert.ok(errors.some((e) => e.message.includes("integration.docs[0].must_mention must contain at least one")));
+    assert.ok(errors.some((e) => e.message.includes("integration.profiles[0].doc_path is required")));
+  });
+
+  it("rejects unsupported integration kinds and workflow roles", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: [
+          {
+            id: "cron",
+            kind: "cron",
+            path: ".github/workflows/repo-guard.yml",
+            role: "custom_gate",
+          },
+        ],
+        templates: [
+          {
+            id: "template",
+            kind: "html",
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+            requires_contract_block: true,
+          },
+        ],
+        docs: [
+          {
+            id: "readme",
+            kind: "html",
+            path: "README.md",
+            must_mention: ["repo-guard"],
+          },
+        ],
+      },
+    });
+
+    assert.equal(errors.length, 4);
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].kind must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].role must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.templates[0].kind must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.docs[0].kind must be one of")));
+  });
+
+  it("rejects profile references that do not resolve to integration.profiles ids", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: [
+          {
+            id: "pr-gate",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard.yml",
+            role: "repo_guard_pr_gate",
+            profiles: ["requirements-strict", "missing-profile"],
+          },
+        ],
+        templates: [
+          {
+            id: "pull-request-template",
+            kind: "markdown",
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+            requires_contract_block: true,
+            profiles: ["missing-template-profile"],
+          },
+        ],
+        docs: [
+          {
+            id: "readme",
+            kind: "markdown",
+            path: "README.md",
+            must_mention: ["repo-guard"],
+            profiles: ["requirements-strict"],
+          },
+        ],
+        profiles: [
+          {
+            id: "requirements-strict",
+            doc_path: "docs/requirements-strict-profile.md",
+          },
+        ],
+      },
+    });
+
+    assert.equal(errors.length, 2);
+    assert.ok(errors.some((e) => e.message.includes("missing-profile")));
+    assert.ok(errors.some((e) => e.message.includes("missing-template-profile")));
   });
 });
 

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -96,6 +96,7 @@ const policyWithIntegration = {
         kind: "github_actions",
         path: ".github/workflows/repo-guard.yml",
         role: "repo_guard_pr_gate",
+        profiles: ["requirements-strict"],
       },
     ],
     templates: [
@@ -104,13 +105,16 @@ const policyWithIntegration = {
         kind: "markdown",
         path: ".github/PULL_REQUEST_TEMPLATE.md",
         requires_contract_block: true,
+        profiles: ["requirements-strict"],
       },
     ],
     docs: [
       {
         id: "readme",
+        kind: "markdown",
         path: "README.md",
         must_mention: ["repo-guard", "anchors.affects"],
+        profiles: ["requirements-strict"],
       },
     ],
     profiles: [
@@ -137,6 +141,36 @@ const invalidIntegrationPolicy = {
   },
 };
 expect("policy with unknown integration workflow kind fails schema", validatePolicy(invalidIntegrationPolicy), false);
+
+const invalidIntegrationRolePolicy = {
+  ...validPolicy,
+  integration: {
+    workflows: [
+      {
+        id: "pr-gate",
+        kind: "github_actions",
+        path: ".github/workflows/repo-guard.yml",
+        role: "custom_gate",
+      },
+    ],
+  },
+};
+expect("policy with unknown integration workflow role fails schema", validatePolicy(invalidIntegrationRolePolicy), false);
+
+const invalidIntegrationDocKindPolicy = {
+  ...validPolicy,
+  integration: {
+    docs: [
+      {
+        id: "readme",
+        kind: "html",
+        path: "README.md",
+        must_mention: ["repo-guard"],
+      },
+    ],
+  },
+};
+expect("policy with unknown integration doc kind fails schema", validatePolicy(invalidIntegrationDocKindPolicy), false);
 
 // Content rules normalization tests
 const oldFormPolicy = loadJSON(resolve(root, "tests/fixtures/invalid-content-rule-old-form.json"));


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#67.

Adds compile-time sanity checks for the `integration` policy section so invalid downstream integration metadata fails during policy validation instead of reaching extraction/runtime paths.

## What changed

- Expands `compileIntegrationPolicy()` to validate section shapes, required fields, duplicate ids across the full integration section, known workflow/template/doc kinds, known workflow roles, unsupported fields, and `profiles` references.
- Extends the policy schema with workflow role enums, optional `profiles` references for workflows/templates/docs, and optional `docs[].kind: markdown`.
- Updates `doctor` so integration compile diagnostics are visible even when schema validation also reports integration-related errors.
- Documents the supported integration roles/kinds and profile-reference behavior.

## Reproduction

Before this change, the new `integration policy compilation` hardening cases failed because malformed integration sections, unsupported roles/kinds, cross-section duplicate ids, and unresolved profile references returned no compiler errors from `compileIntegrationPolicy()`.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/policy-compiler.mjs
  - src/doctor.mjs
  - schemas/repo-policy.schema.json
  - tests/test-hardening.mjs
  - tests/test-doctor.mjs
  - tests/validate-schemas.mjs
  - README.md
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 1000
must_touch:
  - src/policy-compiler.mjs
  - tests/test-hardening.mjs
  - tests/test-doctor.mjs
  - schemas/repo-policy.schema.json
must_not_touch: []
expected_effects:
  - Invalid integration policy shapes and references fail during policy compilation.
  - repo-guard validate and repo-guard doctor surface integration compile diagnostics.
  - Integration schema and docs describe supported roles, kinds, and profile references.
```

## Verification

- `npm run test:hardening` first failed with the new reproducing integration compiler assertions.
- `npm run test:hardening`
- `npm run test:schemas`
- `npm run test:doctor`
- `npm test`
- `npm run validate`
- `node src/repo-guard.mjs check-diff --enforcement blocking`
- `git diff --check`