### PR TITLE
init: scaffold pinned repo-guard action ref

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T16:56:13.224Z for PR creation at branch issue-81-e94a683b91b0 for issue https://github.com/netkeep80/repo-guard/issues/81

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T16:56:13.224Z for PR creation at branch issue-81-e94a683b91b0 for issue https://github.com/netkeep80/repo-guard/issues/81

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ repo-guard init --preset application --mode advisory
 | `.github/PULL_REQUEST_TEMPLATE.md` | Шаблон PR с контрактом изменения |
 | `.github/ISSUE_TEMPLATE/change-contract.yml` | Шаблон issue с контрактом изменения |
 
+Сгенерированный workflow pin-ит Action на release tag установленной версии
+`repo-guard` (`netkeep80/repo-guard@v<version>`), а не на ветку `main`.
+При обновлении инструмента меняйте этот ref на новый release tag осознанно.
+
 Пресеты:
 
 | Пресет | Для чего | Базовые ограничения |
@@ -198,7 +202,8 @@ jobs:
         run: echo "### repo-guard" >> "$GITHUB_STEP_SUMMARY"
 ```
 
-Используйте тег релиза вместо `vX.Y.Z` для воспроизводимых запусков. При
+Используйте тег релиза вместо `vX.Y.Z` для воспроизводимых запусков.
+`repo-guard init` заполняет этот ref тегом версии установленного пакета. При
 локальной самопроверке внутри этого репозитория рабочий процесс может
 использовать `uses: ./`.
 

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -1,6 +1,8 @@
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve, relative, dirname } from "node:path";
 import { normalizeEnforcementMode } from "./enforcement.mjs";
+
+const ACTION_USES_TARGET = "netkeep80/repo-guard";
 
 const PRESETS = {
   application: {
@@ -62,7 +64,16 @@ function buildPolicy(preset, enforcementMode) {
   };
 }
 
-function buildWorkflow(enforcementMode) {
+function defaultActionRef(packageRoot) {
+  const packagePath = resolve(packageRoot, "package.json");
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+  if (!packageJson.version) {
+    throw new Error(`Cannot determine repo-guard package version from ${packagePath}`);
+  }
+  return `v${packageJson.version}`;
+}
+
+function buildWorkflow(enforcementMode, actionRef) {
   return `name: repo-guard policy check
 
 on:
@@ -79,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Enforce repository policy
-        uses: netkeep80/repo-guard@main
+        uses: ${ACTION_USES_TARGET}@${actionRef}
         with:
           mode: check-pr
           enforcement: ${enforcementMode}
@@ -217,7 +228,8 @@ export function runInit(roots, args) {
   writeIfAbsent(policyPath, policyContent, created, skipped);
 
   const workflowPath = resolve(repoRoot, ".github/workflows/repo-guard.yml");
-  writeIfAbsent(workflowPath, buildWorkflow(enforcementMode), created, skipped);
+  const actionRef = defaultActionRef(roots.packageRoot);
+  writeIfAbsent(workflowPath, buildWorkflow(enforcementMode, actionRef), created, skipped);
 
   const prTemplatePath = resolve(repoRoot, ".github/PULL_REQUEST_TEMPLATE.md");
   writeIfAbsent(prTemplatePath, buildPRTemplate(), created, skipped);

--- a/tests/test-init.mjs
+++ b/tests/test-init.mjs
@@ -27,6 +27,15 @@ function expectIncludes(label, str, substring) {
   }
 }
 
+function expectNotIncludes(label, str, substring) {
+  const passed = !str.includes(substring);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected not to include: ${JSON.stringify(substring)}`);
+  }
+}
+
 function makeTmpDir() {
   return mkdtempSync(join(tmpdir(), "repo-guard-init-"));
 }
@@ -37,6 +46,8 @@ function runInit(args = "", cwd) {
 }
 
 const policySchema = JSON.parse(readFileSync(resolve(projectRoot, "schemas/repo-policy.schema.json"), "utf-8"));
+const packageJson = JSON.parse(readFileSync(resolve(projectRoot, "package.json"), "utf-8"));
+const defaultActionRef = `v${packageJson.version}`;
 const ajv = new Ajv({ allErrors: true });
 const validatePolicy = ajv.compile(policySchema);
 
@@ -145,7 +156,8 @@ console.log("\n--- workflow content ---");
   const dir = makeTmpDir();
   runInit(`--repo-root ${dir} init`);
   const workflow = readFileSync(join(dir, ".github/workflows/repo-guard.yml"), "utf-8");
-  expectIncludes("workflow uses repo-guard action", workflow, "netkeep80/repo-guard@main");
+  expectIncludes("workflow uses pinned repo-guard action", workflow, `netkeep80/repo-guard@${defaultActionRef}`);
+  expectNotIncludes("workflow does not use moving main ref", workflow, "netkeep80/repo-guard@main");
   expectIncludes("workflow uses check-pr", workflow, "mode: check-pr");
   expectIncludes("workflow uses blocking enforcement", workflow, "enforcement: blocking");
   expectIncludes("workflow has fetch-depth 0", workflow, "fetch-depth: 0");


### PR DESCRIPTION
Fixes netkeep80/repo-guard#81

## Summary
- Change `repo-guard init` so the generated workflow uses `netkeep80/repo-guard@v<package version>` instead of `@main`.
- Add init coverage that fails if the scaffold emits the moving `@main` ref.
- Align README quick-start/action guidance with the generated pinned release-tag behavior.

## Reproduction
Before this change, running `repo-guard init` generated `.github/workflows/repo-guard.yml` with:

```yaml
uses: netkeep80/repo-guard@main
```

The updated test checks the generated workflow for the package-version tag and rejects `netkeep80/repo-guard@main`.

## Tests
- `node tests/test-init.mjs`
- `node src/repo-guard.mjs check-diff --format summary`
- `npm test`

```repo-guard-yaml
change_type: fix
scope:
  - src/init.mjs
  - tests/test-init.mjs
  - README.md
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 100
anchors:
  affects:
    - RG-INIT-ACTION-REF
must_touch:
  - src/init.mjs
  - tests/test-init.mjs
  - README.md
must_not_touch:
  - schemas/**
  - action.yml
expected_effects:
  - repo-guard init scaffolds a reproducible release-tagged GitHub Action ref instead of a moving branch.
```
