### PR TITLE
Add validate-integration diagnostics command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Run integration extraction tests
         run: npm run test:integration
 
+      - name: Run integration diagnostics tests
+        run: npm run test:integration-diagnostics
+
       - name: Run trace evidence rule tests
         run: npm run test:trace-evidence
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T11:42:25.732Z for PR creation at branch issue-69-47d9cb7f36a3 for issue https://github.com/netkeep80/repo-guard/issues/69

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T11:42:25.732Z for PR creation at branch issue-69-47d9cb7f36a3 for issue https://github.com/netkeep80/repo-guard/issues/69

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ repo-guard doctor
 | `repo-guard check-pr` | Проверяет PR внутри рабочего процесса GitHub Actions `pull_request` |
 | `repo-guard init` | Создает стартовую политику, рабочий процесс и шаблоны |
 | `repo-guard doctor` | Диагностирует окружение, рабочий процесс, политику и авторизацию |
+| `repo-guard validate-integration` | Проверяет integration wiring через normalized facts |
 
 Глобальные флаги можно ставить до или после команды:
 
@@ -306,6 +307,23 @@ contract block, какие документы объясняют contract/profil
 | `profiles` | Идентификаторы профилей, migration target mentions и ссылки на имя профиля |
 | `errors` | Явные ошибки чтения, malformed YAML, malformed contract blocks и незакрытые Markdown fences |
 
+Проверить integration layer как отдельный продуктовый diagnostic:
+
+```bash
+repo-guard validate-integration
+repo-guard validate-integration --format json
+repo-guard validate-integration --format summary
+repo-guard --enforcement advisory validate-integration --format summary
+repo-guard doctor --integration --format json
+```
+
+`validate-integration` читает только файлы репозитория, объявленные в
+`repo-policy.json`, и не требует `GITHUB_EVENT_PATH`. В blocking-режиме
+диагностические нарушения дают код выхода 1; в advisory-режиме они остаются в
+JSON/summary как violations, но код выхода остается 0. JSON-вывод содержит
+normalized `integration` facts, `ruleResults`, `violations`, `diagnostics` и
+итоговый `exitCode`.
+
 Пример:
 
 ```json
@@ -474,6 +492,7 @@ expected_effects:
 ```bash
 repo-guard doctor
 repo-guard --repo-root /path/to/repo doctor
+repo-guard doctor --integration --format summary
 ```
 
 `doctor` проверяет:
@@ -492,6 +511,10 @@ repo-guard --repo-root /path/to/repo doctor
 Локально отсутствие `GITHUB_EVENT_PATH` обычно дает предупреждение, потому что
 `check-pr` нужен только внутри GitHub Actions.
 
+`doctor --integration` запускает тот же встроенный diagnostic engine, что и
+`validate-integration`, но оставляет привычный doctor UX для пользователей,
+которые хотят проверить только integration wiring.
+
 ## Самопроверка репозитория
 
 Этот репозиторий проверяет сам себя через локальный переиспользуемый Action `uses: ./` в
@@ -505,6 +528,10 @@ repo-guard --repo-root /path/to/repo doctor
 CI также запускает тестовый сценарий `advisory` для `check-diff`, чтобы
 проверять, что нарушения в режиме `advisory` видны в выводе, но не ломают
 задание.
+
+Собственный integration profile этого репозитория называется `self-hosting`;
+он документирует профиль, при котором `repo-guard` проверяет собственную
+политику, workflow, шаблоны и README как downstream-интеграцию.
 
 ## Разработка
 

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-integration-diagnostics.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:anchors": "node tests/test-anchor-extractors.mjs",
     "test:integration": "node tests/test-integration-extractors.mjs",
+    "test:integration-diagnostics": "node tests/test-integration-diagnostics.mjs",
     "test:trace-evidence": "node tests/test-trace-evidence-rules.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",

--- a/src/extractors/integration.mjs
+++ b/src/extractors/integration.mjs
@@ -85,6 +85,7 @@ function collectWorkflowFacts(entry, content) {
   const stepInputs = [];
   const envVars = collectEnvVars(data.env, "workflow");
   const ifConditions = [];
+  const runCommands = [];
   const summaryPublishing = [];
   const jobPermissions = [];
 
@@ -145,6 +146,13 @@ function collectWorkflowFacts(entry, content) {
         });
       }
 
+      if (step.run !== undefined) {
+        runCommands.push({
+          ...stepBase,
+          run: normalizeValue(step.run),
+        });
+      }
+
       const summaryMode = detectSummaryPublishingMode(step.run);
       if (summaryMode) {
         summaryPublishing.push({
@@ -172,6 +180,7 @@ function collectWorkflowFacts(entry, content) {
     stepInputs,
     envVars,
     ifConditions,
+    runCommands,
     summaryPublishing,
   };
 }

--- a/src/integration-validator.mjs
+++ b/src/integration-validator.mjs
@@ -1,0 +1,462 @@
+import { resolve } from "node:path";
+import {
+  compileIntegrationPolicy,
+} from "./policy-compiler.mjs";
+import {
+  ajvErrors,
+  createCheckReporter,
+  resolveEnforcementMode,
+} from "./enforcement.mjs";
+import {
+  createAjv,
+  loadJSON,
+} from "./runtime/validation.mjs";
+import { extractIntegration } from "./extractors/integration.mjs";
+
+const FORMATS = new Set(["text", "json", "summary"]);
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function emptyIntegrationFacts() {
+  return {
+    workflows: [],
+    templates: [],
+    docs: [],
+    profiles: [],
+    errors: [],
+  };
+}
+
+function parseArgs(args) {
+  let format = "text";
+  const rest = [];
+  const known = new Set(["--format", "--integration"]);
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--integration") {
+      continue;
+    }
+    if (arg === "--format") {
+      const next = args[i + 1];
+      if (!next || next.startsWith("-")) {
+        return {
+          ok: false,
+          message: "Error: --format requires a value",
+        };
+      }
+      format = next;
+      i++;
+      continue;
+    }
+    if (arg.startsWith("-") && !known.has(arg)) {
+      return {
+        ok: false,
+        message: `Unknown option for validate-integration: ${arg}`,
+      };
+    }
+    rest.push(arg);
+  }
+
+  if (rest.length > 0) {
+    return {
+      ok: false,
+      message: `Unexpected argument for validate-integration: ${rest[0]}`,
+    };
+  }
+
+  if (!FORMATS.has(format)) {
+    return {
+      ok: false,
+      message: `Unknown validate-integration format: ${format}`,
+    };
+  }
+
+  return { ok: true, format };
+}
+
+function usage() {
+  return "Usage: repo-guard validate-integration [--format <text|json|summary>] [--enforcement <advisory|blocking>]";
+}
+
+function countDeclared(integration) {
+  if (!isPlainObject(integration)) {
+    return { workflows: 0, templates: 0, docs: 0, profiles: 0, total: 0 };
+  }
+
+  const counts = {
+    workflows: Array.isArray(integration.workflows) ? integration.workflows.length : 0,
+    templates: Array.isArray(integration.templates) ? integration.templates.length : 0,
+    docs: Array.isArray(integration.docs) ? integration.docs.length : 0,
+    profiles: Array.isArray(integration.profiles) ? integration.profiles.length : 0,
+  };
+  return {
+    ...counts,
+    total: counts.workflows + counts.templates + counts.docs + counts.profiles,
+  };
+}
+
+function countExtracted(integration) {
+  const counts = {
+    workflows: integration.workflows.length,
+    templates: integration.templates.length,
+    docs: integration.docs.length,
+    profiles: integration.profiles.length,
+    errors: integration.errors.length,
+  };
+  return {
+    ...counts,
+    total: counts.workflows + counts.templates + counts.docs + counts.profiles,
+  };
+}
+
+function formatIntegrationError(error) {
+  const location = [
+    error.section,
+    error.id ? `:${error.id}` : "",
+    error.path ? ` (${error.path})` : "",
+  ].join("");
+  return `${location || "integration"}: ${error.message}`;
+}
+
+function compileDetails(errors) {
+  return errors.map((error) => error.message);
+}
+
+function workflowReferencesRepoGuard(workflow) {
+  const usesRepoGuardAction = workflow.actionUses.some((fact) => {
+    const uses = String(fact.uses || "").toLowerCase();
+    return uses.includes("repo-guard") || uses === "./" || uses.startsWith("./");
+  });
+  const runsRepoGuardCommand = workflow.runCommands.some((fact) => {
+    const run = String(fact.run || "").toLowerCase();
+    return run.includes("repo-guard") || run.includes("src/repo-guard.mjs");
+  });
+  return usesRepoGuardAction || runsRepoGuardCommand;
+}
+
+function workflowRunsCheckPR(workflow) {
+  const inputMode = workflow.stepInputs.some((fact) =>
+    Object.values(fact.inputs || {}).some((value) => String(value).includes("check-pr"))
+  );
+  const runMode = workflow.runCommands.some((fact) => String(fact.run || "").includes("check-pr"));
+  return inputMode || runMode;
+}
+
+function workflowHasFetchDepthZero(workflow) {
+  return workflow.stepInputs.some((fact) => {
+    const uses = String(fact.uses || "").toLowerCase();
+    if (!uses.startsWith("actions/checkout")) return false;
+    return fact.inputs?.["fetch-depth"] === "0";
+  });
+}
+
+function workflowHasGitHubToken(workflow) {
+  return workflow.envVars.some((fact) => fact.name === "GH_TOKEN" || fact.name === "GITHUB_TOKEN");
+}
+
+function workflowDiagnostics(integration) {
+  const details = [];
+
+  for (const workflow of integration.workflows) {
+    if (!workflowReferencesRepoGuard(workflow)) {
+      details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
+    }
+
+    if (workflow.role === "repo_guard_pr_gate") {
+      const triggers = new Set(workflow.triggerEvents);
+      if (!triggers.has("pull_request") && !triggers.has("pull_request_target")) {
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow must run on pull_request or pull_request_target`);
+      }
+      if (!workflowHasFetchDepthZero(workflow)) {
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
+      }
+      if (workflowRunsCheckPR(workflow) && !workflowHasGitHubToken(workflow)) {
+        details.push(`${workflow.path}: check-pr workflow should provide GH_TOKEN or GITHUB_TOKEN`);
+      }
+    }
+  }
+
+  return details;
+}
+
+function templateDiagnostics(integration) {
+  const details = [];
+
+  for (const template of integration.templates) {
+    if (!template.requiresContractBlock) continue;
+    if (template.hasRepoGuardYamlBlock || template.hasRepoGuardJsonBlock) continue;
+    details.push(`${template.path}: ${template.id} requires a repo-guard contract block`);
+  }
+
+  return details;
+}
+
+function docDiagnostics(integration) {
+  const details = [];
+
+  for (const doc of integration.docs) {
+    for (const mention of doc.mentions) {
+      if (mention.present) continue;
+      details.push(`${doc.path}: missing required mention "${mention.term}"`);
+    }
+  }
+
+  return details;
+}
+
+function profileDiagnostics(integration) {
+  const details = [];
+
+  for (const profile of integration.profiles) {
+    if (profile.profileNameReferences.length > 0) continue;
+    details.push(`${profile.docPath}: profile "${profile.id}" is not mentioned`);
+  }
+
+  return details;
+}
+
+function renderMarkdownTableCell(value) {
+  return String(value || "")
+    .replaceAll("|", "\\|")
+    .replaceAll("\n", "<br>");
+}
+
+function detailsForSummary(diagnostic) {
+  const details = [];
+  if (diagnostic.message) details.push(diagnostic.message);
+  if (diagnostic.details) details.push(...diagnostic.details);
+  if (diagnostic.errors) details.push(...diagnostic.errors);
+  if (diagnostic.hint) details.push(`hint: ${diagnostic.hint}`);
+  return details.length > 0 ? details.join("<br>") : "Diagnostic reported";
+}
+
+export function renderIntegrationSummary(report) {
+  const declared = report.diagnostics.declared;
+  const extracted = report.diagnostics.extracted;
+  const lines = [
+    "## repo-guard integration summary",
+    "",
+    `- Result: ${report.result}`,
+    `- Mode: ${report.mode}`,
+    `- Repository root: \`${report.repositoryRoot}\``,
+    `- Declared: ${declared.workflows} workflow(s), ${declared.templates} template(s), ${declared.docs} doc(s), ${declared.profiles} profile(s)`,
+    `- Extracted: ${extracted.workflows} workflow(s), ${extracted.templates} template(s), ${extracted.docs} doc(s), ${extracted.profiles} profile(s), ${extracted.errors} artifact error(s)`,
+    `- Diagnostics: ${report.passed} passed, ${report.failed} failed${report.mode === "advisory" ? `, ${report.violationCount} advisory violation(s)` : ""}, ${report.warnings} warning(s)`,
+  ];
+
+  if (report.violations.length > 0) {
+    lines.push("", "| Diagnostic | Details |", "|---|---|");
+    for (const violation of report.violations) {
+      lines.push(`| ${renderMarkdownTableCell(violation.rule)} | ${renderMarkdownTableCell(detailsForSummary(violation))} |`);
+    }
+  }
+
+  if (report.advisoryWarnings.length > 0) {
+    lines.push("", "| Advisory | Details |", "|---|---|");
+    for (const warning of report.advisoryWarnings) {
+      lines.push(`| ${renderMarkdownTableCell(warning.rule)} | ${renderMarkdownTableCell(detailsForSummary(warning))} |`);
+    }
+  }
+
+  if (report.hints.length > 0) {
+    lines.push("", "### Hints");
+    for (const hint of report.hints) {
+      lines.push(`- ${hint.rule}: ${hint.message}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function createReport(roots, { format }) {
+  const policyPath = resolve(roots.repoRoot, "repo-policy.json");
+  const schemaPath = resolve(roots.packageRoot, "schemas/repo-policy.schema.json");
+  let policy = null;
+  let policySchema = null;
+  let policyLoadError = null;
+  let schemaLoadError = null;
+
+  try {
+    policy = loadJSON(policyPath);
+  } catch (e) {
+    policyLoadError = e;
+  }
+
+  try {
+    policySchema = loadJSON(schemaPath);
+  } catch (e) {
+    schemaLoadError = e;
+  }
+
+  const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
+  if (!enforcement.ok) {
+    return {
+      fatal: true,
+      message: `ERROR: ${enforcement.message}`,
+    };
+  }
+
+  const quiet = format !== "text";
+  if (!quiet) {
+    console.log("repo-guard validate-integration\n");
+  }
+
+  const reporter = createCheckReporter(enforcement.mode, { quiet });
+  const diagnostics = {
+    declared: countDeclared(policy?.integration),
+    extracted: countExtracted(emptyIntegrationFacts()),
+    artifactErrors: [],
+  };
+  let integration = emptyIntegrationFacts();
+
+  if (policyLoadError) {
+    reporter.report("repo-policy.json", {
+      ok: false,
+      message: `Cannot read ${policyPath}: ${policyLoadError.message}`,
+      hint: "Create a valid repo-policy.json before validating integration wiring",
+    });
+    return reporter.finish({
+      command: "validate-integration",
+      repositoryRoot: roots.repoRoot,
+      integration,
+      diagnostics,
+    });
+  }
+
+  if (schemaLoadError) {
+    reporter.report("repo-policy-schema", {
+      ok: false,
+      message: `Cannot read ${schemaPath}: ${schemaLoadError.message}`,
+      hint: "Reinstall repo-guard; package schema files are missing",
+    });
+  } else {
+    const ajv = createAjv();
+    const valid = ajv.validate(policySchema, policy);
+    reporter.report("repo-policy.json", valid
+      ? { ok: true, message: "repo-policy.json is valid JSON policy" }
+      : {
+          ok: false,
+          message: "repo-policy.json failed schema validation",
+          errors: ajvErrors(ajv.errors),
+          hint: "Fix policy schema errors before relying on integration diagnostics",
+        });
+  }
+
+  const declared = countDeclared(policy.integration);
+  diagnostics.declared = declared;
+  const compileErrors = compileIntegrationPolicy(policy);
+  const hasIntegration = isPlainObject(policy.integration);
+  if (!hasIntegration) {
+    reporter.report("integration-policy", {
+      ok: false,
+      message: "repo-policy.json has no integration section",
+      hint: "Declare integration.workflows, integration.templates, integration.docs, or integration.profiles",
+    });
+  } else if (declared.total === 0) {
+    reporter.report("integration-policy", {
+      ok: false,
+      message: "integration section declares no artifacts",
+      hint: "Declare at least one integration workflow, template, doc, or profile",
+    });
+  } else if (compileErrors.length > 0) {
+    reporter.report("integration-policy", {
+      ok: false,
+      message: "Integration policy failed compilation",
+      details: compileDetails(compileErrors),
+      hint: "Fix integration ids, roles, kinds, required fields, and profile references",
+    });
+  } else {
+    reporter.report("integration-policy", {
+      ok: true,
+      message: "Integration policy compiles",
+    });
+  }
+
+  if (hasIntegration && compileErrors.length === 0) {
+    integration = extractIntegration(policy, { repoRoot: roots.repoRoot });
+    diagnostics.extracted = countExtracted(integration);
+    diagnostics.artifactErrors = integration.errors.map(formatIntegrationError);
+
+    reporter.report("integration-artifacts", integration.errors.length === 0
+      ? { ok: true, message: "All declared integration artifacts were read and parsed" }
+      : {
+          ok: false,
+          message: "Integration artifact extraction failed",
+          details: diagnostics.artifactErrors,
+          hint: "Fix missing files, malformed workflow YAML, malformed contract blocks, or Markdown fences",
+        });
+
+    const workflowDetails = workflowDiagnostics(integration);
+    reporter.report("integration-workflows", workflowDetails.length === 0
+      ? { ok: true, message: "Workflow integration wiring is valid" }
+      : {
+          ok: false,
+          message: "Workflow integration wiring has issues",
+          details: workflowDetails,
+          hint: "Compare declared repo-guard workflows with templates/example-workflow.yml",
+        });
+
+    const templateDetails = templateDiagnostics(integration);
+    reporter.report("integration-templates", templateDetails.length === 0
+      ? { ok: true, message: "Template integration wiring is valid" }
+      : {
+          ok: false,
+          message: "Template integration wiring has issues",
+          details: templateDetails,
+          hint: "Add repo-guard-yaml or repo-guard-json fenced contract blocks to required templates",
+        });
+
+    const docDetails = docDiagnostics(integration);
+    reporter.report("integration-docs", docDetails.length === 0
+      ? { ok: true, message: "Documentation integration wiring is valid" }
+      : {
+          ok: false,
+          message: "Documentation integration wiring has issues",
+          details: docDetails,
+          hint: "Update declared docs so every must_mention term appears",
+        });
+
+    const profileDetails = profileDiagnostics(integration);
+    reporter.report("integration-profiles", profileDetails.length === 0
+      ? { ok: true, message: "Profile documentation wiring is valid" }
+      : {
+          ok: false,
+          message: "Profile documentation wiring has issues",
+          details: profileDetails,
+          hint: "Mention each integration profile id in its declared profile document",
+        });
+  }
+
+  return reporter.finish({
+    command: "validate-integration",
+    repositoryRoot: roots.repoRoot,
+    integration,
+    diagnostics,
+  });
+}
+
+export function runValidateIntegration(roots, args = []) {
+  const parsed = parseArgs(args);
+  if (!parsed.ok) {
+    console.error(parsed.message);
+    console.error(usage());
+    process.exit(1);
+  }
+
+  const report = createReport(roots, { format: parsed.format });
+  if (report.fatal) {
+    console.error(report.message);
+    process.exit(1);
+  }
+
+  if (parsed.format === "json") {
+    console.log(JSON.stringify(report, null, 2));
+  } else if (parsed.format === "summary") {
+    console.log(renderIntegrationSummary(report));
+  }
+
+  process.exit(report.exitCode);
+}

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -34,7 +34,7 @@ export function resolveRoots(args) {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
         console.error("Error: --repo-root requires a path argument");
-        console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor] [options]");
+        console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor|validate-integration] [options]");
         process.exit(1);
       }
       repoRoot = resolve(args[++i]);
@@ -42,7 +42,7 @@ export function resolveRoots(args) {
       const next = args[i + 1];
       if (!next || next.startsWith("-")) {
         console.error(`Error: ${args[i]} requires a mode argument`);
-        console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor] [options]");
+        console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor|validate-integration] [options]");
         process.exit(1);
       }
       enforcementMode = args[++i];
@@ -223,13 +223,13 @@ function sameEntrypointPath(left, right) {
 const isMain = process.argv[1] && sameEntrypointPath(process.argv[1], resolve(__dirname, "repo-guard.mjs"));
 
 if (isMain) {
-  const MODES = new Set(["check-diff", "check-pr", "init", "doctor"]);
+  const MODES = new Set(["check-diff", "check-pr", "init", "doctor", "validate-integration"]);
   const roots = resolveRoots(process.argv.slice(2));
   const command = roots.args[0];
 
   if (command && !MODES.has(command) && command.startsWith("-")) {
     console.error(`Unknown option: ${command}`);
-    console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor] [options]");
+    console.error("Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor|validate-integration] [options]");
     process.exit(1);
   }
 
@@ -245,9 +245,19 @@ if (isMain) {
     const { runInit } = await import("./init.mjs");
     runInit(roots, roots.args);
   } else if (command === "doctor") {
-    const { runDoctor } = await import("./doctor.mjs");
-    const report = runDoctor(roots);
-    process.exit(report.fails > 0 ? 1 : 0);
+    roots.args = roots.args.slice(1);
+    if (roots.args.includes("--integration")) {
+      const { runValidateIntegration } = await import("./integration-validator.mjs");
+      runValidateIntegration(roots, roots.args);
+    } else {
+      const { runDoctor } = await import("./doctor.mjs");
+      const report = runDoctor(roots);
+      process.exit(report.fails > 0 ? 1 : 0);
+    }
+  } else if (command === "validate-integration") {
+    roots.args = roots.args.slice(1);
+    const { runValidateIntegration } = await import("./integration-validator.mjs");
+    runValidateIntegration(roots, roots.args);
   } else {
     runValidate(roots, roots.args);
   }

--- a/tests/test-integration-diagnostics.mjs
+++ b/tests/test-integration-diagnostics.mjs
@@ -1,0 +1,284 @@
+import { strict as assert } from "node:assert";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+const projectRoot = resolve(__dirname, "..");
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, value, substring) {
+  const actual = String(value || "");
+  const passed = actual.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected ${JSON.stringify(actual)} to include ${JSON.stringify(substring)}`);
+  }
+}
+
+function expectTrue(label, value) {
+  expect(label, Boolean(value), true);
+}
+
+function runGuard(args) {
+  const result = spawnSync(process.execPath, [
+    resolve(projectRoot, "src/repo-guard.mjs"),
+    ...args,
+  ], {
+    cwd: projectRoot,
+    encoding: "utf-8",
+  });
+  return {
+    code: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    output: `${result.stdout || ""}${result.stderr || ""}`,
+  };
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function basePolicy(overrides = {}) {
+  return {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    enforcement: { mode: "blocking" },
+    integration: {
+      workflows: [
+        {
+          id: "pr-gate",
+          kind: "github_actions",
+          path: ".github/workflows/repo-guard.yml",
+          role: "repo_guard_pr_gate",
+          profiles: ["self-hosting"],
+        },
+      ],
+      templates: [
+        {
+          id: "pull-request-template",
+          kind: "markdown",
+          path: ".github/PULL_REQUEST_TEMPLATE.md",
+          requires_contract_block: true,
+        },
+        {
+          id: "change-contract-issue-form",
+          kind: "github_issue_form",
+          path: ".github/ISSUE_TEMPLATE/change-contract.yml",
+          requires_contract_block: true,
+        },
+      ],
+      docs: [
+        {
+          id: "readme",
+          kind: "markdown",
+          path: "README.md",
+          must_mention: ["repo-guard", "contract", "integration"],
+          profiles: ["self-hosting"],
+        },
+      ],
+      profiles: [
+        {
+          id: "self-hosting",
+          doc_path: "README.md",
+        },
+      ],
+      ...overrides.integration,
+    },
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 2,
+      max_new_files: 15,
+      max_net_added_lines: 2000,
+    },
+    content_rules: [],
+    cochange_rules: [],
+  };
+}
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-integration-"));
+  mkdirSync(join(dir, ".github", "workflows"), { recursive: true });
+  mkdirSync(join(dir, ".github", "ISSUE_TEMPLATE"), { recursive: true });
+
+  writeJson(join(dir, "repo-policy.json"), basePolicy());
+  writeFileSync(join(dir, ".github", "workflows", "repo-guard.yml"), [
+    "name: repo guard",
+    "on:",
+    "  pull_request:",
+    "  push:",
+    "jobs:",
+    "  validate:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "        with:",
+    "          fetch-depth: 0",
+    "      - name: Run repo-guard",
+    "        env:",
+    "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+    "        run: npx repo-guard check-pr --format summary",
+    "",
+  ].join("\n"));
+  writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), [
+    "## Change Contract",
+    "",
+    "```repo-guard-yaml",
+    "change_type: feature",
+    "scope:",
+    "  - src/**",
+    "```",
+    "",
+  ].join("\n"));
+  writeFileSync(join(dir, ".github", "ISSUE_TEMPLATE", "change-contract.yml"), [
+    "name: Change contract",
+    "body:",
+    "  - type: textarea",
+    "    attributes:",
+    "      value: |",
+    "        ```repo-guard-yaml",
+    "        change_type: feature",
+    "        scope:",
+    "          - src/**",
+    "        ```",
+    "",
+  ].join("\n"));
+  writeFileSync(join(dir, "README.md"), [
+    "# Test Repo",
+    "",
+    "This repository documents repo-guard contract integration for self-hosting.",
+    "Profile id: self-hosting",
+    "",
+  ].join("\n"));
+  return dir;
+}
+
+function makeBrokenRepo() {
+  const dir = makeRepo();
+  writeFileSync(join(dir, ".github", "workflows", "repo-guard.yml"), [
+    "name: repo guard",
+    "on:",
+    "  push:",
+    "jobs:",
+    "  validate:",
+    "    runs-on: ubuntu-latest",
+    "    steps:",
+    "      - uses: actions/checkout@v4",
+    "      - run: echo no policy gate here",
+    "",
+  ].join("\n"));
+  writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), "## Missing contract\n");
+  writeFileSync(join(dir, "README.md"), "# Missing integration docs\n");
+  return dir;
+}
+
+console.log("\n--- validate-integration --format json emits normalized integration diagnostics ---");
+{
+  const dir = makeRepo();
+  const result = runGuard([
+    "--repo-root", dir,
+    "validate-integration",
+    "--format", "json",
+  ]);
+
+  expect("valid integration exits 0", result.code, 0);
+  expect("json stderr is empty", result.stderr, "");
+
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout);
+    expect("stdout is valid json", true, true);
+  } catch (e) {
+    expect("stdout is valid json", e.message, "valid json");
+  }
+
+  expect("command name is stable", parsed?.command, "validate-integration");
+  expect("mode is blocking", parsed?.mode, "blocking");
+  expect("result passed", parsed?.result, "passed");
+  expect("repository root is included", parsed?.repositoryRoot, dir);
+  expect("workflow facts are emitted", parsed?.integration?.workflows?.[0]?.triggerEvents, ["pull_request", "push"]);
+  expect("run commands are normalized facts", parsed?.integration?.workflows?.[0]?.runCommands?.[0]?.run, "npx repo-guard check-pr --format summary");
+  expect("template diagnostics pass", parsed?.ruleResults?.some((rule) => rule.rule === "integration-templates" && rule.ok), true);
+  expect("stats include declared templates", parsed?.diagnostics?.declared?.templates, 2);
+
+  rmSync(dir, { recursive: true });
+}
+
+console.log("\n--- doctor --integration aliases validate-integration diagnostics ---");
+{
+  const dir = makeRepo();
+  const result = runGuard([
+    "--repo-root", dir,
+    "doctor",
+    "--integration",
+    "--format", "json",
+  ]);
+  const parsed = JSON.parse(result.stdout);
+
+  expect("doctor integration alias exits 0", result.code, 0);
+  expect("alias uses validate-integration command shape", parsed.command, "validate-integration");
+  expect("alias emits integration facts", parsed.integration.workflows.length, 1);
+
+  rmSync(dir, { recursive: true });
+}
+
+console.log("\n--- validate-integration --format summary reports CI-readable diagnostics ---");
+{
+  const dir = makeBrokenRepo();
+  const result = runGuard([
+    "--repo-root", dir,
+    "validate-integration",
+    "--format", "summary",
+  ]);
+
+  expect("broken integration blocks in blocking mode", result.code, 1);
+  expectIncludes("summary heading", result.output, "## repo-guard integration summary");
+  expectIncludes("summary result", result.output, "- Result: failed");
+  expectIncludes("workflow diagnostic appears", result.output, "repo_guard_pr_gate workflow must run on pull_request");
+  expectIncludes("template diagnostic appears", result.output, "requires a repo-guard contract block");
+  expectIncludes("doc diagnostic appears", result.output, "missing required mention");
+
+  rmSync(dir, { recursive: true });
+}
+
+console.log("\n--- validate-integration advisory mode reports but does not block ---");
+{
+  const dir = makeBrokenRepo();
+  const result = runGuard([
+    "--repo-root", dir,
+    "--enforcement", "advisory",
+    "validate-integration",
+    "--format", "json",
+  ]);
+  const parsed = JSON.parse(result.stdout);
+
+  expect("advisory integration exits 0", result.code, 0);
+  expect("advisory result still records failure", parsed.result, "failed");
+  expect("advisory has zero enforced failures", parsed.failed, 0);
+  expectTrue("advisory records violations", parsed.violationCount > 0);
+  expectTrue("template violation is present", parsed.violations.some((violation) => violation.rule === "integration-templates"));
+
+  rmSync(dir, { recursive: true });
+}
+
+console.log(`\n${failures === 0 ? "All integration diagnostics tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#69.

Adds a first-class integration diagnostics command for validating downstream repo-guard wiring from repository files:

- `repo-guard validate-integration` with `text`, `json`, and `summary` output
- `repo-guard doctor --integration` as a doctor-mode alias
- blocking/advisory exit semantics via the existing `--enforcement` mode
- normalized workflow `runCommands` facts so command-based repo-guard wiring is visible in JSON diagnostics

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/
  - tests/
  - README.md
  - package.json
  - .github/workflows/ci.yml
budgets:
  max_new_files: 2
  max_new_docs: 0
  max_net_added_lines: 900
must_touch:
  - src/**
must_not_touch: []
expected_effects:
  - Add a built-in integration validation command with JSON and summary diagnostics
  - Allow doctor to run integration-only diagnostics
```

## How to reproduce the original gap

Before this change, `repo-guard validate-integration --format json` was not a CLI mode and was treated as a contract path, failing with `ENOENT` instead of producing integration diagnostics.

## Verification

- `npm run test:integration-diagnostics`
- `npm test`
- `npm run validate`
- `node src/repo-guard.mjs validate-integration --format summary`
- `node src/repo-guard.mjs --enforcement advisory validate-integration --format summary`
- `npm pack --dry-run`

## Notes

- No UI changes or screenshots are involved; this is CLI/diagnostic output only.
