### PR TITLE
policy: add size rules for files and directories

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T17:53:54.759Z for PR creation at branch issue-89-dcea917e0d3b for issue https://github.com/netkeep80/repo-guard/issues/89

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T17:53:54.759Z for PR creation at branch issue-89-dcea917e0d3b for issue https://github.com/netkeep80/repo-guard/issues/89

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ jobs:
 | `diff_rules.max_new_docs` | Ограничивает новые `.md` вне `canonical_docs` |
 | `diff_rules.max_new_files` | Ограничивает общее число новых файлов |
 | `diff_rules.max_net_added_lines` | Ограничивает чистое число добавленных строк |
+| `size_rules` | Ограничивает абсолютный размер файлов или subtree в строках/байтах |
 | `content_rules` | Ищет запрещенные регулярные выражения только в добавленных строках |
 | `cochange_rules` | Требует `must_change_any`, если сработал `if_changed` |
 | `surfaces` | Описывает именованные области репозитория по glob |
@@ -294,6 +295,52 @@ jobs:
 областям, файл без подходящей области по умолчанию считается нарушением. Для
 `surface_matrix` можно явно разрешить частичное покрытие через
 `allow_unclassified_files: true`.
+
+## Size Rules
+
+`size_rules` задает first-class лимиты на абсолютный размер файлов и каталогов.
+Правило может считать строки (`lines`) или байты (`bytes`), проверять каждый
+файл (`scope: "file"`) или aggregate subtree (`scope: "directory"`).
+
+```json
+{
+  "size_rules": [
+    {
+      "id": "max-source-file-lines",
+      "scope": "file",
+      "metric": "lines",
+      "glob": "src/**/*.mjs",
+      "max": 500
+    },
+    {
+      "id": "max-source-subtree-bytes",
+      "scope": "directory",
+      "metric": "bytes",
+      "glob": "src/**",
+      "max": 262144,
+      "count": "changed_only"
+    }
+  ]
+}
+```
+
+По умолчанию `count` равно `all_tracked`: правило проверяет все tracked files,
+которые подходят под `glob`. Для `count: "changed_only"` file-правило проверяет
+только измененные файлы, а directory-правило проверяет subtree только если в нем
+есть измененный файл. Размер directory считается по всем tracked files внутри
+subtree, чтобы лимит оставался ограничением абсолютной поверхности.
+
+Дополнительные поля:
+
+| Поле | Поведение |
+| --- | --- |
+| `ignore` | Исключает matching paths из конкретного size rule |
+| `level` | `blocking` по умолчанию; `advisory` сообщает warning без fail |
+| `applies_to_change_types` | Применяет правило только к указанным `change_type` |
+| `applies_to_change_classes` | Применяет правило только к указанным `change_class` |
+
+Нарушения включают rule id, scope, path, metric, measured size и max. В JSON
+результате они лежат в `violations[].size_violations`.
 
 ## Профили политики
 
@@ -609,6 +656,7 @@ expected_effects:
 | `max-new-files` | Лимит новых файлов |
 | `max-net-added-lines` | Лимит чистого числа добавленных строк |
 | `surface-debt` | Заявленный временный рост области |
+| `size-rules` | Лимиты абсолютного размера файлов и subtree |
 | `registry-rules` | Согласованность канонических реестров |
 | `advisory-text-rules` | Эвристические предупреждения о дублировании Markdown |
 | `anchor-extraction` | Ошибки regex/json-извлекателей якорей |

--- a/examples/size-rules-policy.json
+++ b/examples/size-rules-policy.json
@@ -1,0 +1,45 @@
+{
+  "policy_format_version": "0.3.0",
+  "repository_kind": "library",
+  "enforcement": {
+    "mode": "blocking"
+  },
+  "paths": {
+    "forbidden": [],
+    "canonical_docs": ["README.md"],
+    "governance_paths": ["repo-policy.json"],
+    "operational_paths": [".gitkeep"]
+  },
+  "diff_rules": {
+    "max_new_docs": 3,
+    "max_new_files": 20,
+    "max_net_added_lines": 1000
+  },
+  "size_rules": [
+    {
+      "id": "max-public-header-lines",
+      "scope": "file",
+      "metric": "lines",
+      "glob": "include/**/*.h",
+      "max": 1500
+    },
+    {
+      "id": "max-source-module-bytes",
+      "scope": "file",
+      "metric": "bytes",
+      "glob": "src/**/*.mjs",
+      "max": 65536,
+      "count": "changed_only"
+    },
+    {
+      "id": "max-core-subtree-lines",
+      "scope": "directory",
+      "metric": "lines",
+      "glob": "src/core/**",
+      "max": 120000,
+      "ignore": ["src/core/generated/**"]
+    }
+  ],
+  "content_rules": [],
+  "cochange_rules": []
+}

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -123,6 +123,11 @@
         }
       }
     },
+    "size_rules": {
+      "type": "array",
+      "description": "Absolute size constraints for files or directory subtrees, measured in lines or bytes.",
+      "items": { "$ref": "#/definitions/size_rule" }
+    },
     "surfaces": {
       "type": "object",
       "description": "Named repository surfaces mapped to one or more path globs. A changed file can match multiple surfaces.",
@@ -428,6 +433,40 @@
           "$ref": "#/definitions/non_empty_string_array",
           "description": "Evidence surfaces required for anchors.verifies declarations."
         }
+      }
+    },
+    "size_rule": {
+      "type": "object",
+      "required": ["id", "scope", "metric", "glob", "max"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "$ref": "#/definitions/non_empty_string" },
+        "scope": {
+          "type": "string",
+          "enum": ["file", "directory"]
+        },
+        "metric": {
+          "type": "string",
+          "enum": ["lines", "bytes"]
+        },
+        "glob": { "$ref": "#/definitions/non_empty_string" },
+        "max": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "count": {
+          "type": "string",
+          "enum": ["all_tracked", "changed_only"],
+          "default": "all_tracked"
+        },
+        "level": {
+          "type": "string",
+          "enum": ["blocking", "advisory"],
+          "default": "blocking"
+        },
+        "ignore": { "$ref": "#/definitions/non_empty_string_array" },
+        "applies_to_change_types": { "$ref": "#/definitions/non_empty_string_array" },
+        "applies_to_change_classes": { "$ref": "#/definitions/non_empty_string_array" }
       }
     },
     "integration_workflow": {

--- a/src/checks/orchestrator.mjs
+++ b/src/checks/orchestrator.mjs
@@ -13,6 +13,7 @@ import {
   checkChangeTypeRules,
   checkRegistryRules,
   checkAdvisoryTextRules,
+  checkSizeRules,
 } from "../diff-checker.mjs";
 import { checkAnchorExtraction } from "../extractors/anchors.mjs";
 import { checkTraceRuleResult } from "./trace-rules.mjs";
@@ -43,6 +44,23 @@ export function runPolicyChecks(facts, reporter, options = {}) {
     budgets.max_net_added_lines ?? policy.diff_rules.max_net_added_lines
   ));
   reporter.report("surface-debt", checkSurfaceDebt(files, contract?.surface_debt));
+  const sizeRuleResult = checkSizeRules(files, policy.size_rules, {
+    repoRoot: facts.repositoryRoot,
+    trackedFiles: facts.trackedFiles,
+    readFile: facts.readFile,
+    ignorePatterns: policy.paths.operational_paths,
+    changeType: contract?.change_type,
+    changeClass: facts.declaredChangeClass,
+  });
+  reporter.report("size-rules", sizeRuleResult);
+  if (sizeRuleResult.advisory_violations.length > 0) {
+    reporter.report("size-rules-advisory", {
+      ok: false,
+      advisory: true,
+      size_violations: sizeRuleResult.advisory_violations,
+      details: sizeRuleResult.advisory_details,
+    });
+  }
   reporter.report("registry-rules", checkRegistryRules(policy.registry_rules, { repoRoot: facts.repositoryRoot }));
   reporter.report(
     "advisory-text-rules",

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -274,14 +274,14 @@ function readSizeRuleFile(path, options = {}) {
   return readFileSync(fullPath);
 }
 
-function countTextLines(content) {
+export function countTextLines(content) {
   if (content.length === 0) return 0;
   const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  const withoutTrailingNewline = normalized.endsWith("\n")
-    ? normalized.slice(0, -1)
-    : normalized;
-  if (withoutTrailingNewline.length === 0) return 0;
-  return withoutTrailingNewline.split("\n").length;
+  let lines = 1;
+  for (const char of normalized) {
+    if (char === "\n") lines++;
+  }
+  return normalized.endsWith("\n") ? lines - 1 : lines;
 }
 
 function measureSizeRuleFile(path, metric, options = {}) {

--- a/src/diff-checker.mjs
+++ b/src/diff-checker.mjs
@@ -1,5 +1,5 @@
 import { minimatch } from "minimatch";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 export function matchesAny(filePath, patterns) {
@@ -203,6 +203,205 @@ function uniqueSorted(values) {
 
 function formatList(values) {
   return values && values.length > 0 ? values.join(", ") : "(none)";
+}
+
+function normalizePathList(values) {
+  return uniqueSorted((values || []).map(normalizeRegistryEntry).filter(Boolean));
+}
+
+function changedPaths(files, options = {}) {
+  const includeDeleted = Boolean(options.includeDeleted);
+  return normalizePathList(
+    (files || [])
+      .filter((file) => includeDeleted || file.status !== "deleted")
+      .map((file) => file.path)
+  );
+}
+
+function allKnownPaths(files, options = {}) {
+  return normalizePathList([
+    ...(options.trackedFiles || options.allFiles || []),
+    ...changedPaths(files),
+  ]);
+}
+
+function ignoredBySizeRule(path, rule, options = {}) {
+  const ignored = [
+    ...(options.ignorePatterns || []),
+    ...(rule.ignore || []),
+  ];
+  return ignored.length > 0 && matchesAny(path, ignored);
+}
+
+function matchingSizeRulePaths(paths, rule, options = {}) {
+  const glob = rule.glob || "**";
+  return normalizePathList(paths).filter(
+    (path) =>
+      minimatch(path, glob, { dot: true }) &&
+      !ignoredBySizeRule(path, rule, options)
+  );
+}
+
+function sizeRuleApplies(rule, options = {}) {
+  const changeType = options.changeType || null;
+  const changeClass = options.changeClass || null;
+  if (
+    rule.applies_to_change_types &&
+    !rule.applies_to_change_types.includes(changeType)
+  ) {
+    return false;
+  }
+  if (
+    rule.applies_to_change_classes &&
+    !rule.applies_to_change_classes.includes(changeClass)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function readSizeRuleFile(path, options = {}) {
+  if (options.readFile) {
+    const content = options.readFile(path);
+    if (content === undefined || content === null) {
+      throw new Error(`cannot read ${path}`);
+    }
+    return Buffer.isBuffer(content) ? content : Buffer.from(String(content));
+  }
+
+  const fullPath = resolve(options.repoRoot || process.cwd(), path);
+  if (!existsSync(fullPath)) return null;
+  return readFileSync(fullPath);
+}
+
+function countTextLines(content) {
+  if (content.length === 0) return 0;
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const withoutTrailingNewline = normalized.endsWith("\n")
+    ? normalized.slice(0, -1)
+    : normalized;
+  if (withoutTrailingNewline.length === 0) return 0;
+  return withoutTrailingNewline.split("\n").length;
+}
+
+function measureSizeRuleFile(path, metric, options = {}) {
+  const content = readSizeRuleFile(path, options);
+  if (content === null) return { skipped: true, actual: 0 };
+  if (metric === "bytes") return { skipped: false, actual: content.length };
+  return { skipped: false, actual: countTextLines(content.toString("utf-8")) };
+}
+
+function directoryPathFromGlob(glob) {
+  const normalized = normalizeRegistryEntry(glob).replace(/\\/g, "/");
+  const parts = normalized.split("/").filter(Boolean);
+  const stableParts = [];
+  for (const part of parts) {
+    if (/[*?[\]{}()]/.test(part)) break;
+    stableParts.push(part);
+  }
+  return stableParts.length > 0 ? stableParts.join("/") : (normalized || ".");
+}
+
+function formatSizeViolation(violation) {
+  const unit = violation.metric;
+  return `[${violation.ruleId}] ${violation.path} has ${violation.actual} ${unit} (max ${violation.max})`;
+}
+
+export function checkSizeRules(files, rules = [], options = {}) {
+  if (!rules || rules.length === 0) {
+    return {
+      ok: true,
+      size_violations: [],
+      advisory_violations: [],
+      failed_rules: [],
+      details: [],
+    };
+  }
+
+  const blockingViolations = [];
+  const advisoryViolations = [];
+  const errors = [];
+  const allPaths = allKnownPaths(files, options);
+  const changedNonDeletedPaths = changedPaths(files);
+  const changedIncludingDeletedPaths = changedPaths(files, { includeDeleted: true });
+
+  for (const rule of rules) {
+    if (!sizeRuleApplies(rule, options)) continue;
+
+    const count = rule.count || "all_tracked";
+    const level = rule.level || "blocking";
+    const addViolation = (violation) => {
+      if (level === "advisory") advisoryViolations.push(violation);
+      else blockingViolations.push(violation);
+    };
+
+    try {
+      if (rule.scope === "file") {
+        const sourcePaths = count === "changed_only" ? changedNonDeletedPaths : allPaths;
+        const paths = matchingSizeRulePaths(sourcePaths, rule, options);
+        for (const path of paths) {
+          const measured = measureSizeRuleFile(path, rule.metric, options);
+          if (measured.skipped || measured.actual <= rule.max) continue;
+          addViolation({
+            ruleId: rule.id,
+            rule_id: rule.id,
+            scope: "file",
+            path,
+            metric: rule.metric,
+            actual: measured.actual,
+            max: rule.max,
+            count,
+            level,
+          });
+        }
+      } else if (rule.scope === "directory") {
+        if (
+          count === "changed_only" &&
+          matchingSizeRulePaths(changedIncludingDeletedPaths, rule, options).length === 0
+        ) {
+          continue;
+        }
+
+        const paths = matchingSizeRulePaths(allPaths, rule, options);
+        let actual = 0;
+        for (const path of paths) {
+          const measured = measureSizeRuleFile(path, rule.metric, options);
+          if (!measured.skipped) actual += measured.actual;
+        }
+        if (actual > rule.max) {
+          addViolation({
+            ruleId: rule.id,
+            rule_id: rule.id,
+            scope: "directory",
+            path: directoryPathFromGlob(rule.glob),
+            metric: rule.metric,
+            actual,
+            max: rule.max,
+            count,
+            level,
+            files: paths,
+          });
+        }
+      }
+    } catch (e) {
+      errors.push(`[${rule.id}] ${e.message}`);
+    }
+  }
+
+  const failedRules = uniqueSorted([
+    ...blockingViolations.map((violation) => violation.ruleId),
+    ...(errors.length > 0 ? ["read-errors"] : []),
+  ]);
+
+  return {
+    ok: blockingViolations.length === 0 && errors.length === 0,
+    size_violations: blockingViolations,
+    advisory_violations: advisoryViolations,
+    failed_rules: failedRules,
+    details: blockingViolations.map(formatSizeViolation),
+    advisory_details: advisoryViolations.map(formatSizeViolation),
+    errors,
+  };
 }
 
 function readPolicyFile(path, options) {

--- a/src/enforcement.mjs
+++ b/src/enforcement.mjs
@@ -128,6 +128,11 @@ function printCheckDetails(mode, check) {
   if (check.failed_rules) {
     write(`    failed_rules: ${formatList(check.failed_rules)}`);
   }
+  if (check.size_violations && (!check.details || check.details.length === 0)) {
+    for (const v of check.size_violations) {
+      write(`    [${v.ruleId}] ${v.path} has ${v.actual} ${v.metric} (max ${v.max})`);
+    }
+  }
   if (check.matches) {
     for (const match of check.matches) {
       const sections = match.duplicate_section_titles && match.duplicate_section_titles.length > 0
@@ -184,6 +189,9 @@ function detailFromCheck(check) {
   if (check.forbidden_surfaces) details.push(`forbidden_surfaces: ${formatList(check.forbidden_surfaces)}`);
   if (check.violating_surfaces) details.push(`violating_surfaces: ${formatList(check.violating_surfaces)}`);
   if (check.failed_rules) details.push(`failed_rules: ${formatList(check.failed_rules)}`);
+  if (check.size_violations && (!check.details || check.details.length === 0)) {
+    details.push(...check.size_violations.map((v) => `[${v.ruleId}] ${v.path} has ${v.actual} ${v.metric} (max ${v.max})`));
+  }
   if (check.matches) {
     details.push(...check.matches.map((match) => {
       const sections = match.duplicate_section_titles && match.duplicate_section_titles.length > 0
@@ -244,6 +252,7 @@ function violationFromCheck(name, check) {
   if (check.violating_surfaces) violation.violating_surfaces = check.violating_surfaces;
   if (check.files_by_surface) violation.files_by_surface = check.files_by_surface;
   if (check.failed_rules) violation.failed_rules = check.failed_rules;
+  if (check.size_violations) violation.size_violations = check.size_violations;
   if (check.results) violation.results = check.results;
   if (check.matches) violation.matches = check.matches;
   if (check.trace_rule) violation.trace_rule = check.trace_rule;

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -57,6 +57,7 @@ export function buildPolicyFacts({
     policy,
     contract,
     contractSource,
+    readFile,
     enforcementMode: enforcement.mode,
     enforcement,
     diff: {

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -18,6 +18,7 @@ import {
   checkRegistryRules,
   checkAdvisoryTextRules,
   checkSizeRules,
+  countTextLines,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -801,6 +802,11 @@ const cappedAdvisoryResult = checkAdvisoryTextRules(
 expect("14. advisory caps reported matches", cappedAdvisoryResult.matches.length, 1);
 
 // --- 15. size rules ---
+
+expect("15. line count empty content", countTextLines(""), 0);
+expect("15. line count single blank line", countTextLines("\n"), 1);
+expect("15. line count trailing newline", countTextLines("a\n"), 1);
+expect("15. line count two blank lines", countTextLines("\n\n"), 2);
 
 const sizeRuleFiles = new Map([
   ["src/small.mjs", "one\ntwo\n"],

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -17,6 +17,7 @@ import {
   checkChangeTypeRules,
   checkRegistryRules,
   checkAdvisoryTextRules,
+  checkSizeRules,
 } from "../src/diff-checker.mjs";
 
 let failures = 0;
@@ -798,6 +799,94 @@ const cappedAdvisoryResult = checkAdvisoryTextRules(
   }
 );
 expect("14. advisory caps reported matches", cappedAdvisoryResult.matches.length, 1);
+
+// --- 15. size rules ---
+
+const sizeRuleFiles = new Map([
+  ["src/small.mjs", "one\ntwo\n"],
+  ["src/large.mjs", "one\ntwo\nthree\n"],
+  ["src/bytes.bin", "abcdef"],
+  ["src/subtree/a.mjs", "a\nb\n"],
+  ["src/subtree/b.mjs", "c\n"],
+  ["docs/readme.md", "# Docs\n"],
+]);
+
+const sizeRuleOptions = {
+  trackedFiles: [...sizeRuleFiles.keys()],
+  readFile: (path) => sizeRuleFiles.get(path),
+};
+
+const passingFileSizeResult = checkSizeRules(
+  [],
+  [{ id: "max-small-lines", scope: "file", metric: "lines", glob: "src/small.mjs", max: 2 }],
+  sizeRuleOptions
+);
+expect("15. passing file line rule", passingFileSizeResult.ok, true);
+
+const failingFileSizeResult = checkSizeRules(
+  [],
+  [{ id: "max-large-lines", scope: "file", metric: "lines", glob: "src/large.mjs", max: 2 }],
+  sizeRuleOptions
+);
+expect("15. failing file line rule", failingFileSizeResult.ok, false);
+expect("15. file violation rule id", failingFileSizeResult.size_violations[0].ruleId, "max-large-lines");
+expect("15. file violation path", failingFileSizeResult.size_violations[0].path, "src/large.mjs");
+expect("15. file violation actual lines", failingFileSizeResult.size_violations[0].actual, 3);
+expect("15. file violation max", failingFileSizeResult.size_violations[0].max, 2);
+
+const passingDirectorySizeResult = checkSizeRules(
+  [],
+  [{ id: "max-subtree-lines", scope: "directory", metric: "lines", glob: "src/subtree/**", max: 3 }],
+  sizeRuleOptions
+);
+expect("15. passing directory line rule", passingDirectorySizeResult.ok, true);
+
+const failingDirectorySizeResult = checkSizeRules(
+  [],
+  [{ id: "max-subtree-bytes", scope: "directory", metric: "bytes", glob: "src/subtree/**", max: 5 }],
+  sizeRuleOptions
+);
+expect("15. failing directory byte rule", failingDirectorySizeResult.ok, false);
+expect("15. directory violation scope", failingDirectorySizeResult.size_violations[0].scope, "directory");
+expect("15. directory violation path", failingDirectorySizeResult.size_violations[0].path, "src/subtree");
+expect("15. directory violation metric", failingDirectorySizeResult.size_violations[0].metric, "bytes");
+
+const failingByteSizeResult = checkSizeRules(
+  [],
+  [{ id: "max-file-bytes", scope: "file", metric: "bytes", glob: "src/bytes.bin", max: 5 }],
+  sizeRuleOptions
+);
+expect("15. failing file byte rule", failingByteSizeResult.ok, false);
+expect("15. file byte violation actual", failingByteSizeResult.size_violations[0].actual, 6);
+
+const changedOnlySkippedResult = checkSizeRules(
+  [{ path: "docs/readme.md", addedLines: ["docs"], deletedLines: [], status: "modified" }],
+  [{ id: "changed-only-lines", scope: "file", metric: "lines", glob: "src/large.mjs", max: 2, count: "changed_only" }],
+  sizeRuleOptions
+);
+expect("15. changed_only skips unchanged file", changedOnlySkippedResult.ok, true);
+
+const changedOnlyFailingResult = checkSizeRules(
+  [{ path: "src/large.mjs", addedLines: ["three"], deletedLines: [], status: "modified" }],
+  [{ id: "changed-only-lines", scope: "file", metric: "lines", glob: "src/large.mjs", max: 2, count: "changed_only" }],
+  sizeRuleOptions
+);
+expect("15. changed_only evaluates changed file", changedOnlyFailingResult.ok, false);
+
+const ignoredSizeResult = checkSizeRules(
+  [],
+  [{ id: "ignore-generated", scope: "file", metric: "bytes", glob: "src/**", max: 10, ignore: ["src/bytes.bin", "src/large.mjs", "src/subtree/**"] }],
+  sizeRuleOptions
+);
+expect("15. ignore patterns exclude matching files", ignoredSizeResult.ok, true);
+
+const advisorySizeResult = checkSizeRules(
+  [],
+  [{ id: "advisory-large-lines", scope: "file", metric: "lines", glob: "src/large.mjs", max: 2, level: "advisory" }],
+  sizeRuleOptions
+);
+expect("15. advisory size rule does not fail blocking result", advisorySizeResult.ok, true);
+expect("15. advisory size rule is reported separately", advisorySizeResult.advisory_violations.length, 1);
 
 // --- Summary ---
 

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -138,5 +138,34 @@ console.log("\n--- equivalent command inputs share one result shape ---");
   );
 }
 
+console.log("\n--- check-pr style pipeline evaluates size rules ---");
+{
+  const sizeResult = runEquivalentInput({
+    mode: "check-pr",
+    policy: {
+      ...policy,
+      size_rules: [
+        {
+          id: "max-feature-lines",
+          scope: "file",
+          metric: "lines",
+          glob: "src/feature.mjs",
+          max: 0,
+          count: "changed_only",
+        },
+      ],
+    },
+    readFile: (path) => {
+      if (path === "src/feature.mjs") return "export const value = 1;\n";
+      return "";
+    },
+  });
+
+  const violation = sizeResult.violations.find((item) => item.rule === "size-rules");
+  expect("check-pr pipeline reports size-rules violation", Boolean(violation), true);
+  expect("check-pr pipeline reports offending file", violation?.size_violations[0]?.path, "src/feature.mjs");
+  expect("check-pr pipeline reports measured lines", violation?.size_violations[0]?.actual, 1);
+}
+
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -86,6 +86,60 @@ function makeRepo() {
   };
 }
 
+function makeSizeRulesRepo() {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-size-rules-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+
+  const policy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: {
+      max_new_docs: 5,
+      max_new_files: 5,
+      max_net_added_lines: 500,
+    },
+    size_rules: [
+      {
+        id: "max-src-lines",
+        scope: "file",
+        metric: "lines",
+        glob: "src/**/*.mjs",
+        max: 2,
+      },
+      {
+        id: "max-src-bytes",
+        scope: "directory",
+        metric: "bytes",
+        glob: "src/**",
+        max: 10,
+      },
+    ],
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  writeFileSync(join(dir, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(dir, "README.md"), "# Test\n");
+  execSync("git add -A && git commit -m init", { cwd: dir, stdio: "pipe" });
+
+  execSync("mkdir -p src", { cwd: dir, stdio: "pipe" });
+  writeFileSync(join(dir, "src", "big.mjs"), "one\ntwo\nthree\n");
+  execSync("git add -A && git commit -m oversized-source", { cwd: dir, stdio: "pipe" });
+
+  return {
+    dir,
+    base: execSync("git rev-parse HEAD~1", { cwd: dir, encoding: "utf-8" }).trim(),
+    head: execSync("git rev-parse HEAD", { cwd: dir, encoding: "utf-8" }).trim(),
+  };
+}
+
 function makeSurfaceRepo() {
   const dir = mkdtempSync(join(tmpdir(), "repo-guard-surfaces-"));
   execSync("git init", { cwd: dir, stdio: "pipe" });
@@ -781,6 +835,72 @@ console.log("\n--- check-diff evaluates registry_rules in JSON output ---");
   );
   expect("registry missing item is reported", registryViolation?.results[0].missing_from_right[0], "docs/policy.md");
   expect("registry extra item is reported", registryViolation?.results[0].extra_in_right[0], "docs/architecture.md");
+
+  rmSync(repo.dir, { recursive: true });
+}
+
+console.log("\n--- check-diff reports size_rules in JSON, text, and summary output ---");
+{
+  const repo = makeSizeRulesRepo();
+  const jsonResult = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "json",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+
+  expect("size rules json exit code follows blocking failure", jsonResult.code, 1);
+  let parsed = null;
+  try {
+    parsed = JSON.parse(jsonResult.stdout);
+    expect("size rules stdout is valid json", true, true);
+  } catch (e) {
+    expect("size rules stdout is valid json", e.message, "valid json");
+  }
+  const violation = parsed?.violations.find((v) => v.rule === "size-rules");
+  expect("size rules violation is present", Boolean(violation), true);
+  expect("size rules structured file violation",
+    violation?.size_violations.some((v) =>
+      v.ruleId === "max-src-lines" &&
+      v.scope === "file" &&
+      v.path === "src/big.mjs" &&
+      v.metric === "lines" &&
+      v.actual === 3 &&
+      v.max === 2
+    ),
+    true);
+  expect("size rules structured directory violation",
+    violation?.size_violations.some((v) =>
+      v.ruleId === "max-src-bytes" &&
+      v.scope === "directory" &&
+      v.path === "src" &&
+      v.metric === "bytes" &&
+      v.actual === 14 &&
+      v.max === 10
+    ),
+    true);
+
+  const textResult = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+  expect("size rules text exit code follows blocking failure", textResult.code, 1);
+  expectIncludes("text output names size-rules check", textResult.output, "FAIL: size-rules");
+  expectIncludes("text output includes size detail", textResult.output, "[max-src-lines] src/big.mjs has 3 lines (max 2)");
+
+  const summaryResult = runGuard([
+    "--repo-root", repo.dir,
+    "check-diff",
+    "--format", "summary",
+    "--base", repo.base,
+    "--head", repo.head,
+  ]);
+  expect("size rules summary exit code follows blocking failure", summaryResult.code, 1);
+  expectIncludes("summary output names size-rules check", summaryResult.output, "| size-rules |");
+  expectIncludes("summary output includes size detail", summaryResult.output, "[max-src-bytes] src has 14 bytes (max 10)");
 
   rmSync(repo.dir, { recursive: true });
 }

--- a/tests/validate-schemas.mjs
+++ b/tests/validate-schemas.mjs
@@ -44,6 +44,9 @@ expect("repo-policy.json (self) passes schema", validatePolicy(repoPolicy), true
 const downstreamIntegrationExample = loadJSON(resolve(root, "examples/downstream-integration-policy.json"));
 expect("downstream integration example policy passes schema", validatePolicy(downstreamIntegrationExample), true);
 
+const sizeRulesExample = loadJSON(resolve(root, "examples/size-rules-policy.json"));
+expect("size rules example policy passes schema", validatePolicy(sizeRulesExample), true);
+
 const policyWithProfile = {
   ...validPolicy,
   profile: "requirements-strict",
@@ -170,6 +173,46 @@ const policyWithIntegration = {
   },
 };
 expect("policy with integration section passes schema", validatePolicy(policyWithIntegration), true);
+
+const policyWithSizeRules = {
+  ...validPolicy,
+  size_rules: [
+    {
+      id: "max-source-lines",
+      scope: "file",
+      metric: "lines",
+      glob: "src/**/*.mjs",
+      max: 500,
+    },
+    {
+      id: "max-source-subtree-bytes",
+      scope: "directory",
+      metric: "bytes",
+      glob: "src/**",
+      max: 65536,
+      count: "changed_only",
+      level: "advisory",
+      ignore: ["src/generated/**"],
+      applies_to_change_types: ["feature", "refactor"],
+      applies_to_change_classes: ["kernel-hardening"],
+    },
+  ],
+};
+expect("policy with size_rules passes schema", validatePolicy(policyWithSizeRules), true);
+
+const invalidSizeRulePolicy = {
+  ...validPolicy,
+  size_rules: [
+    {
+      id: "bad-size-rule",
+      scope: "file",
+      metric: "tokens",
+      glob: "src/**",
+      max: -1,
+    },
+  ],
+};
+expect("policy with malformed size rule fails schema", validatePolicy(invalidSizeRulePolicy), false);
 
 const invalidIntegrationExpectationPolicy = {
   ...validPolicy,


### PR DESCRIPTION
Fixes netkeep80/repo-guard#89

## Summary
- Add `size_rules` to the policy schema for file and directory/subtree limits measured in `lines` or `bytes`.
- Enforce size rules in the shared policy pipeline used by both `check-diff` and `check-pr`, including `all_tracked` and `changed_only` modes, rule-level ignores, advisory rules, and structured `size_violations` diagnostics.
- Add JSON/text/summary reporting coverage, schema validation, README documentation, and an example size-rules policy.
- Fix the review-found blank-line-only edge case so `metric: "lines"` counts `"\n"` as one line, while `""` remains zero lines and trailing newlines do not add phantom lines.
- Remove the initial `.gitkeep` placeholder from the issue branch.

## Reproduction
Before this change, a policy containing `size_rules` failed schema validation, and there was no runtime check that could reject an oversized file or subtree. The tests cover the missing rule path, then verify passing and failing file/directory limits for both line and byte metrics.

The review follow-up also reproduced the line-counting bug with a failing regression for `"\n" -> 1`; the fixed test now covers:
- `"" -> 0`
- `"\n" -> 1`
- `"a\n" -> 1`
- `"\n\n" -> 2`

## Tests
- `npm ci`
- `node tests/test-diff-rules.mjs` before the fix: failed on `15. line count single blank line`
- `node tests/test-diff-rules.mjs`
- `npm test`
- `npm run validate`
- `node src/repo-guard.mjs check-diff --format json`
- `git diff --check`
- CI run `24683212154` passed on commit `04b8656`: `validate` and `smoke-pack`

```repo-guard-yaml
change_type: feature
scope:
  - schemas/repo-policy.schema.json
  - src/diff-checker.mjs
  - src/checks/orchestrator.mjs
  - src/enforcement.mjs
  - src/facts/input.mjs
  - tests/
  - README.md
  - examples/size-rules-policy.json
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 700
anchors:
  affects:
    - RG-SIZE-RULES
  implements:
    - RG-SIZE-RULES
  verifies:
    - RG-SIZE-RULES
must_touch:
  - schemas/repo-policy.schema.json
  - src/diff-checker.mjs
  - src/checks/orchestrator.mjs
  - tests/test-diff-rules.mjs
  - tests/test-structured-output.mjs
  - README.md
must_not_touch:
  - action.yml
  - .github/workflows/**
expected_effects:
  - Policies can declare max file size rules in lines or bytes.
  - Policies can declare max directory/subtree size rules in lines or bytes.
  - check-diff and check-pr evaluate size_rules through the shared policy pipeline.
  - Violations report rule id, scope, path, metric, measured size, and configured max in text, JSON, and summary outputs.
  - Existing policies without size_rules continue to validate and run unchanged.
  - Blank-line-only files are counted correctly by line-based size rules.
```
