### PR TITLE
Add configurable repo-guard PR gate integration rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
 jobs:
   validate:
     # repo-guard's own CI is intentionally blocking: this job protects the
@@ -74,6 +79,10 @@ jobs:
           enforcement: blocking
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish repo-guard summary
+        if: always() && github.event_name == 'pull_request' && !github.event.pull_request.draft
+        run: echo "### repo-guard" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Exercise advisory policy mode
         run: |

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T12:05:46.151Z for PR creation at branch issue-70-aa6eb8d2743f for issue https://github.com/netkeep80/repo-guard/issues/70

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T12:05:46.151Z for PR creation at branch issue-70-aa6eb8d2743f for issue https://github.com/netkeep80/repo-guard/issues/70

--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
 jobs:
   policy-check:
     runs-on: ubuntu-latest
@@ -187,6 +192,10 @@ jobs:
           enforcement: blocking
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish repo-guard summary
+        if: always()
+        run: echo "### repo-guard" >> "$GITHUB_STEP_SUMMARY"
 ```
 
 Используйте тег релиза вместо `vX.Y.Z` для воспроизводимых запусков. При
@@ -282,8 +291,8 @@ jobs:
 `repo-guard`: какой workflow запускает проверку, какие шаблоны содержат
 contract block, какие документы объясняют contract/profile/anchor-практики и
 где описаны профили. Это декларативный слой политики: `repo-guard` читает
-перечисленные YAML/Markdown-файлы и строит normalized facts, но не применяет
-их как runtime enforcement rules.
+перечисленные YAML/Markdown-файлы, строит normalized facts и применяет
+`validate-integration` diagnostics к объявленным ожиданиям.
 
 Во время компиляции политики `repo-guard` проверяет, что ids уникальны во всей
 `integration` секции, обязательные поля заполнены, workflow/template/doc kinds
@@ -296,6 +305,23 @@ contract block, какие документы объясняют contract/profil
 | `workflows[].role` | `repo_guard_pr_gate`, `repo_guard_advisory`, `repo_guard_policy_validation` |
 | `templates[].kind` | `markdown`, `github_issue_form` |
 | `docs[].kind` | `markdown` |
+
+Для `workflows[].role: "repo_guard_pr_gate"` можно объявить `expect`:
+
+| Поле | Что проверяет |
+| --- | --- |
+| `events` | Обязательные GitHub Actions events, например `pull_request` |
+| `event_types` | Обязательные `pull_request.types` / `pull_request_target.types` |
+| `action.uses` | Ожидаемый Action target, например `netkeep80/repo-guard` или `./` |
+| `action.ref_pinning` | Стратегия pinning: `local`, `ref`, `tag`, `semver`, `sha` или `any` |
+| `action.ref` | Конкретный ожидаемый ref Action |
+| `mode` | Ожидаемый input `mode`, обычно `check-pr` |
+| `enforcement` | Ожидаемый input `enforcement`: `blocking` или `advisory` |
+| `permissions` | Минимальные workflow/job permissions, например `contents: read` |
+| `token_env` | Альтернативные env-переменные токена, из которых нужна хотя бы одна |
+| `required_env` | Env-переменные, которые должны присутствовать все |
+| `summary` | Требовать запись в `$GITHUB_STEP_SUMMARY` |
+| `disallow` | Запрещенные patterns: `continue_on_error`, `manual_clone`, `direct_temp_cli_execution` |
 
 `buildPolicyFacts(...).integration` содержит:
 
@@ -335,7 +361,25 @@ normalized `integration` facts, `ruleResults`, `violations`, `diagnostics` и
         "kind": "github_actions",
         "path": ".github/workflows/repo-guard.yml",
         "role": "repo_guard_pr_gate",
-        "profiles": ["requirements-strict"]
+        "profiles": ["requirements-strict"],
+        "expect": {
+          "events": ["pull_request"],
+          "event_types": ["opened", "synchronize", "reopened", "ready_for_review"],
+          "action": {
+            "uses": "netkeep80/repo-guard",
+            "ref_pinning": "semver"
+          },
+          "mode": "check-pr",
+          "enforcement": "blocking",
+          "permissions": {
+            "contents": "read",
+            "pull-requests": "read",
+            "issues": "read"
+          },
+          "token_env": ["GH_TOKEN"],
+          "summary": true,
+          "disallow": ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]
+        }
       }
     ],
     "templates": [

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -10,7 +10,25 @@
         "id": "ci-pr-policy-check",
         "kind": "github_actions",
         "path": ".github/workflows/ci.yml",
-        "role": "repo_guard_pr_gate"
+        "role": "repo_guard_pr_gate",
+        "expect": {
+          "events": ["pull_request"],
+          "event_types": ["opened", "synchronize", "reopened", "ready_for_review"],
+          "action": {
+            "uses": "./",
+            "ref_pinning": "local"
+          },
+          "mode": "check-pr",
+          "enforcement": "blocking",
+          "permissions": {
+            "contents": "read",
+            "pull-requests": "read",
+            "issues": "read"
+          },
+          "token_env": ["GH_TOKEN"],
+          "summary": true,
+          "disallow": ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]
+        }
       }
     ],
     "templates": [

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -394,7 +394,58 @@
           "enum": ["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"],
           "description": "Supported repo-guard role for this workflow."
         },
+        "expect": { "$ref": "#/definitions/integration_workflow_expectation" },
         "profiles": { "$ref": "#/definitions/non_empty_string_array" }
+      }
+    },
+    "integration_workflow_expectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional workflow expectations checked by validate-integration for repo-guard workflow roles.",
+      "properties": {
+        "events": { "$ref": "#/definitions/non_empty_string_array" },
+        "event_types": { "$ref": "#/definitions/non_empty_string_array" },
+        "action": { "$ref": "#/definitions/integration_workflow_action_expectation" },
+        "mode": {
+          "type": "string",
+          "enum": ["check-pr", "check-diff"]
+        },
+        "enforcement": {
+          "type": "string",
+          "enum": ["advisory", "blocking"]
+        },
+        "permissions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["none", "read", "write"]
+          },
+          "minProperties": 1
+        },
+        "token_env": { "$ref": "#/definitions/non_empty_string_array" },
+        "required_env": { "$ref": "#/definitions/non_empty_string_array" },
+        "summary": { "type": "boolean" },
+        "disallow": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
+    "integration_workflow_action_expectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "uses": { "$ref": "#/definitions/non_empty_string" },
+        "ref": { "$ref": "#/definitions/non_empty_string" },
+        "ref_pinning": {
+          "type": "string",
+          "enum": ["any", "local", "ref", "tag", "semver", "sha"]
+        }
       }
     },
     "integration_template": {

--- a/src/extractors/integration.mjs
+++ b/src/extractors/integration.mjs
@@ -63,6 +63,23 @@ function extractTriggerEvents(onValue) {
   return [];
 }
 
+function extractTriggerEventTypes(onValue) {
+  if (!isPlainObject(onValue)) return [];
+
+  const result = [];
+  for (const [event, config] of Object.entries(onValue)) {
+    if (!isPlainObject(config) || !Object.hasOwn(config, "types")) continue;
+    const rawTypes = Array.isArray(config.types) ? config.types : [config.types];
+    const types = rawTypes
+      .filter((item) => item !== null && item !== undefined)
+      .map((item) => normalizeValue(item));
+    if (types.length > 0) {
+      result.push({ event, types });
+    }
+  }
+  return result;
+}
+
 function collectEnvVars(envValue, scope, extra = {}) {
   const env = normalizeMap(envValue);
   if (!env) return [];
@@ -87,6 +104,7 @@ function collectWorkflowFacts(entry, content) {
   const ifConditions = [];
   const runCommands = [];
   const summaryPublishing = [];
+  const continueOnError = [];
   const jobPermissions = [];
 
   for (const [jobId, job] of Object.entries(jobs)) {
@@ -106,6 +124,14 @@ function collectWorkflowFacts(entry, content) {
         scope: "job",
         jobId,
         condition: normalizeValue(job.if),
+      });
+    }
+
+    if (job["continue-on-error"] !== undefined) {
+      continueOnError.push({
+        scope: "job",
+        jobId,
+        value: normalizeValue(job["continue-on-error"]),
       });
     }
 
@@ -146,6 +172,13 @@ function collectWorkflowFacts(entry, content) {
         });
       }
 
+      if (step["continue-on-error"] !== undefined) {
+        continueOnError.push({
+          ...stepBase,
+          value: normalizeValue(step["continue-on-error"]),
+        });
+      }
+
       if (step.run !== undefined) {
         runCommands.push({
           ...stepBase,
@@ -171,7 +204,9 @@ function collectWorkflowFacts(entry, content) {
     kind: entry.kind,
     path: entry.path,
     role: entry.role,
+    expect: entry.expect || null,
     triggerEvents: extractTriggerEvents(data.on),
+    triggerEventTypes: extractTriggerEventTypes(data.on),
     permissions: {
       workflow: workflowPermission,
       jobs: jobPermissions,
@@ -182,6 +217,7 @@ function collectWorkflowFacts(entry, content) {
     ifConditions,
     runCommands,
     summaryPublishing,
+    continueOnError,
   };
 }
 

--- a/src/integration-validator.mjs
+++ b/src/integration-validator.mjs
@@ -137,6 +137,35 @@ function workflowReferencesRepoGuard(workflow) {
   return usesRepoGuardAction || runsRepoGuardCommand;
 }
 
+function isLocalActionUse(uses) {
+  const value = String(uses || "");
+  return value === "./" || value.startsWith("./") || value.startsWith("../");
+}
+
+function parseActionUse(uses) {
+  const value = String(uses || "").trim();
+  if (isLocalActionUse(value)) {
+    return { raw: value, target: value, ref: "", local: true };
+  }
+
+  const atIndex = value.lastIndexOf("@");
+  if (atIndex === -1) {
+    return { raw: value, target: value, ref: "", local: false };
+  }
+
+  return {
+    raw: value,
+    target: value.slice(0, atIndex),
+    ref: value.slice(atIndex + 1),
+    local: false,
+  };
+}
+
+function isRepoGuardActionUse(uses) {
+  const parsed = parseActionUse(uses);
+  return parsed.local || parsed.target.toLowerCase().includes("repo-guard");
+}
+
 function workflowRunsCheckPR(workflow) {
   const inputMode = workflow.stepInputs.some((fact) =>
     Object.values(fact.inputs || {}).some((value) => String(value).includes("check-pr"))
@@ -153,29 +182,259 @@ function workflowHasFetchDepthZero(workflow) {
   });
 }
 
-function workflowHasGitHubToken(workflow) {
-  return workflow.envVars.some((fact) => fact.name === "GH_TOKEN" || fact.name === "GITHUB_TOKEN");
+function workflowHasEnv(workflow, names) {
+  const expected = new Set(names);
+  return workflow.envVars.some((fact) => expected.has(fact.name));
+}
+
+function workflowHasAllEnv(workflow, names) {
+  const actual = new Set(workflow.envVars.map((fact) => fact.name));
+  return names.every((name) => actual.has(name));
+}
+
+function formatStepName(fact) {
+  return fact.stepName ? ` "${fact.stepName}"` : "";
+}
+
+function workflowLocation(workflow, fact = {}) {
+  const context = [];
+  if (fact.jobId) context.push(`job ${fact.jobId}`);
+  if (fact.stepIndex) context.push(`step ${fact.stepIndex}${formatStepName(fact)}`);
+  return context.length > 0 ? `${workflow.path}: ${context.join(" ")}` : workflow.path;
+}
+
+function workflowDetail(workflow, fact, message) {
+  return `${workflowLocation(workflow, fact)}: ${message}`;
+}
+
+function triggerTypesFor(workflow, event) {
+  return workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
+}
+
+function repoGuardActionFacts(workflow, actionExpectation = {}) {
+  const expectedUses = actionExpectation.uses;
+  return workflow.actionUses
+    .map((fact) => ({ ...fact, parsedUses: parseActionUse(fact.uses) }))
+    .filter((fact) => {
+      if (expectedUses) {
+        return fact.parsedUses.target === expectedUses || fact.uses === expectedUses;
+      }
+      return isRepoGuardActionUse(fact.uses);
+    });
+}
+
+function stepInputsForAction(workflow, actionFact) {
+  return workflow.stepInputs.find((fact) =>
+    fact.jobId === actionFact.jobId &&
+    fact.stepIndex === actionFact.stepIndex &&
+    fact.uses === actionFact.uses
+  );
+}
+
+function semverRef(ref) {
+  return /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(String(ref || ""));
+}
+
+function shaRef(ref) {
+  return /^[0-9a-f]{40}$/i.test(String(ref || ""));
+}
+
+function branchLikeRef(ref) {
+  return /^(main|master|develop|dev|trunk|head)$/i.test(String(ref || ""));
+}
+
+function satisfiesRefPinning(parsedUses, strategy = "ref") {
+  if (strategy === "any") return true;
+  if (strategy === "local") return parsedUses.local;
+  if (parsedUses.local) return true;
+  if (strategy === "ref") return parsedUses.ref.length > 0;
+  if (strategy === "sha") return shaRef(parsedUses.ref);
+  if (strategy === "semver") return semverRef(parsedUses.ref);
+  if (strategy === "tag") return parsedUses.ref.length > 0 && !shaRef(parsedUses.ref) && !branchLikeRef(parsedUses.ref);
+  return false;
+}
+
+function permissionMatches(actual, expected) {
+  return actual && String(actual).toLowerCase() === String(expected).toLowerCase();
+}
+
+function workflowHasPermission(workflow, permission, expectedValue) {
+  if (isPlainObject(workflow.permissions.workflow) &&
+    permissionMatches(workflow.permissions.workflow[permission], expectedValue)) {
+    return true;
+  }
+
+  return workflow.permissions.jobs.some((job) =>
+    isPlainObject(job.permissions) &&
+    permissionMatches(job.permissions[permission], expectedValue)
+  );
+}
+
+function isTruthyContinueOnError(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  return normalized !== "" && normalized !== "false" && normalized !== "0" && normalized !== "null";
+}
+
+function runClonesRepoGuard(run) {
+  const text = String(run || "");
+  return /\bgit\s+clone\b/i.test(text) && /repo-guard/i.test(text);
+}
+
+function runUsesTemporaryRepoGuardCli(run) {
+  const text = String(run || "");
+  return text.split(/\r?\n/).some((line) =>
+    /RUNNER_TEMP|TMPDIR|\/tmp|\btemp\b/i.test(line) &&
+    /src\/repo-guard\.mjs|repo-guard\.mjs/i.test(line)
+  );
+}
+
+function validateExpectedAction(details, workflow, expect) {
+  const actionExpectation = expect.action || {};
+  const actionFacts = repoGuardActionFacts(workflow, actionExpectation);
+  if (actionFacts.length === 0) {
+    const expected = actionExpectation.uses || "a repo-guard action";
+    details.push(`${workflow.path}: repo_guard_pr_gate workflow must use ${expected} via uses`);
+    return [];
+  }
+
+  const refPinning = actionExpectation.ref_pinning || (actionExpectation.ref ? "ref" : "ref");
+  const matchingRef = actionFacts.find((fact) => {
+    if (actionExpectation.ref && fact.parsedUses.ref !== actionExpectation.ref) return false;
+    return satisfiesRefPinning(fact.parsedUses, refPinning);
+  });
+
+  if (!matchingRef) {
+    const actual = actionFacts.map((fact) => fact.uses).join(", ");
+    details.push(`${workflow.path}: repo_guard_pr_gate action must satisfy ref_pinning ${refPinning}${actionExpectation.ref ? ` at ref ${actionExpectation.ref}` : ""}; actual uses: ${actual}`);
+  }
+
+  return actionFacts;
+}
+
+function validateExpectedActionInput(details, workflow, actionFacts, field, expectedValue) {
+  if (!expectedValue) return;
+
+  const matching = actionFacts.find((fact) => {
+    const inputs = stepInputsForAction(workflow, fact)?.inputs || {};
+    return inputs[field] === expectedValue;
+  });
+  if (matching) return;
+
+  const locationFact = actionFacts[0] || {};
+  details.push(workflowDetail(
+    workflow,
+    locationFact,
+    `repo_guard_pr_gate action must set ${field}: ${expectedValue}`
+  ));
+}
+
+function validateWorkflowDisallowedPatterns(details, workflow, disallow) {
+  const patterns = new Set(disallow || []);
+
+  if (patterns.has("continue_on_error")) {
+    for (const fact of workflow.continueOnError || []) {
+      if (!isTruthyContinueOnError(fact.value)) continue;
+      details.push(workflowDetail(workflow, fact, "repo_guard_pr_gate step must not set continue-on-error"));
+    }
+  }
+
+  if (patterns.has("manual_clone")) {
+    for (const fact of workflow.runCommands) {
+      if (!runClonesRepoGuard(fact.run)) continue;
+      details.push(workflowDetail(workflow, fact, "repo_guard_pr_gate workflow must not clone repo-guard manually"));
+    }
+  }
+
+  if (patterns.has("direct_temp_cli_execution")) {
+    for (const fact of workflow.runCommands) {
+      if (!runUsesTemporaryRepoGuardCli(fact.run)) continue;
+      details.push(workflowDetail(workflow, fact, "repo_guard_pr_gate workflow must not run repo-guard directly from a temporary clone"));
+    }
+  }
+}
+
+function validateRepoGuardPrGate(details, workflow) {
+  const expect = workflow.expect || {};
+  const triggers = new Set(workflow.triggerEvents);
+  const expectedEvents = expect.events || [];
+
+  if (expectedEvents.length > 0) {
+    for (const event of expectedEvents) {
+      if (!triggers.has(event)) {
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required event ${event}`);
+      }
+    }
+  } else if (!triggers.has("pull_request") && !triggers.has("pull_request_target")) {
+    details.push(`${workflow.path}: repo_guard_pr_gate workflow must run on pull_request or pull_request_target`);
+  }
+
+  if (expect.event_types && expect.event_types.length > 0) {
+    const event = triggers.has("pull_request") ? "pull_request" : "pull_request_target";
+    const actualTypes = new Set(triggerTypesFor(workflow, event));
+    for (const type of expect.event_types) {
+      if (!actualTypes.has(type)) {
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required ${event} type ${type}`);
+      }
+    }
+  }
+
+  if (!workflowHasFetchDepthZero(workflow)) {
+    details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
+  }
+
+  const actionFacts = expect.action
+    ? validateExpectedAction(details, workflow, expect)
+    : repoGuardActionFacts(workflow);
+
+  if (!expect.action && !workflowReferencesRepoGuard(workflow)) {
+    details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
+  }
+
+  const expectedMode = expect.mode || "check-pr";
+  if (actionFacts.length > 0) {
+    validateExpectedActionInput(details, workflow, actionFacts, "mode", expectedMode);
+    validateExpectedActionInput(details, workflow, actionFacts, "enforcement", expect.enforcement);
+  } else if (expectedMode === "check-pr" && !workflowRunsCheckPR(workflow)) {
+    details.push(`${workflow.path}: repo_guard_pr_gate workflow must run check-pr`);
+  }
+
+  if (expect.permissions) {
+    for (const [permission, expectedValue] of Object.entries(expect.permissions)) {
+      if (workflowHasPermission(workflow, permission, expectedValue)) continue;
+      details.push(`${workflow.path}: repo_guard_pr_gate workflow must declare permission ${permission}: ${expectedValue}`);
+    }
+  }
+
+  const tokenEnv = expect.token_env || (expectedMode === "check-pr" ? ["GH_TOKEN", "GITHUB_TOKEN"] : []);
+  if (tokenEnv.length > 0 && !workflowHasEnv(workflow, tokenEnv)) {
+    details.push(`${workflow.path}: check-pr workflow should provide one of ${tokenEnv.join(", ")}`);
+  }
+
+  if (expect.required_env && expect.required_env.length > 0 && !workflowHasAllEnv(workflow, expect.required_env)) {
+    const actual = new Set(workflow.envVars.map((fact) => fact.name));
+    const missing = expect.required_env.filter((name) => !actual.has(name));
+    details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required env ${missing.join(", ")}`);
+  }
+
+  if (expect.summary === true && workflow.summaryPublishing.length === 0) {
+    details.push(`${workflow.path}: repo_guard_pr_gate workflow must publish to GITHUB_STEP_SUMMARY`);
+  }
+
+  validateWorkflowDisallowedPatterns(
+    details,
+    workflow,
+    expect.disallow || ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]
+  );
 }
 
 function workflowDiagnostics(integration) {
   const details = [];
 
   for (const workflow of integration.workflows) {
-    if (!workflowReferencesRepoGuard(workflow)) {
-      details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
-    }
-
     if (workflow.role === "repo_guard_pr_gate") {
-      const triggers = new Set(workflow.triggerEvents);
-      if (!triggers.has("pull_request") && !triggers.has("pull_request_target")) {
-        details.push(`${workflow.path}: repo_guard_pr_gate workflow must run on pull_request or pull_request_target`);
-      }
-      if (!workflowHasFetchDepthZero(workflow)) {
-        details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
-      }
-      if (workflowRunsCheckPR(workflow) && !workflowHasGitHubToken(workflow)) {
-        details.push(`${workflow.path}: check-pr workflow should provide GH_TOKEN or GITHUB_TOKEN`);
-      }
+      validateRepoGuardPrGate(details, workflow);
+    } else if (!workflowReferencesRepoGuard(workflow)) {
+      details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
     }
   }
 

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -267,7 +267,7 @@ const integrationSectionRules = {
     requiredBooleans: [],
     requiredStringArrays: [],
     optionalStringArrays: ["profiles"],
-    allowedFields: new Set(["id", "kind", "path", "role", "profiles"]),
+    allowedFields: new Set(["id", "kind", "path", "role", "expect", "profiles"]),
     kinds: new Set(["github_actions"]),
     roles: new Set(["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"]),
   },
@@ -295,6 +295,27 @@ const integrationSectionRules = {
     optionalStringArrays: [],
     allowedFields: new Set(["id", "doc_path"]),
   },
+};
+
+const workflowExpectationRules = {
+  allowedFields: new Set([
+    "events",
+    "event_types",
+    "action",
+    "mode",
+    "enforcement",
+    "permissions",
+    "token_env",
+    "required_env",
+    "summary",
+    "disallow",
+  ]),
+  actionFields: new Set(["uses", "ref", "ref_pinning"]),
+  modes: new Set(["check-pr", "check-diff"]),
+  enforcementModes: new Set(["advisory", "blocking"]),
+  permissionValues: new Set(["none", "read", "write"]),
+  refPinning: new Set(["any", "local", "ref", "tag", "semver", "sha"]),
+  disallowedPatterns: new Set(["continue_on_error", "manual_clone", "direct_temp_cli_execution"]),
 };
 
 function formatAllowed(values) {
@@ -420,6 +441,222 @@ function validateIntegrationStringArray(errors, section, index, entry, field, { 
   return validValues;
 }
 
+function integrationExpectationMessage(index, path, message) {
+  return `integration.workflows[${index}].expect.${path} ${message}`;
+}
+
+function pushWorkflowExpectationError(errors, index, path, message, extra = {}) {
+  errors.push(compileIntegrationError(
+    "workflows",
+    index,
+    `expect.${path}`,
+    integrationExpectationMessage(index, path, message),
+    extra
+  ));
+}
+
+function validateExpectationString(errors, index, source, path, { required = false, field = path } = {}) {
+  if (!Object.hasOwn(source, field)) {
+    if (required) {
+      pushWorkflowExpectationError(errors, index, path, "is required");
+    }
+    return false;
+  }
+
+  if (typeof source[field] !== "string" || source[field].trim().length === 0) {
+    pushWorkflowExpectationError(
+      errors,
+      index,
+      path,
+      "is required and must be a non-empty string",
+      { value: source[field] }
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function validateExpectationEnum(errors, index, source, path, allowedValues, { required = false, field = path } = {}) {
+  if (!validateExpectationString(errors, index, source, path, { required, field })) {
+    return;
+  }
+
+  if (!allowedValues.has(source[field])) {
+    pushWorkflowExpectationError(
+      errors,
+      index,
+      path,
+      `must be one of ${formatAllowed(allowedValues)}`,
+      { value: source[field] }
+    );
+  }
+}
+
+function validateExpectationStringArray(errors, index, source, path, allowedValues = null) {
+  const value = source[path];
+  if (!Array.isArray(value)) {
+    pushWorkflowExpectationError(
+      errors,
+      index,
+      path,
+      "must be an array of non-empty strings",
+      { value }
+    );
+    return [];
+  }
+
+  const validValues = [];
+  for (const [itemIndex, item] of value.entries()) {
+    const itemPath = `${path}[${itemIndex}]`;
+    if (typeof item !== "string" || item.trim().length === 0) {
+      pushWorkflowExpectationError(
+        errors,
+        index,
+        itemPath,
+        "must be a non-empty string",
+        { value: item }
+      );
+      continue;
+    }
+
+    if (allowedValues && !allowedValues.has(item)) {
+      pushWorkflowExpectationError(
+        errors,
+        index,
+        itemPath,
+        `must be one of ${formatAllowed(allowedValues)}`,
+        { value: item }
+      );
+      continue;
+    }
+
+    validValues.push(item);
+  }
+
+  if (validValues.length === 0) {
+    pushWorkflowExpectationError(
+      errors,
+      index,
+      path,
+      "must contain at least one non-empty string"
+    );
+  }
+
+  return validValues;
+}
+
+function validateWorkflowExpectations(errors, index, entry) {
+  if (!Object.hasOwn(entry, "expect")) return;
+
+  const expect = entry.expect;
+  if (!isPlainObject(expect)) {
+    errors.push(compileIntegrationError(
+      "workflows",
+      index,
+      "expect",
+      `integration.workflows[${index}].expect must be an object`,
+      { value: expect }
+    ));
+    return;
+  }
+
+  for (const field of Object.keys(expect)) {
+    if (!workflowExpectationRules.allowedFields.has(field)) {
+      pushWorkflowExpectationError(errors, index, field, "is not supported");
+    }
+  }
+
+  for (const field of ["events", "event_types", "token_env", "required_env"]) {
+    if (Object.hasOwn(expect, field)) {
+      validateExpectationStringArray(errors, index, expect, field);
+    }
+  }
+
+  if (Object.hasOwn(expect, "mode")) {
+    validateExpectationEnum(errors, index, expect, "mode", workflowExpectationRules.modes);
+  }
+
+  if (Object.hasOwn(expect, "enforcement")) {
+    validateExpectationEnum(errors, index, expect, "enforcement", workflowExpectationRules.enforcementModes);
+  }
+
+  if (Object.hasOwn(expect, "summary") && typeof expect.summary !== "boolean") {
+    pushWorkflowExpectationError(
+      errors,
+      index,
+      "summary",
+      "must be a boolean",
+      { value: expect.summary }
+    );
+  }
+
+  if (Object.hasOwn(expect, "disallow")) {
+    validateExpectationStringArray(errors, index, expect, "disallow", workflowExpectationRules.disallowedPatterns);
+  }
+
+  if (Object.hasOwn(expect, "permissions")) {
+    if (!isPlainObject(expect.permissions)) {
+      pushWorkflowExpectationError(
+        errors,
+        index,
+        "permissions",
+        "must be an object",
+        { value: expect.permissions }
+      );
+    } else {
+      const entries = Object.entries(expect.permissions);
+      if (entries.length === 0) {
+        pushWorkflowExpectationError(errors, index, "permissions", "must declare at least one permission");
+      }
+      for (const [permission, value] of entries) {
+        if (!workflowExpectationRules.permissionValues.has(value)) {
+          pushWorkflowExpectationError(
+            errors,
+            index,
+            `permissions.${permission}`,
+            `must be one of ${formatAllowed(workflowExpectationRules.permissionValues)}`,
+            { value }
+          );
+        }
+      }
+    }
+  }
+
+  if (Object.hasOwn(expect, "action")) {
+    if (!isPlainObject(expect.action)) {
+      pushWorkflowExpectationError(
+        errors,
+        index,
+        "action",
+        "must be an object",
+        { value: expect.action }
+      );
+    } else {
+      for (const field of Object.keys(expect.action)) {
+        if (!workflowExpectationRules.actionFields.has(field)) {
+          pushWorkflowExpectationError(errors, index, `action.${field}`, "is not supported");
+        }
+      }
+      for (const field of ["uses", "ref"]) {
+        if (Object.hasOwn(expect.action, field)) {
+          validateExpectationString(errors, index, expect.action, `action.${field}`, { field });
+        }
+      }
+      if (Object.hasOwn(expect.action, "ref_pinning")) {
+        validateExpectationEnum(
+          errors,
+          index,
+          expect.action,
+          "action.ref_pinning",
+          workflowExpectationRules.refPinning,
+          { field: "ref_pinning" }
+        );
+      }
+    }
+  }
+}
+
 export function compileIntegrationPolicy(policy) {
   const errors = [];
   const integration = policy.integration;
@@ -526,6 +763,10 @@ export function compileIntegrationPolicy(policy) {
           `integration.${section}[${index}].role must be one of ${formatAllowed(rules.roles)}`,
           { value: entry.role }
         ));
+      }
+
+      if (section === "workflows") {
+        validateWorkflowExpectations(errors, index, entry);
       }
 
       if (!hasNonEmptyString(entry, "id")) continue;

--- a/templates/example-workflow.yml
+++ b/templates/example-workflow.yml
@@ -15,6 +15,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
 jobs:
   policy-check:
     runs-on: ubuntu-latest
@@ -32,3 +37,7 @@ jobs:
         env:
           # Required for fetching linked issue contracts
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish repo-guard summary
+        if: always()
+        run: echo "### repo-guard" >> "$GITHUB_STEP_SUMMARY"

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -348,6 +348,23 @@ describe("integration policy compilation", () => {
             path: ".github/workflows/repo-guard.yml",
             role: "repo_guard_pr_gate",
             profiles: ["requirements-strict"],
+            expect: {
+              events: ["pull_request"],
+              event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
+              action: {
+                uses: "netkeep80/repo-guard",
+                ref_pinning: "semver",
+              },
+              mode: "check-pr",
+              enforcement: "blocking",
+              permissions: {
+                contents: "read",
+                "pull-requests": "read",
+              },
+              token_env: ["GH_TOKEN"],
+              summary: true,
+              disallow: ["continue_on_error", "manual_clone", "direct_temp_cli_execution"],
+            },
           },
         ],
         templates: [
@@ -500,6 +517,46 @@ describe("integration policy compilation", () => {
     assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].role must be one of")));
     assert.ok(errors.some((e) => e.message.includes("integration.templates[0].kind must be one of")));
     assert.ok(errors.some((e) => e.message.includes("integration.docs[0].kind must be one of")));
+  });
+
+  it("rejects malformed workflow PR-gate expectations during compilation", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        workflows: [
+          {
+            id: "pr-gate",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard.yml",
+            role: "repo_guard_pr_gate",
+            expect: {
+              events: "pull_request",
+              action: {
+                uses: "",
+                ref_pinning: "floating",
+              },
+              mode: "deploy",
+              enforcement: "warn",
+              permissions: {
+                contents: "admin",
+              },
+              token_env: [],
+              summary: "yes",
+              disallow: ["manual_clone", "unknown_pattern"],
+            },
+          },
+        ],
+      },
+    });
+
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.events must be an array")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.action.uses is required")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.action.ref_pinning must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.mode must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.enforcement must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.permissions.contents must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.token_env must contain at least one")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.summary must be a boolean")));
+    assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.disallow[1] must be one of")));
   });
 
   it("rejects profile references that do not resolve to integration.profiles ids", () => {

--- a/tests/test-integration-diagnostics.mjs
+++ b/tests/test-integration-diagnostics.mjs
@@ -54,6 +54,31 @@ function writeJson(path, value) {
   writeFileSync(path, JSON.stringify(value, null, 2));
 }
 
+function prGateExpect(overrides = {}) {
+  return {
+    events: ["pull_request"],
+    event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
+    action: {
+      uses: "netkeep80/repo-guard",
+      ref_pinning: "semver",
+      ...overrides.action,
+    },
+    mode: "check-pr",
+    enforcement: "blocking",
+    permissions: {
+      contents: "read",
+      "pull-requests": "read",
+      ...overrides.permissions,
+    },
+    token_env: ["GH_TOKEN"],
+    summary: true,
+    disallow: ["continue_on_error", "manual_clone", "direct_temp_cli_execution"],
+    ...Object.fromEntries(Object.entries(overrides).filter(([key]) =>
+      key !== "action" && key !== "permissions"
+    )),
+  };
+}
+
 function basePolicy(overrides = {}) {
   return {
     policy_format_version: "0.3.0",
@@ -67,6 +92,7 @@ function basePolicy(overrides = {}) {
           path: ".github/workflows/repo-guard.yml",
           role: "repo_guard_pr_gate",
           profiles: ["self-hosting"],
+          expect: prGateExpect(),
         },
       ],
       templates: [
@@ -125,7 +151,11 @@ function makeRepo() {
     "name: repo guard",
     "on:",
     "  pull_request:",
+    "    types: [opened, synchronize, reopened, ready_for_review]",
     "  push:",
+    "permissions:",
+    "  contents: read",
+    "  pull-requests: read",
     "jobs:",
     "  validate:",
     "    runs-on: ubuntu-latest",
@@ -134,9 +164,15 @@ function makeRepo() {
     "        with:",
     "          fetch-depth: 0",
     "      - name: Run repo-guard",
+    "        uses: netkeep80/repo-guard@v1.2.3",
+    "        with:",
+    "          mode: check-pr",
+    "          enforcement: blocking",
     "        env:",
     "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
-    "        run: npx repo-guard check-pr --format summary",
+    "      - name: Publish repo-guard summary",
+    "        if: always()",
+    "        run: echo \"### repo-guard\" >> \"$GITHUB_STEP_SUMMARY\"",
     "",
   ].join("\n"));
   writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), [
@@ -177,13 +213,20 @@ function makeBrokenRepo() {
   writeFileSync(join(dir, ".github", "workflows", "repo-guard.yml"), [
     "name: repo guard",
     "on:",
-    "  push:",
+    "  pull_request:",
+    "    types: [opened]",
+    "permissions:",
+    "  contents: write",
     "jobs:",
     "  validate:",
     "    runs-on: ubuntu-latest",
     "    steps:",
     "      - uses: actions/checkout@v4",
-    "      - run: echo no policy gate here",
+    "      - name: Drifted repo-guard",
+    "        continue-on-error: true",
+    "        run: |",
+    "          git clone https://github.com/netkeep80/repo-guard \"$RUNNER_TEMP/repo-guard\"",
+    "          node \"$RUNNER_TEMP/repo-guard/src/repo-guard.mjs\" check-diff",
     "",
   ].join("\n"));
   writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), "## Missing contract\n");
@@ -216,7 +259,15 @@ console.log("\n--- validate-integration --format json emits normalized integrati
   expect("result passed", parsed?.result, "passed");
   expect("repository root is included", parsed?.repositoryRoot, dir);
   expect("workflow facts are emitted", parsed?.integration?.workflows?.[0]?.triggerEvents, ["pull_request", "push"]);
-  expect("run commands are normalized facts", parsed?.integration?.workflows?.[0]?.runCommands?.[0]?.run, "npx repo-guard check-pr --format summary");
+  expect("workflow event types are emitted", parsed?.integration?.workflows?.[0]?.triggerEventTypes, [
+    {
+      event: "pull_request",
+      types: ["opened", "synchronize", "reopened", "ready_for_review"],
+    },
+  ]);
+  expect("action inputs are normalized facts",
+    parsed?.integration?.workflows?.[0]?.stepInputs?.find((fact) => fact.uses === "netkeep80/repo-guard@v1.2.3")?.inputs,
+    { enforcement: "blocking", mode: "check-pr" });
   expect("template diagnostics pass", parsed?.ruleResults?.some((rule) => rule.rule === "integration-templates" && rule.ok), true);
   expect("stats include declared templates", parsed?.diagnostics?.declared?.templates, 2);
 
@@ -253,7 +304,12 @@ console.log("\n--- validate-integration --format summary reports CI-readable dia
   expect("broken integration blocks in blocking mode", result.code, 1);
   expectIncludes("summary heading", result.output, "## repo-guard integration summary");
   expectIncludes("summary result", result.output, "- Result: failed");
-  expectIncludes("workflow diagnostic appears", result.output, "repo_guard_pr_gate workflow must run on pull_request");
+  expectIncludes("workflow diagnostic appears", result.output, "missing required pull_request type synchronize");
+  expectIncludes("step diagnostic includes workflow context", result.output, ".github/workflows/repo-guard.yml: job validate step 2 \"Drifted repo-guard\"");
+  expectIncludes("continue-on-error diagnostic appears", result.output, "must not set continue-on-error");
+  expectIncludes("manual clone diagnostic appears", result.output, "must not clone repo-guard manually");
+  expectIncludes("direct temp CLI diagnostic appears", result.output, "must not run repo-guard directly from a temporary clone");
+  expectIncludes("summary diagnostic appears", result.output, "must publish to GITHUB_STEP_SUMMARY");
   expectIncludes("template diagnostic appears", result.output, "requires a repo-guard contract block");
   expectIncludes("doc diagnostic appears", result.output, "missing required mention");
 

--- a/tests/test-integration-extractors.mjs
+++ b/tests/test-integration-extractors.mjs
@@ -117,6 +117,7 @@ const files = {
     "          fetch-depth: 0",
     "      - name: Run repo-guard",
     "        if: always()",
+    "        continue-on-error: true",
     "        env:",
     "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
     "        run: |",
@@ -178,6 +179,12 @@ console.log("\n--- integration extractor builds normalized workflow, template, d
 
   const workflow = extraction.workflows[0];
   expect("workflow trigger events are normalized", workflow.triggerEvents, ["pull_request", "push"]);
+  expect("workflow trigger event types are normalized", workflow.triggerEventTypes, [
+    {
+      event: "pull_request",
+      types: ["opened", "synchronize"],
+    },
+  ]);
   expect("workflow permissions are normalized", workflow.permissions.workflow, { contents: "read" });
   expect("job permissions are normalized", workflow.permissions.jobs, [
     { jobId: "validate", permissions: { "pull-requests": "write" } },
@@ -201,6 +208,14 @@ console.log("\n--- integration extractor builds normalized workflow, template, d
       stepIndex: 2,
       stepName: "Run repo-guard",
       mode: "append",
+    },
+  ]);
+  expect("continue-on-error behavior is detected", workflow.continueOnError, [
+    {
+      jobId: "validate",
+      stepIndex: 2,
+      stepName: "Run repo-guard",
+      value: "true",
     },
   ]);
 

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -97,6 +97,23 @@ const policyWithIntegration = {
         path: ".github/workflows/repo-guard.yml",
         role: "repo_guard_pr_gate",
         profiles: ["requirements-strict"],
+        expect: {
+          events: ["pull_request"],
+          event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
+          action: {
+            uses: "netkeep80/repo-guard",
+            ref_pinning: "semver",
+          },
+          mode: "check-pr",
+          enforcement: "blocking",
+          permissions: {
+            contents: "read",
+            "pull-requests": "read",
+          },
+          token_env: ["GH_TOKEN"],
+          summary: true,
+          disallow: ["continue_on_error", "manual_clone", "direct_temp_cli_execution"],
+        },
       },
     ],
     templates: [
@@ -126,6 +143,30 @@ const policyWithIntegration = {
   },
 };
 expect("policy with integration section passes schema", validatePolicy(policyWithIntegration), true);
+
+const invalidIntegrationExpectationPolicy = {
+  ...validPolicy,
+  integration: {
+    workflows: [
+      {
+        id: "pr-gate",
+        kind: "github_actions",
+        path: ".github/workflows/repo-guard.yml",
+        role: "repo_guard_pr_gate",
+        expect: {
+          action: {
+            uses: "",
+            ref_pinning: "floating",
+          },
+          mode: "deploy",
+          token_env: [],
+          disallow: ["shell_script"],
+        },
+      },
+    ],
+  },
+};
+expect("policy with malformed integration workflow expectations fails schema", validatePolicy(invalidIntegrationExpectationPolicy), false);
 
 const invalidIntegrationPolicy = {
   ...validPolicy,


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#70.

Adds a generalized `repo_guard_pr_gate` rule pack to `validate-integration` so downstream repositories can declare PR-gate expectations directly in `integration.workflows[].expect` instead of maintaining bespoke workflow text checks.

## What changed

- Adds schema and compiler validation for workflow expectations: trigger events/types, Action target/ref pinning, mode, enforcement, permissions, token/env requirements, summary publishing, and disallowed workflow patterns.
- Extends workflow facts with `triggerEventTypes`, declared `expect`, and `continueOnError` step/job context.
- Validates repo-guard PR gates from normalized facts with file/job/step diagnostics for drifted wiring.
- Updates the self-hosting policy/workflow and example workflow to declare and satisfy the new PR-gate expectations.
- Documents the `expect` contract in the README.

## Reproduction

Before the implementation, the new reproducing schema test rejected `integration.workflows[].expect`, and there was no generalized diagnostic path for PR-gate drift such as missing event types, unpinned or missing Action usage, `continue-on-error`, manual clone execution, or missing `$GITHUB_STEP_SUMMARY` publishing.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/
  - schemas/repo-policy.schema.json
  - tests/
  - README.md
  - templates/example-workflow.yml
  - .github/workflows/ci.yml
  - repo-policy.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 1200
must_touch:
  - src/integration-validator.mjs
  - src/policy-compiler.mjs
  - src/extractors/integration.mjs
  - tests/**
must_not_touch: []
expected_effects:
  - Downstream policies can declare repo_guard_pr_gate expectations under integration.workflows[].expect.
  - validate-integration fails with workflow file and step context when PR-gate wiring drifts.
  - The rule pack remains generic and is not hardcoded to this repository's policy JSON.
```

## Verification

- `npm run test:schemas`
- `npm run test:hardening`
- `npm run test:integration`
- `npm run test:integration-diagnostics`
- `node src/repo-guard.mjs validate-integration --format summary`
- `npm run validate`
- `npm test`
- `git diff --check`
- `npm pack --dry-run`
- `node src/repo-guard.mjs check-diff --enforcement blocking`