### PR TITLE
Use base policy for PR enforcement

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-21T04:29:45.867Z for PR creation at branch issue-95-a7cd5a3a7774 for issue https://github.com/netkeep80/repo-guard/issues/95

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-21T04:29:45.867Z for PR creation at branch issue-95-a7cd5a3a7774 for issue https://github.com/netkeep80/repo-guard/issues/95

--- a/README.md
+++ b/README.md
@@ -162,12 +162,16 @@ repo-guard check-diff --format summary --base main --head feature
 
 1. Читает `GITHUB_EVENT_PATH`.
 2. Берет базовый и головной SHA из события pull request.
-3. Извлекает контракт из тела PR.
-4. Если контракта в PR нет, ищет ровно одну связанную issue по `Fixes #N`,
+3. Валидирует `repo-policy.json` из рабочей копии PR как предлагаемую будущую
+   политику.
+4. Читает `repo-policy.json` из базового SHA PR и использует именно эту
+   доверенную политику для проверки текущего diff.
+5. Извлекает контракт из тела PR.
+6. Если контракта в PR нет, ищет ровно одну связанную issue по `Fixes #N`,
    `Closes #N` или `Resolves owner/repo#N` и пробует взять контракт из issue.
-5. Валидирует контракт по `schemas/change-contract.schema.json`.
-6. Проверяет `git diff base...head` тем же конвейером политики, что и
-   `check-diff`.
+7. Валидирует контракт по `schemas/change-contract.schema.json`.
+8. Проверяет `git diff base...head` тем же конвейером политики, что и
+   `check-diff`, но с политикой базовой ветки.
 
 Если PR ссылается на несколько issues без контракта в PR, команда завершается
 ошибкой `issue_link_ambiguous`. Для резервного чтения связанной issue нужен
@@ -289,7 +293,7 @@ jobs:
 
 | Поле | Поведение сейчас |
 | --- | --- |
-| `paths.governance_paths` | Блокирует правки перечисленных файлов управления, пока в теле связанного issue не появится блок `repo-guard-yaml` с `authorized_governance_paths`. Граница читается из `repo-policy.json` базовой ветки, а поле `authorized_governance_paths` в PR-body-контракте игнорируется (см. раздел «Санкционирование изменений политики») |
+| `paths.governance_paths` | Блокирует правки перечисленных файлов управления, пока в теле связанного issue не появится блок `repo-guard-yaml` с `authorized_governance_paths`. В `check-pr` вся runtime-политика читается из `repo-policy.json` базовой ветки, а поле `authorized_governance_paths` в PR-body-контракте игнорируется (см. раздел «Санкционирование изменений политики») |
 | `paths.public_api` | Зарезервировано; непустое значение дает предупреждение |
 | `contract.overrides` | Зарезервировано; непустое значение дает предупреждение |
 
@@ -748,11 +752,17 @@ repo-guard doctor --integration --format summary
   доверенный, потому что редактирование issue обычно требует прав, которых у
   ИИ-агента нет.
 
-Правило сравнивает список тронутых файлов с `paths.governance_paths`, причём
-этот список читается из `repo-policy.json` **базовой ветки** (trusted base
-policy), а не из версии в текущем PR. Это закрывает обходной путь, при котором
-PR сначала сужает `governance_paths`, а потом правит файл, уже выпавший из
-нового периметра, — граница фиксируется до того, как PR успеет её подправить.
+В режиме `check-pr` весь runtime policy читается из `repo-policy.json`
+**базовой ветки** (trusted base policy), а не из версии в текущем PR. Поэтому PR
+не может ослабить `diff_rules`, `size_rules`, `content_rules` или другие
+ограничения, которые применяются к его собственному diff. Версия политики из PR
+head всё равно валидируется как предлагаемое будущее состояние, но вступает в
+силу только после merge.
+
+Семейство `governance-paths` сравнивает список тронутых файлов с
+`paths.governance_paths` из trusted base policy. Это закрывает обходной путь,
+при котором PR сначала сужает `governance_paths`, а потом правит файл, уже
+выпавший из нового периметра.
 
 `authorized_governance_paths`, указанный в контракте тела PR, намеренно
 игнорируется как источник авторизации (диагностика отметит его как
@@ -780,9 +790,8 @@ expected_effects:
 Если `repo-policy.json` базовой ветки не удаётся прочитать или распарсить
 (`git show <base>:repo-policy.json` падает, JSON невалиден и т. п.),
 `check-pr` **намеренно завершается ошибкой** (`governance-trusted-boundary`)
-вместо отката на head policy текущего PR. Без доверенной границы
-governance-решение не принимается: лучше hard fail, чем доверять mutable
-PR state.
+вместо отката на head policy текущего PR. Без доверенной base policy runtime
+не принимает решение по PR: лучше hard fail, чем доверять mutable PR state.
 
 CI также запускает:
 

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -90,7 +90,7 @@
         "governance_paths": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Canonical list of paths that define repository governance. At runtime, check-pr reads this list from the base branch of the PR (the trusted boundary) rather than from the PR's head, so a PR cannot escape governance by narrowing the list in the same diff. Changes to files that match any pattern here require the linked issue body to carry a repo-guard contract block with matching authorized_governance_paths; authorization placed in the PR body is ignored so the change is sanctioned outside the PR an AI agent can author."
+          "description": "Canonical list of paths that define repository governance. In check-pr, runtime policy is read from the base branch of the PR rather than from the PR's head, so a PR cannot relax policy rules or escape governance by narrowing this list in the same diff. Changes to files that match any pattern here require the linked issue body to carry a repo-guard contract block with matching authorized_governance_paths; authorization placed in the PR body is ignored so the change is sanctioned outside the PR an AI agent can author."
         },
         "operational_paths": {
           "type": "array",

--- a/src/git.mjs
+++ b/src/git.mjs
@@ -35,22 +35,28 @@ export function readFileAtRef(ref, path, cwd) {
   return runGit(["show", `${ref}:${path}`], { cwd });
 }
 
-export function readBaseGovernancePaths(base, cwd, policyPath = "repo-policy.json") {
-  if (!base) return { governancePaths: null, error: "no_base_ref" };
+export function readBasePolicy(base, cwd, policyPath = "repo-policy.json") {
+  if (!base) return { policy: null, error: "no_base_ref" };
   let raw;
   try {
     raw = readFileAtRef(base, policyPath, cwd);
   } catch (e) {
-    return { governancePaths: null, error: `git_show_failed: ${e.message}` };
+    return { policy: null, error: `git_show_failed: ${e.message}` };
   }
-  if (raw == null) return { governancePaths: null, error: "empty_base_policy" };
+  if (raw == null) return { policy: null, error: "empty_base_policy" };
   let parsed;
   try {
     parsed = JSON.parse(raw);
   } catch (e) {
-    return { governancePaths: null, error: `base_policy_parse_error: ${e.message}` };
+    return { policy: null, error: `base_policy_parse_error: ${e.message}` };
   }
-  const list = parsed?.paths?.governance_paths;
+  return { policy: parsed, error: null };
+}
+
+export function readBaseGovernancePaths(base, cwd, policyPath = "repo-policy.json") {
+  const result = readBasePolicy(base, cwd, policyPath);
+  if (result.error) return { governancePaths: null, error: result.error };
+  const list = result.policy?.paths?.governance_paths;
   if (!Array.isArray(list)) return { governancePaths: [], error: null };
   return { governancePaths: list, error: null };
 }

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { getDiff, readBaseGovernancePaths } from "./git.mjs";
+import { getDiff, readBasePolicy } from "./git.mjs";
 import {
   extractContract,
   extractIssueAuthorization,
@@ -9,7 +9,7 @@ import {
 } from "./markdown-contract.mjs";
 import { warnReservedContractFields } from "./policy-compiler.mjs";
 import { resolveEnforcementMode } from "./enforcement.mjs";
-import { loadPolicyRuntime, validationCheck } from "./runtime/validation.mjs";
+import { loadPolicyRuntime, loadPolicyRuntimeFromObject, validationCheck } from "./runtime/validation.mjs";
 import { runPolicyPipeline } from "./runtime/pipeline.mjs";
 
 const GITHUB_REPO_FULL_NAME = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -143,6 +143,24 @@ export function resolvePRContractFacts({ prBody, issueBody = null, linkedIssueCo
   };
 }
 
+function loadPolicyRuntimeOrExit(loadRuntime, { label, failureMessage }) {
+  let runtime;
+  try {
+    runtime = loadRuntime();
+  } catch (e) {
+    console.error(`FAIL: ${label}`);
+    console.error(`  ${e.message}`);
+    console.error(`\n${failureMessage}`);
+    process.exit(1);
+  }
+
+  if (!runtime.ok) {
+    console.error(`\n${failureMessage}`);
+    process.exit(1);
+  }
+  return runtime;
+}
+
 export function runCheckPR(roots, args = []) {
   for (const arg of args) {
     if (arg.startsWith("-")) {
@@ -174,13 +192,39 @@ export function runCheckPR(roots, args = []) {
   }
   console.log(`PR #${prNumber}: checking contract and diff (${base?.slice(0, 7)}..${head?.slice(0, 7)})`);
 
-  const runtime = loadPolicyRuntime(roots);
-  const { ajv, policy, contractSchema } = runtime;
-
-  if (!runtime.ok) {
-    console.error("\nPolicy compilation failed");
-    process.exit(1);
+  const headRuntime = loadPolicyRuntimeOrExit(
+    () => loadPolicyRuntime(roots, { label: "repo-policy.json (PR head)" }),
+    {
+      label: "repo-policy.json (PR head)",
+      failureMessage: "Proposed policy compilation failed",
+    }
+  );
+  const initialChecks = [];
+  const basePolicyRead = readBasePolicy(base, roots.repoRoot);
+  let runtime = headRuntime;
+  let trustedGovernancePaths = [];
+  if (basePolicyRead.error) {
+    initialChecks.push({
+      name: "governance-trusted-boundary",
+      check: {
+        ok: false,
+        message: `cannot establish trusted governance boundary: ${basePolicyRead.error}`,
+        hint: "check-pr requires reading repo-policy.json at the PR base via `git show <base>:repo-policy.json` so a PR cannot change the policy that evaluates itself. The boundary is intentionally not falling back to the PR head policy. Ensure the base ref is fetched and repo-policy.json is valid JSON on the base branch.",
+        details: [`base_ref: ${base}`, `base_policy_read_error: ${basePolicyRead.error}`],
+      },
+    });
+  } else {
+    runtime = loadPolicyRuntimeOrExit(
+      () => loadPolicyRuntimeFromObject(roots, basePolicyRead.policy, { label: "repo-policy.json (base)" }),
+      {
+        label: "repo-policy.json (base)",
+        failureMessage: "Base policy compilation failed",
+      }
+    );
+    trustedGovernancePaths = runtime.policy.paths?.governance_paths ?? [];
   }
+
+  const { ajv, policy, contractSchema } = runtime;
 
   const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
   if (!enforcement.ok) {
@@ -238,7 +282,6 @@ export function runCheckPR(roots, args = []) {
   let contract = null;
   let contractSource = contractResult.contractSource || "none";
   const issueAuthorization = contractResult.issueAuthorization || null;
-  const initialChecks = [];
   if (!contractResult.ok) {
     initialChecks.push({
       name: "change-contract",
@@ -265,23 +308,6 @@ export function runCheckPR(roots, args = []) {
   } catch (e) {
     console.error(`ERROR: ${e.message}`);
     process.exit(1);
-  }
-
-  const basePolicyRead = readBaseGovernancePaths(base, roots.repoRoot);
-  let trustedGovernancePaths;
-  if (basePolicyRead.error) {
-    initialChecks.push({
-      name: "governance-trusted-boundary",
-      check: {
-        ok: false,
-        message: `cannot establish trusted governance boundary: ${basePolicyRead.error}`,
-        hint: "check-pr requires reading repo-policy.json at the PR base via `git show <base>:repo-policy.json` so a PR cannot narrow the governance perimeter in the same diff. The boundary is intentionally not falling back to the PR head policy. Ensure the base ref is fetched and repo-policy.json is valid JSON on the base branch.",
-        details: [`base_ref: ${base}`, `base_policy_read_error: ${basePolicyRead.error}`],
-      },
-    });
-    trustedGovernancePaths = [];
-  } else {
-    trustedGovernancePaths = basePolicyRead.governancePaths ?? [];
   }
 
   const summary = runPolicyPipeline({

--- a/src/runtime/validation.mjs
+++ b/src/runtime/validation.mjs
@@ -48,15 +48,15 @@ export function validationCheck(ajv, schema, data, label) {
   };
 }
 
-export function loadPolicyRuntime(roots, options = {}) {
+export function loadPolicyRuntimeFromObject(roots, rawPolicy, options = {}) {
   const policySchema = loadJSON(resolve(roots.packageRoot, "schemas/repo-policy.schema.json"));
   const contractSchema = loadJSON(resolve(roots.packageRoot, "schemas/change-contract.schema.json"));
-  const rawPolicy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
   const ajv = createAjv();
   const quiet = options.quiet || false;
+  const label = options.label || "repo-policy.json";
 
   let ok = true;
-  ok = validate(ajv, policySchema, rawPolicy, "repo-policy.json", { quiet }) && ok;
+  ok = validate(ajv, policySchema, rawPolicy, label, { quiet }) && ok;
 
   const profileResult = resolvePolicyProfile(rawPolicy);
   const policy = profileResult.policy;
@@ -88,4 +88,9 @@ export function loadPolicyRuntime(roots, options = {}) {
   }
 
   return { ok, ajv, policy, contractSchema };
+}
+
+export function loadPolicyRuntime(roots, options = {}) {
+  const rawPolicy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
+  return loadPolicyRuntimeFromObject(roots, rawPolicy, options);
 }

--- a/tests/test-github-pr.mjs
+++ b/tests/test-github-pr.mjs
@@ -497,5 +497,119 @@ Feature request.
   rmSync(tmp, { recursive: true });
 }
 
+// --- check-pr evaluates rules from the trusted base policy, not the PR head policy ---
+
+{
+  const { mkdirSync } = await import("node:fs");
+  const tmp = mkdtempSync(join(tmpdir(), "rg-base-policy-rules-"));
+  execSync("git init", { cwd: tmp, stdio: "pipe" });
+  execSync("git config user.email test@test.com", { cwd: tmp, stdio: "pipe" });
+  execSync("git config user.name Test", { cwd: tmp, stdio: "pipe" });
+
+  const basePolicy = {
+    policy_format_version: "0.3.0",
+    repository_kind: "library",
+    paths: {
+      forbidden: [],
+      canonical_docs: ["README.md"],
+      governance_paths: ["repo-policy.json"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    size_rules: [
+      {
+        id: "base-max-feature-lines",
+        scope: "file",
+        metric: "lines",
+        glob: "src/feature.txt",
+        max: 0,
+        count: "changed_only",
+        level: "blocking",
+      },
+    ],
+    content_rules: [],
+    cochange_rules: [],
+  };
+
+  mkdirSync(join(tmp, "src"), { recursive: true });
+  writeFileSync(join(tmp, "README.md"), "# Test\n");
+  writeFileSync(join(tmp, "src/feature.txt"), "");
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(basePolicy, null, 2));
+  execSync("git add -A && git commit -m init", { cwd: tmp, stdio: "pipe" });
+  const baseSha = execSync("git rev-parse HEAD", { cwd: tmp, encoding: "utf-8" }).trim();
+
+  const relaxedHeadPolicy = {
+    ...basePolicy,
+    size_rules: [
+      {
+        ...basePolicy.size_rules[0],
+        max: 1000,
+      },
+    ],
+  };
+  writeFileSync(join(tmp, "repo-policy.json"), JSON.stringify(relaxedHeadPolicy, null, 2));
+  writeFileSync(join(tmp, "src/feature.txt"), "one line that base policy must reject\n");
+  execSync("git add -A && git commit -m relax-policy-and-change-feature", { cwd: tmp, stdio: "pipe" });
+
+  const prContract = {
+    change_type: "feature",
+    scope: ["repo-policy.json", "src/feature.txt"],
+    budgets: { max_new_files: 5, max_net_added_lines: 500 },
+    must_touch: [],
+    must_not_touch: [],
+    expected_effects: ["exercise base policy"],
+  };
+  const eventFile = join(tmp, "event.json");
+  writeFileSync(eventFile, JSON.stringify({
+    pull_request: {
+      number: 42,
+      base: { sha: baseSha },
+      head: { sha: "HEAD" },
+      body: "```repo-guard-json\n" + JSON.stringify(prContract) + "\n```\n\nFixes #77",
+    },
+    repository: { full_name: "owner/repo" },
+  }));
+
+  const fakeGhDir = mkdtempSync(join(tmpdir(), "rg-fake-gh-"));
+  const fakeGh = join(fakeGhDir, "gh");
+  const issueBody = [
+    "```repo-guard-yaml",
+    "authorized_governance_paths:",
+    "  - repo-policy.json",
+    "```",
+  ].join("\n");
+  writeFileSync(
+    fakeGh,
+    `#!/usr/bin/env node\nif (process.argv.includes("--version")) { console.log("gh 0.0"); process.exit(0); }\nprocess.stdout.write(${JSON.stringify(issueBody)});\n`
+  );
+  execSync(`chmod +x ${fakeGh}`);
+
+  const result = runRepoGuard(["--repo-root", tmp, "check-pr"], {
+    env: {
+      ...process.env,
+      GITHUB_EVENT_PATH: eventFile,
+      PATH: `${fakeGhDir}:${process.env.PATH}`,
+    },
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  expect(
+    "check-pr uses base policy rules: exits non-zero",
+    result.status,
+    1
+  );
+  expect(
+    "check-pr uses base policy rules: size rule fails",
+    output.includes("FAIL: size-rules"),
+    true
+  );
+  expect(
+    "check-pr uses base policy rules: reports base rule id",
+    output.includes("base-max-feature-lines"),
+    true
+  );
+
+  rmSync(tmp, { recursive: true });
+  rmSync(fakeGhDir, { recursive: true });
+}
+
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes netkeep80/repo-guard#95.

`check-pr` now validates the PR head `repo-policy.json` as the proposed future
policy, then compiles `repo-policy.json` from the PR base SHA and uses that
trusted base policy for the current diff. A PR can still update policy files
when the linked issue authorizes the governance path, but the updated policy
does not control the checks for the PR that edits it.

## What Changed

- Added a base-policy reader that parses `repo-policy.json` through `git show <base>:repo-policy.json`.
- Added a runtime loader that can compile an already-read policy object.
- Updated `check-pr` to use the base policy for enforcement and the PR head policy only for future-state validation.
- Kept the existing fail-closed behavior when the base policy cannot be read or parsed.
- Documented the trust model in `README.md` and the policy schema.
- Added a regression test where the PR relaxes a `size_rules` limit in `repo-policy.json`; the check now fails under the stricter base rule.

## Reproduction

Before this PR:

1. Base branch policy has a strict `size_rules` limit.
2. A PR edits `repo-policy.json` to relax that limit and changes a file that violates the base limit.
3. `check-pr` compiles the PR head policy and the PR can pass under its own relaxed rule.

After this PR:

1. The same PR still validates the proposed head policy.
2. The diff is evaluated with the base branch policy.
3. The base `size_rules` violation is reported, so the PR cannot relax the rule for itself.

## Tests

- `npm run test:github-pr`
- `npm run test:schemas`
- `npm run test:self-hosting`
- `npm test`

```repo-guard-yaml
change_type: bugfix
scope:
  - src/
  - tests/
  - schemas/
  - README.md
budgets:
  max_new_files: 0
  max_net_added_lines: 600
anchors:
  affects:
    - FR-014
  implements:
    - FR-014
  verifies:
    - FR-014
must_touch:
  - src/github-pr.mjs
  - src/git.mjs
  - src/runtime/validation.mjs
  - tests/test-github-pr.mjs
must_not_touch:
  - .github/
expected_effects:
  - check-pr evaluates PR diffs with repo-policy.json from the PR base branch
  - PR head repo-policy.json is still validated as the proposed future policy
  - A PR cannot relax policy limits in the same diff it is asking repo-guard to evaluate
```
