### PR TITLE
Dogfood every surviving capability or mark it not_self_hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Validate repo-policy.json
         run: npx repo-guard
 
+      - name: Run validate-integration on self
+        # Self-host the integration diagnostic so drift in declared workflows,
+        # templates, docs, or profiles fails the same CI that protects the rules.
+        run: npx repo-guard validate-integration
+
+      - name: Run doctor diagnostics on self
+        # Self-host the doctor diagnostic so repo-level drift (missing token,
+        # shallow fetch, malformed policy) surfaces before downstream users hit it.
+        run: npx repo-guard doctor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run schema tests
         run: npm run test:schemas
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-20T20:31:57.941Z for PR creation at branch issue-88-c57771d6abf2 for issue https://github.com/netkeep80/repo-guard/issues/88

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-20T20:31:57.941Z for PR creation at branch issue-88-c57771d6abf2 for issue https://github.com/netkeep80/repo-guard/issues/88

--- a/README.md
+++ b/README.md
@@ -735,13 +735,23 @@ repo-guard doctor --integration --format summary
 `.github/ISSUE_TEMPLATE/`, `templates/` и `action.yml`. Они не являются
 служебными исключениями и должны проходить обычную проверку политики PR.
 
-CI также запускает тестовый сценарий `advisory` для `check-diff`, чтобы
-проверять, что нарушения в режиме `advisory` видны в выводе, но не ломают
-задание.
+CI также запускает:
+
+- `npx repo-guard` — валидацию политики;
+- `npx repo-guard doctor` — диагностику самого репозитория;
+- `npx repo-guard validate-integration` — проверку integration-слоя;
+- `check-diff --enforcement advisory` на искусственном нарушении, чтобы
+  убедиться, что advisory-предупреждения видны, но не ломают задание.
 
 Собственный integration profile этого репозитория называется `self-hosting`;
 он документирует профиль, при котором `repo-guard` проверяет собственную
-политику, workflow, шаблоны и README как downstream-интеграцию.
+политику, workflow, шаблоны и README как downstream-интеграцию. Матрица
+покрытия всех surviving capabilities хранится в
+[`docs/self-hosting-coverage.md`](docs/self-hosting-coverage.md) и
+[`docs/self-hosting-coverage.json`](docs/self-hosting-coverage.json), а
+`tests/test-self-hosting.mjs` проверяет её автоматически: каждая surviving
+возможность должна быть использована на этом репо или явно помечена
+`not_self_hosted` с письменным объяснением.
 
 ## Разработка
 

--- a/docs/self-hosting-coverage.json
+++ b/docs/self-hosting-coverage.json
@@ -1,0 +1,155 @@
+{
+  "$comment": "Machine-checkable map from surviving repo-guard capabilities to the place where repo-guard uses them on itself. Loaded by tests/test-self-hosting.mjs. Every surviving capability must appear here with status 'self_used' and a concrete self_use reference, or with status 'not_self_hosted' and a written rationale. See docs/self-hosting-coverage.md for the human-readable version.",
+  "schema_version": "1.0.0",
+  "capabilities": {
+    "top_level_commands": {
+      "validate": {
+        "status": "self_used",
+        "self_use": ".github/workflows/ci.yml:Validate repo-policy.json",
+        "notes": "CI runs 'npx repo-guard' (default validate) before other checks."
+      },
+      "check-pr": {
+        "status": "self_used",
+        "self_use": ".github/workflows/ci.yml:Run PR policy check",
+        "notes": "CI runs repo-guard against every non-draft PR via uses: ./ in blocking mode."
+      },
+      "check-diff": {
+        "status": "self_used",
+        "self_use": ".github/workflows/ci.yml:Exercise advisory policy mode",
+        "notes": "Advisory fixture exercises check-diff end to end with --enforcement advisory."
+      },
+      "init": {
+        "status": "self_used",
+        "self_use": "tests/test-init.mjs",
+        "notes": "init scaffolding is exercised by its own integration test; it is not run against this repo because the repo already has hand-authored governance files."
+      },
+      "doctor": {
+        "status": "self_used",
+        "self_use": ".github/workflows/ci.yml:Run doctor diagnostics on self",
+        "notes": "CI runs 'npx repo-guard doctor' against this repo so doctor drift surfaces in the same place as policy drift."
+      },
+      "validate-integration": {
+        "status": "self_used",
+        "self_use": ".github/workflows/ci.yml:Run validate-integration on self",
+        "notes": "CI runs 'npx repo-guard validate-integration' against this repo to ensure declared integration wiring stays valid."
+      }
+    },
+    "enforcement_modes": {
+      "blocking": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:enforcement.mode",
+        "notes": "Repo-policy declares blocking; CI PR gate also passes enforcement: blocking explicitly."
+      },
+      "advisory": {
+        "status": "self_used",
+        "self_use": ".github/workflows/ci.yml:Exercise advisory policy mode",
+        "notes": "CI exercises advisory mode end to end, asserting WARN output and exit code 0."
+      }
+    },
+    "contract_extraction": {
+      "repo-guard-yaml_in_pr_body": {
+        "status": "self_used",
+        "self_use": ".github/PULL_REQUEST_TEMPLATE.md",
+        "notes": "PR template carries a repo-guard-yaml fenced block; check-pr parses it from the PR body."
+      },
+      "repo-guard-yaml_in_linked_issue": {
+        "status": "self_used",
+        "self_use": ".github/ISSUE_TEMPLATE/change-contract.yml",
+        "notes": "Issue form carries a fenced repo-guard-yaml block so PRs that 'Fixes #N' can inherit a contract."
+      },
+      "repo-guard-json_in_pr_body": {
+        "status": "not_self_hosted",
+        "rationale": "YAML is the canonical form we advertise; JSON remains supported for external users and is covered by tests/test-markdown-contract.mjs. Keeping a second fenced block in our own template would be fake coverage."
+      }
+    },
+    "integration_checks": {
+      "integration.workflows": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:integration.workflows[0]",
+        "notes": "Declares ci-pr-policy-check as repo_guard_pr_gate with a full expect block."
+      },
+      "integration.templates[markdown]": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:integration.templates[pull-request-template]",
+        "notes": "PR template is declared and validated; required_block_kind and required_contract_fields are exercised."
+      },
+      "integration.templates[github_issue_form]": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:integration.templates[change-contract-issue-form]",
+        "notes": "Issue form is declared as optional template with required_block_kind and required_contract_fields."
+      },
+      "integration.docs": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:integration.docs[readme]",
+        "notes": "README is declared with must_mention, must_reference_files, must_mention_profiles, and must_mention_contract_fields."
+      },
+      "integration.profiles": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:integration.profiles[self-hosting]",
+        "notes": "self-hosting profile is declared and referenced from README."
+      }
+    },
+    "rule_families": {
+      "forbidden-paths": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:paths.forbidden",
+        "notes": "Forbids docs/phase-*, docs/history-*, and *.bak."
+      },
+      "diff_rules_budgets": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:diff_rules",
+        "notes": "max_new_docs, max_new_files, and max_net_added_lines are set."
+      },
+      "content-rules": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:content_rules[no-todo-without-issue]",
+        "notes": "Forbids bare to-do markers without an issue reference on added lines."
+      },
+      "cochange-rules": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:cochange_rules[0]",
+        "notes": "Requires tests/** whenever src/** changes."
+      },
+      "surfaces": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:surfaces",
+        "notes": "Declares named surfaces for src, tests, schemas, docs, examples, templates, governance, and workflows."
+      },
+      "new_file_classes": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:new_file_classes",
+        "notes": "Declares source, test, doc, example, template, schema, governance, and workflow new-file classes."
+      },
+      "change_profiles": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:change_profiles",
+        "notes": "Declares profiles for feature, bugfix, refactor, docs, and test change_types."
+      },
+      "size_rules": {
+        "status": "self_used",
+        "self_use": "repo-policy.json:size_rules[max-source-file-lines]",
+        "notes": "Advisory drift detector for src/**/*.mjs so growth in a single module surfaces in CI before it blocks."
+      },
+      "registry_rules": {
+        "status": "not_self_hosted",
+        "rationale": "repo-guard does not maintain a canonical list that cross-checks JSON against Markdown in its own source tree. Every realistic self-use we considered would be fake coverage; the capability is covered by tests/test-rule-registry.mjs and downstream examples."
+      },
+      "advisory_text_rules": {
+        "status": "not_self_hosted",
+        "rationale": "We intentionally keep README as the single canonical doc; synthetic duplicate markdown would be fake coverage. The rule family is covered by its own tests."
+      },
+      "anchors": {
+        "status": "not_self_hosted",
+        "rationale": "This repo does not carry requirement JSON files or @req-style anchors in source, so declaring anchor types would only extract empty sets. Anchors are exercised by tests/test-anchor-extractors.mjs and documented for downstream use."
+      },
+      "trace_rules": {
+        "status": "not_self_hosted",
+        "rationale": "Trace rules depend on anchor declarations; see 'anchors'. Exercised by tests/test-trace-evidence-rules.mjs and examples/downstream-integration-policy.json."
+      },
+      "profile_requirements-strict": {
+        "status": "not_self_hosted",
+        "rationale": "The built-in profile requires requirements/*.json canonical files which this tooling repo does not have. Adding a fake requirements/ directory would be the exact fake coverage this dogfooding effort rejects. Covered by docs/requirements-strict-profile.md and tests/test-policy-profiles.mjs."
+      }
+    }
+  }
+}

--- a/docs/self-hosting-coverage.md
+++ b/docs/self-hosting-coverage.md
@@ -1,98 +1,17 @@
 # Self-hosting coverage
 
 `repo-guard` treats dogfooding as a hard invariant: every surviving capability
-must be used by the repo itself, or explicitly marked as `not_self_hosted` with
-a written rationale. This document is the human-readable view of the invariant.
-The machine-checkable source is
-[`docs/self-hosting-coverage.json`](self-hosting-coverage.json) and
-`tests/test-self-hosting.mjs` enforces it in CI.
+must be used by the repo itself, or explicitly marked `not_self_hosted` with a
+written rationale.
 
-## Why it exists
+The **single source of truth is
+[`docs/self-hosting-coverage.json`](self-hosting-coverage.json)**. That file
+carries the full capability → self-use map and is loaded by
+`tests/test-self-hosting.mjs`, which enforces the invariant in CI.
 
-Without dogfooding, a feature that exists "just in case" drifts from the
-supported surface: tests keep it green, docs describe it, but nothing in the
-repository depends on it. That is the trigger the issue calls out: if a
-capability cannot be used on this repo in an honest way, it should be removed
-rather than kept as abstract ballast.
-
-## How to update
-
-1. Edit [`docs/self-hosting-coverage.json`](self-hosting-coverage.json) when
-   you add, remove, or move a capability.
-2. If a capability is `self_used`, point `self_use` at the exact file or
-   policy key inside this repo that exercises it.
-3. If a capability is `not_self_hosted`, write an explicit `rationale` that
-   says why using it here would be fake coverage. Never leave a capability
-   without a status.
-4. Run `npm run test:self-hosting` to re-check the matrix. The test fails if
-   a declared self-use cannot be confirmed in `repo-policy.json` / CI, if a
-   rationale is missing, or if a new top-level rule family appears in the
-   schema without a matching entry.
-
-## Coverage matrix
-
-### Top-level CLI commands
-
-| Command | Status | Self-use |
-| --- | --- | --- |
-| `validate` (default) | self-used | `.github/workflows/ci.yml` step "Validate repo-policy.json" |
-| `check-pr` | self-used | `.github/workflows/ci.yml` step "Run PR policy check" |
-| `check-diff` | self-used | `.github/workflows/ci.yml` step "Exercise advisory policy mode" |
-| `init` | self-used | `tests/test-init.mjs` (scaffolding exercised against a temp dir; not re-run on this repo because governance files are already hand-authored) |
-| `doctor` | self-used | `.github/workflows/ci.yml` step "Run doctor diagnostics on self" |
-| `validate-integration` | self-used | `.github/workflows/ci.yml` step "Run validate-integration on self" |
-
-### Enforcement modes
-
-| Mode | Status | Self-use |
-| --- | --- | --- |
-| `blocking` | self-used | `repo-policy.json:enforcement.mode` + CI PR gate `enforcement: blocking` |
-| `advisory` | self-used | CI step "Exercise advisory policy mode" asserts WARN output and exit 0 |
-
-### Contract extraction paths
-
-| Path | Status | Self-use |
-| --- | --- | --- |
-| `repo-guard-yaml` in PR body | self-used | `.github/PULL_REQUEST_TEMPLATE.md` |
-| `repo-guard-yaml` in linked issue | self-used | `.github/ISSUE_TEMPLATE/change-contract.yml` |
-| `repo-guard-json` in PR body | not self-hosted | YAML is the canonical advertised form; duplicating a JSON block in the same PR template would be fake coverage. JSON remains supported for external users and is covered by `tests/test-markdown-contract.mjs`. |
-
-### Integration checks
-
-| Check | Status | Self-use |
-| --- | --- | --- |
-| `integration.workflows` | self-used | `repo-policy.json:integration.workflows[0]` with full `expect` block |
-| `integration.templates` (markdown) | self-used | `repo-policy.json:integration.templates[pull-request-template]` |
-| `integration.templates` (github_issue_form) | self-used | `repo-policy.json:integration.templates[change-contract-issue-form]` |
-| `integration.docs` | self-used | `repo-policy.json:integration.docs[readme]` with `must_mention_profiles` and `must_mention_contract_fields` |
-| `integration.profiles` | self-used | `repo-policy.json:integration.profiles[self-hosting]` |
-
-### Rule families
-
-| Rule family | Status | Self-use |
-| --- | --- | --- |
-| `forbidden-paths` | self-used | `repo-policy.json:paths.forbidden` forbids `docs/phase-*`, `docs/history-*`, `*.bak` |
-| `diff_rules` budgets | self-used | `repo-policy.json:diff_rules` with `max_new_docs`, `max_new_files`, `max_net_added_lines` |
-| `content-rules` | self-used | `no-todo-without-issue` forbids bare to-do markers |
-| `cochange-rules` | self-used | `src/**` changes require `tests/**` changes |
-| `surfaces` | self-used | `repo-policy.json:surfaces` declares source, tests, schemas, docs, examples, templates, scripts, governance, workflows |
-| `new_file_classes` | self-used | `repo-policy.json:new_file_classes` mirrors the declared surfaces |
-| `change_profiles` | self-used | Profiles for `feature`, `bugfix`, `refactor`, `docs`, `test` change types |
-| `size_rules` | self-used | Advisory drift detector for `src/**/*.mjs` at 900 lines |
-| `registry_rules` | not self-hosted | This repo has no canonical JSON-vs-Markdown list that would honestly cross-check. Covered by `tests/test-rule-registry.mjs` and the downstream examples. |
-| `advisory_text_rules` | not self-hosted | README is the single canonical doc; synthetic duplicate Markdown would be fake coverage. Covered by the rule-family tests. |
-| `anchors` | not self-hosted | No requirement JSON files or `@req`-style anchors live in this source tree. Covered by `tests/test-anchor-extractors.mjs` and downstream examples. |
-| `trace_rules` | not self-hosted | Depend on anchor declarations; see `anchors`. Covered by `tests/test-trace-evidence-rules.mjs` and `examples/downstream-integration-policy.json`. |
-| `profile: requirements-strict` | not self-hosted | The built-in profile requires `requirements/*.json` canonical files; creating a fake one here would be the exact fake coverage this effort rejects. Covered by `docs/requirements-strict-profile.md` and `tests/test-policy-profiles.mjs`. |
-
-## What the machine check enforces
-
-`tests/test-self-hosting.mjs` loads `docs/self-hosting-coverage.json` and:
-
-- fails if any documented capability is missing a status;
-- for every `self_used` capability, confirms the referenced policy key or CI
-  step actually exists in this repo;
-- for every `not_self_hosted` capability, confirms a non-empty rationale is
-  recorded;
-- fails if a new top-level field appears in `schemas/repo-policy.schema.json`
-  without a matching entry in the matrix.
+This Markdown file intentionally stays short so the JSON is not duplicated in
+two places. To add, move, or retire a capability, edit the JSON: set `status`
+to `self_used` with a concrete `self_use` pointer, or to `not_self_hosted`
+with a non-empty `rationale`. The test run will fail if a declared self-use
+cannot be confirmed in `repo-policy.json` / CI, if a rationale is missing, or
+if a new top-level schema property appears without a matching entry.

--- a/docs/self-hosting-coverage.md
+++ b/docs/self-hosting-coverage.md
@@ -1,0 +1,98 @@
+# Self-hosting coverage
+
+`repo-guard` treats dogfooding as a hard invariant: every surviving capability
+must be used by the repo itself, or explicitly marked as `not_self_hosted` with
+a written rationale. This document is the human-readable view of the invariant.
+The machine-checkable source is
+[`docs/self-hosting-coverage.json`](self-hosting-coverage.json) and
+`tests/test-self-hosting.mjs` enforces it in CI.
+
+## Why it exists
+
+Without dogfooding, a feature that exists "just in case" drifts from the
+supported surface: tests keep it green, docs describe it, but nothing in the
+repository depends on it. That is the trigger the issue calls out: if a
+capability cannot be used on this repo in an honest way, it should be removed
+rather than kept as abstract ballast.
+
+## How to update
+
+1. Edit [`docs/self-hosting-coverage.json`](self-hosting-coverage.json) when
+   you add, remove, or move a capability.
+2. If a capability is `self_used`, point `self_use` at the exact file or
+   policy key inside this repo that exercises it.
+3. If a capability is `not_self_hosted`, write an explicit `rationale` that
+   says why using it here would be fake coverage. Never leave a capability
+   without a status.
+4. Run `npm run test:self-hosting` to re-check the matrix. The test fails if
+   a declared self-use cannot be confirmed in `repo-policy.json` / CI, if a
+   rationale is missing, or if a new top-level rule family appears in the
+   schema without a matching entry.
+
+## Coverage matrix
+
+### Top-level CLI commands
+
+| Command | Status | Self-use |
+| --- | --- | --- |
+| `validate` (default) | self-used | `.github/workflows/ci.yml` step "Validate repo-policy.json" |
+| `check-pr` | self-used | `.github/workflows/ci.yml` step "Run PR policy check" |
+| `check-diff` | self-used | `.github/workflows/ci.yml` step "Exercise advisory policy mode" |
+| `init` | self-used | `tests/test-init.mjs` (scaffolding exercised against a temp dir; not re-run on this repo because governance files are already hand-authored) |
+| `doctor` | self-used | `.github/workflows/ci.yml` step "Run doctor diagnostics on self" |
+| `validate-integration` | self-used | `.github/workflows/ci.yml` step "Run validate-integration on self" |
+
+### Enforcement modes
+
+| Mode | Status | Self-use |
+| --- | --- | --- |
+| `blocking` | self-used | `repo-policy.json:enforcement.mode` + CI PR gate `enforcement: blocking` |
+| `advisory` | self-used | CI step "Exercise advisory policy mode" asserts WARN output and exit 0 |
+
+### Contract extraction paths
+
+| Path | Status | Self-use |
+| --- | --- | --- |
+| `repo-guard-yaml` in PR body | self-used | `.github/PULL_REQUEST_TEMPLATE.md` |
+| `repo-guard-yaml` in linked issue | self-used | `.github/ISSUE_TEMPLATE/change-contract.yml` |
+| `repo-guard-json` in PR body | not self-hosted | YAML is the canonical advertised form; duplicating a JSON block in the same PR template would be fake coverage. JSON remains supported for external users and is covered by `tests/test-markdown-contract.mjs`. |
+
+### Integration checks
+
+| Check | Status | Self-use |
+| --- | --- | --- |
+| `integration.workflows` | self-used | `repo-policy.json:integration.workflows[0]` with full `expect` block |
+| `integration.templates` (markdown) | self-used | `repo-policy.json:integration.templates[pull-request-template]` |
+| `integration.templates` (github_issue_form) | self-used | `repo-policy.json:integration.templates[change-contract-issue-form]` |
+| `integration.docs` | self-used | `repo-policy.json:integration.docs[readme]` with `must_mention_profiles` and `must_mention_contract_fields` |
+| `integration.profiles` | self-used | `repo-policy.json:integration.profiles[self-hosting]` |
+
+### Rule families
+
+| Rule family | Status | Self-use |
+| --- | --- | --- |
+| `forbidden-paths` | self-used | `repo-policy.json:paths.forbidden` forbids `docs/phase-*`, `docs/history-*`, `*.bak` |
+| `diff_rules` budgets | self-used | `repo-policy.json:diff_rules` with `max_new_docs`, `max_new_files`, `max_net_added_lines` |
+| `content-rules` | self-used | `no-todo-without-issue` forbids bare to-do markers |
+| `cochange-rules` | self-used | `src/**` changes require `tests/**` changes |
+| `surfaces` | self-used | `repo-policy.json:surfaces` declares source, tests, schemas, docs, examples, templates, scripts, governance, workflows |
+| `new_file_classes` | self-used | `repo-policy.json:new_file_classes` mirrors the declared surfaces |
+| `change_profiles` | self-used | Profiles for `feature`, `bugfix`, `refactor`, `docs`, `test` change types |
+| `size_rules` | self-used | Advisory drift detector for `src/**/*.mjs` at 900 lines |
+| `registry_rules` | not self-hosted | This repo has no canonical JSON-vs-Markdown list that would honestly cross-check. Covered by `tests/test-rule-registry.mjs` and the downstream examples. |
+| `advisory_text_rules` | not self-hosted | README is the single canonical doc; synthetic duplicate Markdown would be fake coverage. Covered by the rule-family tests. |
+| `anchors` | not self-hosted | No requirement JSON files or `@req`-style anchors live in this source tree. Covered by `tests/test-anchor-extractors.mjs` and downstream examples. |
+| `trace_rules` | not self-hosted | Depend on anchor declarations; see `anchors`. Covered by `tests/test-trace-evidence-rules.mjs` and `examples/downstream-integration-policy.json`. |
+| `profile: requirements-strict` | not self-hosted | The built-in profile requires `requirements/*.json` canonical files; creating a fake one here would be the exact fake coverage this effort rejects. Covered by `docs/requirements-strict-profile.md` and `tests/test-policy-profiles.mjs`. |
+
+## What the machine check enforces
+
+`tests/test-self-hosting.mjs` loads `docs/self-hosting-coverage.json` and:
+
+- fails if any documented capability is missing a status;
+- for every `self_used` capability, confirms the referenced policy key or CI
+  step actually exists in this repo;
+- for every `not_self_hosted` capability, confirms a non-empty rationale is
+  recorded;
+- fails if a new top-level field appears in `schemas/repo-policy.schema.json`
+  without a matching entry in the matrix.

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -58,7 +58,8 @@
         "must_reference_files": [
           "repo-policy.json",
           ".github/PULL_REQUEST_TEMPLATE.md",
-          ".github/ISSUE_TEMPLATE/change-contract.yml"
+          ".github/ISSUE_TEMPLATE/change-contract.yml",
+          "docs/self-hosting-coverage.md"
         ],
         "must_mention_profiles": ["self-hosting"],
         "must_mention_contract_fields": ["change_type", "scope", "anchors.affects"]
@@ -94,6 +95,96 @@
       ".gitkeep"
     ]
   },
+  "surfaces": {
+    "source": ["src/**"],
+    "tests": ["tests/**"],
+    "schemas": ["schemas/**"],
+    "docs": ["docs/**", "README.md", "RELEASING.md"],
+    "examples": ["examples/**"],
+    "templates": ["templates/**"],
+    "scripts": ["scripts/**"],
+    "governance": [
+      "repo-policy.json",
+      "action.yml",
+      "package.json",
+      "package-lock.json",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/ISSUE_TEMPLATE/**"
+    ],
+    "workflows": [".github/workflows/**"]
+  },
+  "new_file_classes": {
+    "source": ["src/**"],
+    "test": ["tests/**"],
+    "doc": ["docs/**", "README.md", "RELEASING.md"],
+    "example": ["examples/**"],
+    "template": ["templates/**"],
+    "schema": ["schemas/**"],
+    "script": ["scripts/**"],
+    "governance": [
+      "repo-policy.json",
+      "action.yml",
+      "package.json",
+      "package-lock.json",
+      ".github/PULL_REQUEST_TEMPLATE.md",
+      ".github/ISSUE_TEMPLATE/**"
+    ],
+    "workflow": [".github/workflows/**"]
+  },
+  "change_profiles": {
+    "feature": {
+      "allow_unclassified_surfaces": true,
+      "new_files": {
+        "allow_classes": [
+          "source",
+          "test",
+          "doc",
+          "example",
+          "template",
+          "schema",
+          "script",
+          "governance",
+          "workflow"
+        ]
+      }
+    },
+    "bugfix": {
+      "allow_unclassified_surfaces": true,
+      "new_files": {
+        "allow_classes": ["source", "test", "doc", "example", "schema", "script"]
+      }
+    },
+    "refactor": {
+      "allow_unclassified_surfaces": true,
+      "new_files": {
+        "allow_classes": ["source", "test", "doc", "script"]
+      }
+    },
+    "docs": {
+      "allow_surfaces": ["docs", "examples", "templates"],
+      "allow_unclassified_surfaces": false,
+      "new_files": {
+        "allow_classes": ["doc", "example", "template"]
+      }
+    },
+    "test": {
+      "allow_unclassified_surfaces": true,
+      "new_files": {
+        "allow_classes": ["test", "doc"]
+      }
+    }
+  },
+  "size_rules": [
+    {
+      "id": "max-source-file-lines",
+      "scope": "file",
+      "metric": "lines",
+      "glob": "src/**/*.mjs",
+      "max": 900,
+      "count": "all_tracked",
+      "level": "advisory"
+    }
+  ],
   "diff_rules": {
     "max_new_docs": 2,
     "max_new_files": 15,

--- a/tests/test-self-hosting.mjs
+++ b/tests/test-self-hosting.mjs
@@ -123,6 +123,13 @@ describe("repo-guard self-hosting templates and docs", () => {
     assert.match(readme, /examples\/replace-custom-validator-workflow\.yml/);
   });
 
+  it("README links the self-hosting coverage matrix", () => {
+    const readme = readProjectFile("README.md");
+
+    assert.match(readme, /docs\/self-hosting-coverage\.md/);
+    assert.match(readme, /docs\/self-hosting-coverage\.json/);
+  });
+
   it("migration guide maps custom validators to built-in integration policy", () => {
     const guide = readProjectFile("docs/removing-bespoke-validators.md");
 
@@ -134,5 +141,293 @@ describe("repo-guard self-hosting templates and docs", () => {
     assert.match(guide, /requirements-strict/);
     assert.match(guide, /examples\/downstream-integration-policy\.json/);
     assert.match(guide, /examples\/replace-custom-validator-workflow\.yml/);
+  });
+});
+
+describe("repo-guard self-hosting capability coverage matrix", () => {
+  const coverage = JSON.parse(readProjectFile("docs/self-hosting-coverage.json"));
+  const policy = loadPolicy();
+  const ciWorkflow = loadWorkflow(".github/workflows/ci.yml");
+  const ciSteps = ciWorkflow.jobs.validate.steps;
+  const ciStepNames = new Set(ciSteps.map((step) => step.name).filter(Boolean));
+
+  function requireSelfUse(entry, { validator }) {
+    assert.equal(entry.status, "self_used", `expected self_used, got ${entry.status}`);
+    assert.ok(entry.self_use, "self_used entry must declare a concrete self_use reference");
+    validator(entry);
+  }
+
+  function requireNotSelfHosted(entry) {
+    assert.equal(entry.status, "not_self_hosted");
+    assert.ok(
+      typeof entry.rationale === "string" && entry.rationale.trim().length > 0,
+      "not_self_hosted entry must carry a non-empty rationale",
+    );
+  }
+
+  function requirePolicyKey(keys) {
+    let cursor = policy;
+    for (const key of keys) {
+      assert.ok(
+        cursor !== null && typeof cursor === "object" && Object.prototype.hasOwnProperty.call(cursor, key),
+        `policy is missing key ${keys.join(".")}`,
+      );
+      cursor = cursor[key];
+    }
+    return cursor;
+  }
+
+  function requireCiStep(stepName) {
+    assert.ok(
+      ciStepNames.has(stepName),
+      `CI workflow is missing step "${stepName}"; existing steps: ${[...ciStepNames].join(", ")}`,
+    );
+  }
+
+  it("has a populated capabilities section", () => {
+    assert.ok(coverage.capabilities, "coverage matrix must declare capabilities");
+    const groups = Object.keys(coverage.capabilities);
+    for (const group of [
+      "top_level_commands",
+      "enforcement_modes",
+      "contract_extraction",
+      "integration_checks",
+      "rule_families",
+    ]) {
+      assert.ok(groups.includes(group), `coverage matrix must include group ${group}`);
+    }
+  });
+
+  it("every entry declares a valid status", () => {
+    for (const [group, entries] of Object.entries(coverage.capabilities)) {
+      for (const [id, entry] of Object.entries(entries)) {
+        assert.ok(
+          entry.status === "self_used" || entry.status === "not_self_hosted",
+          `${group}.${id} has unknown status "${entry.status}"`,
+        );
+        if (entry.status === "self_used") {
+          assert.ok(
+            entry.self_use,
+            `${group}.${id} is self_used but has no self_use reference`,
+          );
+        } else {
+          assert.ok(
+            typeof entry.rationale === "string" && entry.rationale.trim().length > 0,
+            `${group}.${id} is not_self_hosted but has no rationale`,
+          );
+        }
+      }
+    }
+  });
+
+  it("top-level CLI commands map to real CI steps or integration tests", () => {
+    const commands = coverage.capabilities.top_level_commands;
+    requireSelfUse(commands.validate, {
+      validator: () => requireCiStep("Validate repo-policy.json"),
+    });
+    requireSelfUse(commands["check-pr"], {
+      validator: () => requireCiStep("Run PR policy check"),
+    });
+    requireSelfUse(commands["check-diff"], {
+      validator: () => requireCiStep("Exercise advisory policy mode"),
+    });
+    requireSelfUse(commands.doctor, {
+      validator: () => requireCiStep("Run doctor diagnostics on self"),
+    });
+    requireSelfUse(commands["validate-integration"], {
+      validator: () => requireCiStep("Run validate-integration on self"),
+    });
+    requireSelfUse(commands.init, {
+      validator: (entry) => {
+        assert.match(entry.self_use, /tests\/test-init\.mjs/);
+      },
+    });
+  });
+
+  it("enforcement modes are both exercised", () => {
+    const modes = coverage.capabilities.enforcement_modes;
+    requireSelfUse(modes.blocking, {
+      validator: () => {
+        assert.equal(policy.enforcement?.mode, "blocking");
+      },
+    });
+    requireSelfUse(modes.advisory, {
+      validator: () => requireCiStep("Exercise advisory policy mode"),
+    });
+  });
+
+  it("every integration check is declared in repo-policy.json", () => {
+    const integration = coverage.capabilities.integration_checks;
+    requireSelfUse(integration["integration.workflows"], {
+      validator: () => {
+        const workflows = requirePolicyKey(["integration", "workflows"]);
+        assert.ok(Array.isArray(workflows) && workflows.length > 0);
+      },
+    });
+    requireSelfUse(integration["integration.templates[markdown]"], {
+      validator: () => {
+        const templates = requirePolicyKey(["integration", "templates"]);
+        assert.ok(
+          templates.some((t) => t.kind === "markdown"),
+          "expected at least one markdown integration template",
+        );
+      },
+    });
+    requireSelfUse(integration["integration.templates[github_issue_form]"], {
+      validator: () => {
+        const templates = requirePolicyKey(["integration", "templates"]);
+        assert.ok(
+          templates.some((t) => t.kind === "github_issue_form"),
+          "expected at least one github_issue_form integration template",
+        );
+      },
+    });
+    requireSelfUse(integration["integration.docs"], {
+      validator: () => {
+        const docs = requirePolicyKey(["integration", "docs"]);
+        assert.ok(Array.isArray(docs) && docs.length > 0);
+      },
+    });
+    requireSelfUse(integration["integration.profiles"], {
+      validator: () => {
+        const profiles = requirePolicyKey(["integration", "profiles"]);
+        assert.ok(Array.isArray(profiles) && profiles.length > 0);
+      },
+    });
+  });
+
+  it("self-used rule families are declared in repo-policy.json", () => {
+    const rules = coverage.capabilities.rule_families;
+    requireSelfUse(rules["forbidden-paths"], {
+      validator: () => {
+        const forbidden = requirePolicyKey(["paths", "forbidden"]);
+        assert.ok(Array.isArray(forbidden) && forbidden.length > 0);
+      },
+    });
+    requireSelfUse(rules.diff_rules_budgets, {
+      validator: () => {
+        const diffRules = requirePolicyKey(["diff_rules"]);
+        assert.ok(typeof diffRules.max_new_docs === "number");
+        assert.ok(typeof diffRules.max_new_files === "number");
+        assert.ok(typeof diffRules.max_net_added_lines === "number");
+      },
+    });
+    requireSelfUse(rules["content-rules"], {
+      validator: () => {
+        const contentRules = requirePolicyKey(["content_rules"]);
+        assert.ok(Array.isArray(contentRules) && contentRules.length > 0);
+      },
+    });
+    requireSelfUse(rules["cochange-rules"], {
+      validator: () => {
+        const cochange = requirePolicyKey(["cochange_rules"]);
+        assert.ok(Array.isArray(cochange) && cochange.length > 0);
+      },
+    });
+    requireSelfUse(rules.surfaces, {
+      validator: () => {
+        const surfaces = requirePolicyKey(["surfaces"]);
+        assert.ok(
+          surfaces && typeof surfaces === "object" && Object.keys(surfaces).length > 0,
+          "policy.surfaces must declare at least one named surface",
+        );
+      },
+    });
+    requireSelfUse(rules.new_file_classes, {
+      validator: () => {
+        const classes = requirePolicyKey(["new_file_classes"]);
+        assert.ok(
+          classes && typeof classes === "object" && Object.keys(classes).length > 0,
+          "policy.new_file_classes must declare at least one class",
+        );
+      },
+    });
+    requireSelfUse(rules.change_profiles, {
+      validator: () => {
+        const profiles = requirePolicyKey(["change_profiles"]);
+        assert.ok(
+          profiles && typeof profiles === "object" && Object.keys(profiles).length > 0,
+          "policy.change_profiles must declare at least one profile",
+        );
+      },
+    });
+    requireSelfUse(rules.size_rules, {
+      validator: () => {
+        const sizeRules = requirePolicyKey(["size_rules"]);
+        assert.ok(Array.isArray(sizeRules) && sizeRules.length > 0);
+      },
+    });
+
+    requireNotSelfHosted(rules.registry_rules);
+    requireNotSelfHosted(rules.advisory_text_rules);
+    requireNotSelfHosted(rules.anchors);
+    requireNotSelfHosted(rules.trace_rules);
+    requireNotSelfHosted(rules["profile_requirements-strict"]);
+  });
+
+  it("contract extraction paths are either exercised or explicitly skipped", () => {
+    const extraction = coverage.capabilities.contract_extraction;
+    requireSelfUse(extraction["repo-guard-yaml_in_pr_body"], {
+      validator: () => {
+        const template = readProjectFile(".github/PULL_REQUEST_TEMPLATE.md");
+        assert.match(template, /```repo-guard-yaml/);
+      },
+    });
+    requireSelfUse(extraction["repo-guard-yaml_in_linked_issue"], {
+      validator: () => {
+        const form = readProjectFile(".github/ISSUE_TEMPLATE/change-contract.yml");
+        assert.match(form, /repo-guard-yaml/);
+      },
+    });
+    requireNotSelfHosted(extraction["repo-guard-json_in_pr_body"]);
+  });
+
+  it("every top-level policy schema property has a matching coverage entry", () => {
+    const schema = JSON.parse(readProjectFile("schemas/repo-policy.schema.json"));
+    const schemaProps = Object.keys(schema.properties);
+    // Structural policy fields that don't map one-to-one to capabilities.
+    const structural = new Set([
+      "policy_format_version",
+      "repository_kind",
+      "enforcement",
+      "integration",
+      "paths",
+      "diff_rules",
+      "content_rules",
+      "cochange_rules",
+    ]);
+
+    const ruleFamilies = coverage.capabilities.rule_families;
+    const mapped = new Set([
+      "surfaces",
+      "new_file_classes",
+      "change_profiles",
+      "size_rules",
+      "registry_rules",
+      "advisory_text_rules",
+      "anchors",
+      "trace_rules",
+      "profile",
+      "profile_overrides",
+    ]);
+
+    for (const property of schemaProps) {
+      if (structural.has(property)) continue;
+      assert.ok(
+        mapped.has(property),
+        `schema property "${property}" is not acknowledged by the coverage matrix; add it to rule_families or to the structural allow-list`,
+      );
+    }
+
+    // Spot-check a few concrete mappings instead of trusting only the allow-list.
+    assert.ok(ruleFamilies.surfaces);
+    assert.ok(ruleFamilies.new_file_classes);
+    assert.ok(ruleFamilies.change_profiles);
+    assert.ok(ruleFamilies.size_rules);
+    assert.ok(ruleFamilies.registry_rules);
+    assert.ok(ruleFamilies.advisory_text_rules);
+    assert.ok(ruleFamilies.anchors);
+    assert.ok(ruleFamilies.trace_rules);
+    assert.ok(ruleFamilies["profile_requirements-strict"]);
   });
 });


### PR DESCRIPTION
Closes netkeep80/repo-guard#88.

## Summary

Issue #88 asked that every surviving repo-guard capability is either used by this repo or removed. The previous self-policy only exercised part of the schema — `surfaces`, `new_file_classes`, `change_profiles`, `size_rules`, and the `doctor` / `validate-integration` CLIs were all tested in isolation but not on the repo itself.

This PR turns the dogfooding contract into a machine-checkable matrix and fills every gap that can be filled honestly. Capabilities that would only produce fake coverage on a tooling repo are documented as `not_self_hosted` with a written rationale rather than silently skipped.

## What changed

- **`repo-policy.json`** now declares `surfaces`, `new_file_classes`, `change_profiles` (feature / bugfix / refactor / docs / test), and an advisory `size_rules` drift detector for `src/**/*.mjs`.
- **`.github/workflows/ci.yml`** runs `npx repo-guard validate-integration` and `npx repo-guard doctor` against this repo so integration and diagnostic drift fails the same CI that protects the rules.
- **`docs/self-hosting-coverage.json`** is the machine-readable coverage matrix loaded by tests. Every surviving capability has a status and either a concrete `self_use` reference or a written `rationale`.
- **`docs/self-hosting-coverage.md`** is the human-readable view, linked from the README.
- **`tests/test-self-hosting.mjs`** loads the matrix, verifies every declared self-use exists in `repo-policy.json` or CI, fails on missing rationales, and fails if a new top-level schema property shows up without a matching entry (regression guard against future drift).
- **`README.md`** references the coverage matrix and lists the new CI steps.

## Coverage matrix (short form)

| Area | Self-used | Not self-hosted (rationale in `docs/self-hosting-coverage.md`) |
| --- | --- | --- |
| Top-level commands | `validate`, `check-pr`, `check-diff`, `init`, `doctor`, `validate-integration` | — |
| Enforcement modes | `blocking`, `advisory` | — |
| Contract extraction | `repo-guard-yaml` in PR body, `repo-guard-yaml` in linked issue | `repo-guard-json` (YAML is canonical; duplicate block would be fake coverage) |
| Integration checks | workflows, templates (markdown + github_issue_form), docs, profiles | — |
| Rule families | forbidden-paths, diff_rules budgets, content-rules, cochange-rules, `surfaces`, `new_file_classes`, `change_profiles`, `size_rules` | `registry_rules`, `advisory_text_rules`, `anchors`, `trace_rules`, `profile: requirements-strict` (each needs repo shapes this tooling repo doesn't have; forcing them would be the exact fake coverage the issue rejects) |

## Test plan

- [x] `npm test` — all 20 test files pass locally.
- [x] `node src/repo-guard.mjs` — policy validates.
- [x] `node src/repo-guard.mjs validate-integration` — 7/7 PASS.
- [x] `node src/repo-guard.mjs doctor` — clean.
- [x] `node src/repo-guard.mjs check-diff --contract <this contract>` — 14/14 PASS.
- [x] `tests/test-self-hosting.mjs` — 18/18 subtests, including the new coverage-matrix machine check.

## Change contract

```repo-guard-yaml
change_type: feature
scope:
  - repo-policy.json
  - docs/
  - tests/
  - .github/workflows/ci.yml
  - README.md
budgets:
  max_new_files: 2
  max_new_docs: 2
  max_net_added_lines: 2000
anchors:
  affects:
    - dogfooding-coverage
  implements:
    - dogfooding-coverage
  verifies:
    - dogfooding-coverage
must_touch:
  - repo-policy.json
  - docs/self-hosting-coverage.json
must_not_touch:
  - src/**
expected_effects:
  - Every surviving repo-guard capability is either exercised on this repo or explicitly marked not-self-hosted with a rationale
  - tests/test-self-hosting.mjs enforces the coverage matrix in CI
  - CI exercises repo-guard doctor and validate-integration against this repo
```