### PR TITLE
Add generalized template and docs integration rules

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T13:15:41.676Z for PR creation at branch issue-71-ffaf5fbed839 for issue https://github.com/netkeep80/repo-guard/issues/71

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T13:15:41.676Z for PR creation at branch issue-71-ffaf5fbed839 for issue https://github.com/netkeep80/repo-guard/issues/71

--- a/README.md
+++ b/README.md
@@ -333,6 +333,20 @@ contract block, какие документы объясняют contract/profil
 | `profiles` | Идентификаторы профилей, migration target mentions и ссылки на имя профиля |
 | `errors` | Явные ошибки чтения, malformed YAML, malformed contract blocks и незакрытые Markdown fences |
 
+Template rules могут дополнительно требовать конкретный fenced block kind
+через `required_block_kind`, поля внутри примера контракта через
+`required_contract_fields`, а fallback issue template можно объявить
+`optional: true`. Optional template не считается ошибкой, если файл отсутствует,
+но проверяется обычными template rules, когда файл есть.
+
+Doc rules поддерживают несколько типов обязательных ссылок:
+`must_mention` для общих терминов, `must_reference_files` для путей файлов,
+`must_mention_profiles` для integration profile ids и
+`must_mention_contract_fields` для contract field anchors вроде
+`change_type`, `scope` или `anchors.affects`. Ошибки template rules и doc
+rules остаются в разных diagnostics: `integration-templates` и
+`integration-docs`.
+
 Проверить integration layer как отдельный продуктовый diagnostic:
 
 ```bash
@@ -388,7 +402,18 @@ normalized `integration` facts, `ruleResults`, `violations`, `diagnostics` и
         "kind": "markdown",
         "path": ".github/PULL_REQUEST_TEMPLATE.md",
         "requires_contract_block": true,
+        "required_block_kind": "repo-guard-yaml",
+        "required_contract_fields": ["change_type", "scope", "anchors.affects"],
         "profiles": ["requirements-strict"]
+      },
+      {
+        "id": "change-contract-issue-form",
+        "kind": "github_issue_form",
+        "path": ".github/ISSUE_TEMPLATE/change-contract.yml",
+        "requires_contract_block": true,
+        "optional": true,
+        "required_block_kind": "repo-guard-yaml",
+        "required_contract_fields": ["change_type", "scope"]
       }
     ],
     "docs": [
@@ -397,6 +422,9 @@ normalized `integration` facts, `ruleResults`, `violations`, `diagnostics` и
         "kind": "markdown",
         "path": "README.md",
         "must_mention": ["repo-guard", "anchors.affects"],
+        "must_reference_files": ["repo-policy.json", ".github/PULL_REQUEST_TEMPLATE.md"],
+        "must_mention_profiles": ["requirements-strict"],
+        "must_mention_contract_fields": ["change_type", "scope", "anchors.affects"],
         "profiles": ["requirements-strict"]
       }
     ],

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -36,20 +36,32 @@
         "id": "pull-request-template",
         "kind": "markdown",
         "path": ".github/PULL_REQUEST_TEMPLATE.md",
-        "requires_contract_block": true
+        "requires_contract_block": true,
+        "required_block_kind": "repo-guard-yaml",
+        "required_contract_fields": ["change_type", "scope", "anchors.affects"]
       },
       {
         "id": "change-contract-issue-form",
         "kind": "github_issue_form",
         "path": ".github/ISSUE_TEMPLATE/change-contract.yml",
-        "requires_contract_block": true
+        "requires_contract_block": true,
+        "optional": true,
+        "required_block_kind": "repo-guard-yaml",
+        "required_contract_fields": ["change_type", "scope", "anchors.affects"]
       }
     ],
     "docs": [
       {
         "id": "readme",
         "path": "README.md",
-        "must_mention": ["repo-guard", "contract", "integration"]
+        "must_mention": ["repo-guard", "contract", "integration"],
+        "must_reference_files": [
+          "repo-policy.json",
+          ".github/PULL_REQUEST_TEMPLATE.md",
+          ".github/ISSUE_TEMPLATE/change-contract.yml"
+        ],
+        "must_mention_profiles": ["self-hosting"],
+        "must_mention_contract_fields": ["change_type", "scope", "anchors.affects"]
       }
     ],
     "profiles": [

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -463,6 +463,19 @@
           "type": "boolean",
           "description": "Whether the template is expected to include a repo-guard contract block."
         },
+        "optional": {
+          "type": "boolean",
+          "description": "When true, a missing declared template is allowed; if the file exists, its configured template rules still apply."
+        },
+        "required_block_kind": {
+          "type": "string",
+          "enum": ["repo-guard-yaml", "repo-guard-json"],
+          "description": "Specific repo-guard fenced block kind required in the template."
+        },
+        "required_contract_fields": {
+          "$ref": "#/definitions/non_empty_string_array",
+          "description": "Contract field paths that must be present in at least one extracted contract example."
+        },
         "profiles": { "$ref": "#/definitions/non_empty_string_array" }
       }
     },
@@ -478,6 +491,18 @@
         },
         "path": { "$ref": "#/definitions/non_empty_string" },
         "must_mention": { "$ref": "#/definitions/non_empty_string_array" },
+        "must_reference_files": {
+          "$ref": "#/definitions/non_empty_string_array",
+          "description": "Repository file paths that must be mentioned in this documentation file."
+        },
+        "must_mention_profiles": {
+          "$ref": "#/definitions/non_empty_string_array",
+          "description": "Integration profile ids that must be mentioned in this documentation file."
+        },
+        "must_mention_contract_fields": {
+          "$ref": "#/definitions/non_empty_string_array",
+          "description": "Contract field paths that must be mentioned in this documentation file."
+        },
         "profiles": { "$ref": "#/definitions/non_empty_string_array" }
       }
     },

--- a/src/extractors/integration.mjs
+++ b/src/extractors/integration.mjs
@@ -372,7 +372,11 @@ function templateFactFromMarkdown(entry, markdown) {
       id: entry.id,
       kind: entry.kind,
       path: entry.path,
+      present: true,
+      optional: Boolean(entry.optional),
       requiresContractBlock: Boolean(entry.requires_contract_block),
+      requiredBlockKind: entry.required_block_kind || null,
+      requiredContractFields: entry.required_contract_fields || [],
       hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
       hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
       contractBlocks: blocks,
@@ -421,13 +425,36 @@ function collectIssueFormTemplateFacts(entry, content) {
       id: entry.id,
       kind: entry.kind,
       path: entry.path,
+      present: true,
+      optional: Boolean(entry.optional),
       requiresContractBlock: Boolean(entry.requires_contract_block),
+      requiredBlockKind: entry.required_block_kind || null,
+      requiredContractFields: entry.required_contract_fields || [],
       hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
       hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
       contractBlocks: blocks,
       contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
     },
     errors,
+  };
+}
+
+function missingOptionalTemplateFact(entry) {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    path: entry.path,
+    present: false,
+    optional: true,
+    requiresContractBlock: Boolean(entry.requires_contract_block),
+    requiredBlockKind: entry.required_block_kind || null,
+    requiredContractFields: entry.required_contract_fields || [],
+    hasRepoGuardYamlBlock: false,
+    hasRepoGuardJsonBlock: false,
+    contractBlocks: [],
+    contractFieldNames: [],
+    headings: [],
+    codeBlocks: [],
   };
 }
 
@@ -479,6 +506,9 @@ function collectDocFacts(entry, content) {
       codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
       hasCodeBlocks: markdown.codeBlocks.length > 0,
       mentions: (entry.must_mention || []).map((term) => mentionFact(content, term)),
+      fileReferences: (entry.must_reference_files || []).map((term) => mentionFact(content, term)),
+      profileMentions: (entry.must_mention_profiles || []).map((term) => mentionFact(content, term)),
+      contractFieldMentions: (entry.must_mention_contract_fields || []).map((term) => mentionFact(content, term)),
     },
     errors: markdown.errors,
   };
@@ -574,6 +604,15 @@ function withErrorContext(section, entry, message) {
   };
 }
 
+function isMissingRepositoryFileError(error, entry) {
+  const message = String(error?.message || "");
+  return error?.code === "ENOENT" ||
+    message.includes("ENOENT") ||
+    message.includes("no such file or directory") ||
+    message === `cannot read ${entry.path}` ||
+    message.includes(`missing fixture ${entry.path}`);
+}
+
 export function extractIntegration(policy, options = {}) {
   const integration = policy.integration;
   const result = {
@@ -610,7 +649,11 @@ export function extractIntegration(policy, options = {}) {
         withErrorContext("templates", entry, error.message)
       ));
     } catch (e) {
-      result.errors.push(withErrorContext("templates", entry, e.message));
+      if (entry.optional === true && isMissingRepositoryFileError(e, entry)) {
+        result.templates.push(missingOptionalTemplateFact(entry));
+      } else {
+        result.errors.push(withErrorContext("templates", entry, e.message));
+      }
     }
   }
 

--- a/src/integration-validator.mjs
+++ b/src/integration-validator.mjs
@@ -445,22 +445,46 @@ function templateDiagnostics(integration) {
   const details = [];
 
   for (const template of integration.templates) {
-    if (!template.requiresContractBlock) continue;
-    if (template.hasRepoGuardYamlBlock || template.hasRepoGuardJsonBlock) continue;
-    details.push(`${template.path}: ${template.id} requires a repo-guard contract block`);
+    if (template.present === false && template.optional) continue;
+
+    const contractBlocks = template.contractBlocks || [];
+    if (template.requiredBlockKind) {
+      const hasRequiredKind = contractBlocks.some((block) => block.format === template.requiredBlockKind);
+      if (!hasRequiredKind) {
+        details.push(`${template.path}: ${template.id} requires a ${template.requiredBlockKind} fenced contract block`);
+      }
+    } else if (template.requiresContractBlock && !template.hasRepoGuardYamlBlock && !template.hasRepoGuardJsonBlock) {
+      details.push(`${template.path}: ${template.id} requires a repo-guard contract block`);
+    }
+
+    const fieldSourceBlocks = template.requiredBlockKind
+      ? contractBlocks.filter((block) => block.format === template.requiredBlockKind)
+      : contractBlocks;
+    const fields = new Set(fieldSourceBlocks.flatMap((block) => block.fieldPaths || []));
+    for (const field of template.requiredContractFields || []) {
+      if (fields.has(field)) continue;
+      details.push(`${template.path}: ${template.id} contract block missing required field "${field}"`);
+    }
   }
 
   return details;
+}
+
+function reportMissingMentions(details, doc, facts, label) {
+  for (const mention of facts || []) {
+    if (mention.present) continue;
+    details.push(`${doc.path}: missing required ${label} "${mention.term}"`);
+  }
 }
 
 function docDiagnostics(integration) {
   const details = [];
 
   for (const doc of integration.docs) {
-    for (const mention of doc.mentions) {
-      if (mention.present) continue;
-      details.push(`${doc.path}: missing required mention "${mention.term}"`);
-    }
+    reportMissingMentions(details, doc, doc.mentions, "mention");
+    reportMissingMentions(details, doc, doc.fileReferences, "file reference");
+    reportMissingMentions(details, doc, doc.profileMentions, "profile mention");
+    reportMissingMentions(details, doc, doc.contractFieldMentions, "contract field mention");
   }
 
   return details;

--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -265,34 +265,69 @@ const integrationSectionRules = {
   workflows: {
     requiredStrings: ["id", "kind", "path", "role"],
     requiredBooleans: [],
+    optionalBooleans: [],
     requiredStringArrays: [],
     optionalStringArrays: ["profiles"],
+    profileReferenceArrays: new Set(["profiles"]),
     allowedFields: new Set(["id", "kind", "path", "role", "expect", "profiles"]),
     kinds: new Set(["github_actions"]),
     roles: new Set(["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"]),
   },
   templates: {
     requiredStrings: ["id", "kind", "path"],
+    optionalStrings: ["required_block_kind"],
     requiredBooleans: ["requires_contract_block"],
+    optionalBooleans: ["optional"],
     requiredStringArrays: [],
-    optionalStringArrays: ["profiles"],
-    allowedFields: new Set(["id", "kind", "path", "requires_contract_block", "profiles"]),
+    optionalStringArrays: ["profiles", "required_contract_fields"],
+    profileReferenceArrays: new Set(["profiles"]),
+    allowedFields: new Set([
+      "id",
+      "kind",
+      "path",
+      "requires_contract_block",
+      "optional",
+      "required_block_kind",
+      "required_contract_fields",
+      "profiles",
+    ]),
     kinds: new Set(["github_issue_form", "markdown"]),
+    stringEnums: {
+      required_block_kind: new Set(["repo-guard-json", "repo-guard-yaml"]),
+    },
   },
   docs: {
     requiredStrings: ["id", "path"],
     optionalStrings: ["kind"],
     requiredBooleans: [],
+    optionalBooleans: [],
     requiredStringArrays: ["must_mention"],
-    optionalStringArrays: ["profiles"],
-    allowedFields: new Set(["id", "kind", "path", "must_mention", "profiles"]),
+    optionalStringArrays: [
+      "profiles",
+      "must_reference_files",
+      "must_mention_profiles",
+      "must_mention_contract_fields",
+    ],
+    profileReferenceArrays: new Set(["profiles", "must_mention_profiles"]),
+    allowedFields: new Set([
+      "id",
+      "kind",
+      "path",
+      "must_mention",
+      "must_reference_files",
+      "must_mention_profiles",
+      "must_mention_contract_fields",
+      "profiles",
+    ]),
     kinds: new Set(["markdown"]),
   },
   profiles: {
     requiredStrings: ["id", "doc_path"],
     requiredBooleans: [],
+    optionalBooleans: [],
     requiredStringArrays: [],
     optionalStringArrays: [],
+    profileReferenceArrays: new Set(),
     allowedFields: new Set(["id", "doc_path"]),
   },
 };
@@ -363,14 +398,16 @@ function validateIntegrationString(errors, section, index, entry, field, { requi
   return true;
 }
 
-function validateIntegrationBoolean(errors, section, index, entry, field) {
+function validateIntegrationBoolean(errors, section, index, entry, field, { required = true } = {}) {
   if (!Object.hasOwn(entry, field)) {
-    errors.push(compileIntegrationError(
-      section,
-      index,
-      field,
-      `integration.${section}[${index}].${field} is required`
-    ));
+    if (required) {
+      errors.push(compileIntegrationError(
+        section,
+        index,
+        field,
+        `integration.${section}[${index}].${field} is required`
+      ));
+    }
     return false;
   }
 
@@ -734,14 +771,25 @@ export function compileIntegrationPolicy(policy) {
         validateIntegrationBoolean(errors, section, index, entry, field);
       }
 
+      for (const field of rules.optionalBooleans || []) {
+        validateIntegrationBoolean(errors, section, index, entry, field, { required: false });
+      }
+
       for (const field of rules.requiredStringArrays || []) {
-        validateIntegrationStringArray(errors, section, index, entry, field);
+        const references = validateIntegrationStringArray(errors, section, index, entry, field);
+        if (rules.profileReferenceArrays?.has(field)) {
+          for (const profileId of references) {
+            profileReferences.push({ section, index, field, profileId });
+          }
+        }
       }
 
       for (const field of rules.optionalStringArrays || []) {
         const references = validateIntegrationStringArray(errors, section, index, entry, field, { required: false });
-        for (const profileId of references) {
-          profileReferences.push({ section, index, field, profileId });
+        if (rules.profileReferenceArrays?.has(field)) {
+          for (const profileId of references) {
+            profileReferences.push({ section, index, field, profileId });
+          }
         }
       }
 
@@ -762,6 +810,17 @@ export function compileIntegrationPolicy(policy) {
           "role",
           `integration.${section}[${index}].role must be one of ${formatAllowed(rules.roles)}`,
           { value: entry.role }
+        ));
+      }
+
+      for (const [field, allowedValues] of Object.entries(rules.stringEnums || {})) {
+        if (!hasNonEmptyString(entry, field) || allowedValues.has(entry[field])) continue;
+        errors.push(compileIntegrationError(
+          section,
+          index,
+          field,
+          `integration.${section}[${index}].${field} must be one of ${formatAllowed(allowedValues)}`,
+          { value: entry[field] }
         ));
       }
 

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -373,6 +373,9 @@ describe("integration policy compilation", () => {
             kind: "markdown",
             path: ".github/PULL_REQUEST_TEMPLATE.md",
             requires_contract_block: true,
+            optional: true,
+            required_block_kind: "repo-guard-yaml",
+            required_contract_fields: ["change_type", "scope", "anchors.affects"],
             profiles: ["requirements-strict"],
           },
         ],
@@ -382,6 +385,9 @@ describe("integration policy compilation", () => {
             kind: "markdown",
             path: "README.md",
             must_mention: ["repo-guard"],
+            must_reference_files: ["repo-policy.json"],
+            must_mention_profiles: ["requirements-strict"],
+            must_mention_contract_fields: ["anchors.affects"],
             profiles: ["requirements-strict"],
           },
         ],
@@ -557,6 +563,43 @@ describe("integration policy compilation", () => {
     assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.token_env must contain at least one")));
     assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.summary must be a boolean")));
     assert.ok(errors.some((e) => e.message.includes("integration.workflows[0].expect.disallow[1] must be one of")));
+  });
+
+  it("rejects malformed generalized template and doc integration rules", () => {
+    const errors = compileIntegrationPolicy({
+      integration: {
+        templates: [
+          {
+            id: "pull-request-template",
+            kind: "markdown",
+            path: ".github/PULL_REQUEST_TEMPLATE.md",
+            requires_contract_block: true,
+            optional: "yes",
+            required_block_kind: "repo-guard-xml",
+            required_contract_fields: ["change_type", ""],
+          },
+        ],
+        docs: [
+          {
+            id: "readme",
+            kind: "markdown",
+            path: "README.md",
+            must_mention: ["repo-guard"],
+            must_reference_files: [],
+            must_mention_profiles: ["missing-profile"],
+            must_mention_contract_fields: [""],
+          },
+        ],
+        profiles: [],
+      },
+    });
+
+    assert.ok(errors.some((e) => e.message.includes("integration.templates[0].optional must be a boolean")));
+    assert.ok(errors.some((e) => e.message.includes("integration.templates[0].required_block_kind must be one of")));
+    assert.ok(errors.some((e) => e.message.includes("integration.templates[0].required_contract_fields[1] must be a non-empty string")));
+    assert.ok(errors.some((e) => e.message.includes("integration.docs[0].must_reference_files must contain at least one")));
+    assert.ok(errors.some((e) => e.message.includes("integration.docs[0].must_mention_contract_fields[0] must be a non-empty string")));
+    assert.ok(errors.some((e) => e.message.includes("missing-profile")));
   });
 
   it("rejects profile references that do not resolve to integration.profiles ids", () => {

--- a/tests/test-integration-diagnostics.mjs
+++ b/tests/test-integration-diagnostics.mjs
@@ -101,12 +101,17 @@ function basePolicy(overrides = {}) {
           kind: "markdown",
           path: ".github/PULL_REQUEST_TEMPLATE.md",
           requires_contract_block: true,
+          required_block_kind: "repo-guard-yaml",
+          required_contract_fields: ["change_type", "scope"],
         },
         {
           id: "change-contract-issue-form",
           kind: "github_issue_form",
           path: ".github/ISSUE_TEMPLATE/change-contract.yml",
           requires_contract_block: true,
+          optional: true,
+          required_block_kind: "repo-guard-yaml",
+          required_contract_fields: ["change_type", "scope"],
         },
       ],
       docs: [
@@ -115,6 +120,9 @@ function basePolicy(overrides = {}) {
           kind: "markdown",
           path: "README.md",
           must_mention: ["repo-guard", "contract", "integration"],
+          must_reference_files: ["repo-policy.json", ".github/PULL_REQUEST_TEMPLATE.md"],
+          must_mention_profiles: ["self-hosting"],
+          must_mention_contract_fields: ["change_type", "scope"],
           profiles: ["self-hosting"],
         },
       ],
@@ -202,6 +210,8 @@ function makeRepo() {
     "# Test Repo",
     "",
     "This repository documents repo-guard contract integration for self-hosting.",
+    "The repo-policy.json file declares the .github/PULL_REQUEST_TEMPLATE.md contract wiring.",
+    "Required contract fields include change_type and scope.",
     "Profile id: self-hosting",
     "",
   ].join("\n"));
@@ -269,7 +279,28 @@ console.log("\n--- validate-integration --format json emits normalized integrati
     parsed?.integration?.workflows?.[0]?.stepInputs?.find((fact) => fact.uses === "netkeep80/repo-guard@v1.2.3")?.inputs,
     { enforcement: "blocking", mode: "check-pr" });
   expect("template diagnostics pass", parsed?.ruleResults?.some((rule) => rule.rule === "integration-templates" && rule.ok), true);
+  expect("doc diagnostics pass", parsed?.ruleResults?.some((rule) => rule.rule === "integration-docs" && rule.ok), true);
   expect("stats include declared templates", parsed?.diagnostics?.declared?.templates, 2);
+
+  rmSync(dir, { recursive: true });
+}
+
+console.log("\n--- optional issue-template fallback may be absent ---");
+{
+  const dir = makeRepo();
+  rmSync(join(dir, ".github", "ISSUE_TEMPLATE", "change-contract.yml"));
+  const result = runGuard([
+    "--repo-root", dir,
+    "validate-integration",
+    "--format", "json",
+  ]);
+  const parsed = JSON.parse(result.stdout);
+
+  expect("missing optional issue template exits 0", result.code, 0);
+  expect("optional template fact is still emitted",
+    parsed.integration.templates.find((template) => template.id === "change-contract-issue-form")?.present,
+    false);
+  expect("optional template does not create artifact errors", parsed.diagnostics.artifactErrors, []);
 
   rmSync(dir, { recursive: true });
 }
@@ -310,8 +341,11 @@ console.log("\n--- validate-integration --format summary reports CI-readable dia
   expectIncludes("manual clone diagnostic appears", result.output, "must not clone repo-guard manually");
   expectIncludes("direct temp CLI diagnostic appears", result.output, "must not run repo-guard directly from a temporary clone");
   expectIncludes("summary diagnostic appears", result.output, "must publish to GITHUB_STEP_SUMMARY");
-  expectIncludes("template diagnostic appears", result.output, "requires a repo-guard contract block");
+  expectIncludes("template diagnostic appears", result.output, "requires a repo-guard-yaml fenced contract block");
   expectIncludes("doc diagnostic appears", result.output, "missing required mention");
+  expectIncludes("doc file reference diagnostic appears", result.output, "missing required file reference");
+  expectIncludes("doc profile mention diagnostic appears", result.output, "missing required profile mention");
+  expectIncludes("doc contract field diagnostic appears", result.output, "missing required contract field mention");
 
   rmSync(dir, { recursive: true });
 }

--- a/tests/test-integration-extractors.mjs
+++ b/tests/test-integration-extractors.mjs
@@ -53,12 +53,17 @@ function makePolicy(overrides = {}) {
           kind: "markdown",
           path: ".github/PULL_REQUEST_TEMPLATE.md",
           requires_contract_block: true,
+          required_block_kind: "repo-guard-yaml",
+          required_contract_fields: ["change_type", "scope", "anchors.affects"],
         },
         {
           id: "change-contract-issue-form",
           kind: "github_issue_form",
           path: ".github/ISSUE_TEMPLATE/change-contract.yml",
           requires_contract_block: true,
+          optional: true,
+          required_block_kind: "repo-guard-yaml",
+          required_contract_fields: ["change_type", "expected_effects"],
         },
       ],
       docs: [
@@ -66,6 +71,9 @@ function makePolicy(overrides = {}) {
           id: "readme",
           path: "README.md",
           must_mention: ["repo-guard", "contract", "integration", "anchors.affects"],
+          must_reference_files: ["repo-policy.json"],
+          must_mention_profiles: ["self-hosting"],
+          must_mention_contract_fields: ["anchors.affects"],
         },
       ],
       profiles: [
@@ -155,6 +163,8 @@ const files = {
     "# Repo Guard",
     "",
     "Uses repo-guard contract and integration policy.",
+    "See repo-policy.json for integration configuration.",
+    "Documented contract field: anchors.affects.",
     "",
     "```bash",
     "repo-guard check-pr",
@@ -221,6 +231,13 @@ console.log("\n--- integration extractor builds normalized workflow, template, d
 
   const prTemplate = extraction.templates.find((template) => template.id === "pull-request-template");
   const issueTemplate = extraction.templates.find((template) => template.id === "change-contract-issue-form");
+  expect("template exposes configured block kind requirement", prTemplate?.requiredBlockKind, "repo-guard-yaml");
+  expect("template exposes configured contract field requirements", prTemplate?.requiredContractFields, [
+    "change_type",
+    "scope",
+    "anchors.affects",
+  ]);
+  expect("issue template exposes optional fallback metadata", issueTemplate?.optional, true);
   expect("markdown template detects repo-guard-yaml block", prTemplate?.hasRepoGuardYamlBlock, true);
   expect("markdown template extracts nested contract field names", prTemplate?.contractFieldNames, [
     "anchors",
@@ -235,11 +252,20 @@ console.log("\n--- integration extractor builds normalized workflow, template, d
   const doc = extraction.docs[0];
   expect("docs expose headings", doc.headings, [{ level: 1, text: "Repo Guard", line: 1 }]);
   expect("docs expose code block presence", doc.codeBlocks, [
-    { language: "bash", infoString: "bash", startLine: 5, endLine: 7 },
+    { language: "bash", infoString: "bash", startLine: 7, endLine: 9 },
   ]);
   expect("docs expose text mention facts",
     doc.mentions.map((mention) => `${mention.term}:${mention.present}:${mention.count}`),
-    ["repo-guard:true:2", "contract:true:1", "integration:true:1", "anchors.affects:false:0"]);
+    ["repo-guard:true:2", "contract:true:2", "integration:true:2", "anchors.affects:true:1"]);
+  expect("docs expose file reference facts",
+    doc.fileReferences.map((mention) => `${mention.term}:${mention.present}:${mention.count}`),
+    ["repo-policy.json:true:1"]);
+  expect("docs expose profile mention facts",
+    doc.profileMentions.map((mention) => `${mention.term}:${mention.present}:${mention.count}`),
+    ["self-hosting:true:2"]);
+  expect("docs expose contract field mention facts",
+    doc.contractFieldMentions.map((mention) => `${mention.term}:${mention.present}:${mention.count}`),
+    ["anchors.affects:true:1"]);
 
   const profile = extraction.profiles[0];
   expect("profile docs expose configured profile identifiers",

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -122,6 +122,9 @@ const policyWithIntegration = {
         kind: "markdown",
         path: ".github/PULL_REQUEST_TEMPLATE.md",
         requires_contract_block: true,
+        optional: true,
+        required_block_kind: "repo-guard-yaml",
+        required_contract_fields: ["change_type", "scope", "anchors.affects"],
         profiles: ["requirements-strict"],
       },
     ],
@@ -131,6 +134,9 @@ const policyWithIntegration = {
         kind: "markdown",
         path: "README.md",
         must_mention: ["repo-guard", "anchors.affects"],
+        must_reference_files: ["repo-policy.json", ".github/PULL_REQUEST_TEMPLATE.md"],
+        must_mention_profiles: ["requirements-strict"],
+        must_mention_contract_fields: ["anchors.affects"],
         profiles: ["requirements-strict"],
       },
     ],
@@ -167,6 +173,35 @@ const invalidIntegrationExpectationPolicy = {
   },
 };
 expect("policy with malformed integration workflow expectations fails schema", validatePolicy(invalidIntegrationExpectationPolicy), false);
+
+const invalidTemplateDocRulePolicy = {
+  ...validPolicy,
+  integration: {
+    templates: [
+      {
+        id: "pull-request-template",
+        kind: "markdown",
+        path: ".github/PULL_REQUEST_TEMPLATE.md",
+        requires_contract_block: true,
+        optional: "yes",
+        required_block_kind: "repo-guard-xml",
+        required_contract_fields: [],
+      },
+    ],
+    docs: [
+      {
+        id: "readme",
+        kind: "markdown",
+        path: "README.md",
+        must_mention: ["repo-guard"],
+        must_reference_files: [],
+        must_mention_profiles: [],
+        must_mention_contract_fields: [],
+      },
+    ],
+  },
+};
+expect("policy with malformed template and doc integration rules fails schema", validatePolicy(invalidTemplateDocRulePolicy), false);
 
 const invalidIntegrationPolicy = {
   ...validPolicy,


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#71.

Adds generalized declarative integration checks for downstream PR templates, optional issue-template fallback templates, and contributor docs. Policies can now require a specific repo-guard fenced block kind, required contract fields inside extracted template examples, required doc file references, required profile mentions, and required contract field mentions.

## What Changed

- Extends `integration.templates[]` with `optional`, `required_block_kind`, and `required_contract_fields` schema/compiler support.
- Extends template extraction with presence metadata and configured template expectations, including missing optional template facts.
- Extends `integration.docs[]` with `must_reference_files`, `must_mention_profiles`, and `must_mention_contract_fields` facts and diagnostics.
- Keeps template and doc failures separated under `integration-templates` and `integration-docs` diagnostics.
- Updates this repository self-policy and README to exercise the stricter integration rules.
- Removes the bootstrap `.gitkeep` placeholder now that the branch has real changes.

## Reproduction

Before this change, policies that declared generalized template/doc expectations failed schema and integration compilation as unsupported fields, and `validate-integration` only checked generic contract block presence plus `must_mention` doc terms.

The new tests reproduce those gaps by declaring required block kind, required contract fields, optional issue-template fallback behavior, file references, profile mentions, and contract-field mentions.

## Change Contract

```repo-guard-yaml
change_type: feature
scope:
  - src/extractors/integration.mjs
  - src/integration-validator.mjs
  - src/policy-compiler.mjs
  - schemas/repo-policy.schema.json
  - repo-policy.json
  - README.md
  - tests/
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 500
must_touch:
  - src/extractors/integration.mjs
  - src/integration-validator.mjs
  - src/policy-compiler.mjs
  - schemas/repo-policy.schema.json
  - tests/test-integration-diagnostics.mjs
  - tests/test-integration-extractors.mjs
must_not_touch: []
expected_effects:
  - Downstream policies can require specific repo-guard template block kinds and contract fields.
  - Optional issue-template fallback files do not fail validation when absent.
  - Contributor docs can be checked for required file, profile, and contract field references.
  - Template and doc failures remain separate structured diagnostics.
```

## Verification

- `npm run test:integration`
- `npm run test:integration-diagnostics`
- `npm run test:schemas`
- `npm run test:hardening`
- `node src/repo-guard.mjs validate-integration --format summary`
- `npm test`
- `npm run validate`
- `git diff --check`
- `npm pack --dry-run`
- `node src/repo-guard.mjs check-diff --enforcement blocking`