### PR TITLE
Resolve check-pr diff against the current base ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-rule-registry.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-integration-diagnostics.mjs && node tests/test-integration-fixtures.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-policy-profiles.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-release-ref.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-governance-paths.mjs && node tests/test-policy-delta-rules.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-rule-registry.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-current-base-ref.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-integration-diagnostics.mjs && node tests/test-integration-fixtures.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-policy-profiles.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-release-ref.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-governance-paths.mjs && node tests/test-policy-delta-rules.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:anchors": "node tests/test-anchor-extractors.mjs",
     "test:integration": "node tests/test-integration-extractors.mjs",
@@ -32,6 +32,7 @@
     "test:registry": "node tests/test-rule-registry.mjs",
     "test:contract": "node tests/test-markdown-contract.mjs",
     "test:github-pr": "node tests/test-github-pr.mjs",
+    "test:current-base": "node tests/test-current-base-ref.mjs",
     "test:init": "node tests/test-init.mjs",
     "test:release-ref": "node tests/test-release-ref.mjs",
     "test:doctor": "node tests/test-doctor.mjs",

--- a/src/git.mjs
+++ b/src/git.mjs
@@ -21,6 +21,18 @@ export function runGit(args, options = {}) {
   }
 }
 
+export function resolveRemoteBaseRef(baseRef, cwd, remote = "origin") {
+  if (typeof baseRef !== "string" || baseRef.length === 0) {
+    throw new Error("missing PR base ref");
+  }
+  const ref = `refs/remotes/${remote}/${baseRef}`;
+  const sha = runGit(["rev-parse", "--verify", `${ref}^{commit}`], { cwd }).trim();
+  if (!sha) {
+    throw new Error(`current base ref ${ref} resolved to an empty object id`);
+  }
+  return sha;
+}
+
 export function getDiff(base, head, cwd) {
   if (base && head) {
     return runGit(["diff", `${base}...${head}`], { cwd });

--- a/src/github-pr.mjs
+++ b/src/github-pr.mjs
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { getDiff, readBasePolicy } from "./git.mjs";
+import { getDiff, readBasePolicy, resolveRemoteBaseRef } from "./git.mjs";
 import {
   extractContract,
   extractIssueAuthorization,
@@ -38,6 +38,7 @@ export function loadGitHubEvent() {
   return {
     ok: true,
     base: pr.base?.sha,
+    baseRef: pr.base?.ref,
     head: pr.head?.sha,
     prBody: pr.body || "",
     prNumber: pr.number,
@@ -187,12 +188,28 @@ export function runCheckPR(roots, args = []) {
     process.exit(1);
   }
 
-  const { base, head, prBody, prNumber, repoFullName } = eventInfo;
-  if (!base || !head) {
+  const { base: eventBase, baseRef, head, prBody, prNumber, repoFullName } = eventInfo;
+  if (!eventBase || !head) {
     console.error("ERROR: pull_request event missing base/head SHA");
     process.exit(1);
   }
-  console.log(`PR #${prNumber}: checking contract and diff (${base?.slice(0, 7)}..${head?.slice(0, 7)})`);
+
+  let base = eventBase;
+  if (baseRef) {
+    try {
+      base = resolveRemoteBaseRef(baseRef, roots.repoRoot);
+    } catch (e) {
+      console.error(`ERROR: cannot resolve current PR base ref ${baseRef}: ${e.message}`);
+      process.exit(1);
+    }
+    if (base !== eventBase) {
+      console.log(
+        `Base ref ${baseRef} advanced from event snapshot ${eventBase.slice(0, 7)} to ${base.slice(0, 7)}; using current base`
+      );
+    }
+  }
+
+  console.log(`PR #${prNumber}: checking contract and diff (${base.slice(0, 7)}..${head.slice(0, 7)})`);
 
   const headRuntime = loadPolicyRuntimeOrExit(
     () => loadPolicyRuntime(roots, { label: "repo-policy.json (PR head)" }),
@@ -213,7 +230,7 @@ export function runCheckPR(roots, args = []) {
       check: {
         ok: false,
         message: `cannot establish trusted governance boundary: ${basePolicyRead.error}`,
-        hint: "check-pr requires reading repo-policy.json at the PR base via `git show <base>:repo-policy.json` so a PR cannot change the policy that evaluates itself. The boundary is intentionally not falling back to the PR head policy. Ensure the base ref is fetched and repo-policy.json is valid JSON on the base branch.",
+        hint: "check-pr requires reading repo-policy.json at the current PR base ref so a PR cannot change the policy that evaluates itself. The boundary is intentionally not falling back to the PR head policy. Ensure the base ref is fetched and repo-policy.json is valid JSON on the base branch.",
         details: [`base_ref: ${base}`, `base_policy_read_error: ${basePolicyRead.error}`],
       },
     });

--- a/tests/test-current-base-ref.mjs
+++ b/tests/test-current-base-ref.mjs
@@ -1,0 +1,154 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+let failures = 0;
+
+function expect(label, condition) {
+  const passed = Boolean(condition);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) failures++;
+}
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
+}
+
+function commit(cwd, message) {
+  git(cwd, "add", "-A");
+  git(cwd, "commit", "-m", message);
+  return git(cwd, "rev-parse", "HEAD");
+}
+
+function writePolicy(root) {
+  const policy = {
+    policy_format_version: "0.1.0",
+    repository_kind: "library",
+    enforcement: { mode: "blocking" },
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      governance_paths: ["governance.txt"],
+    },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
+    content_rules: [],
+    cochange_rules: [],
+  };
+  writeFileSync(join(root, "repo-policy.json"), JSON.stringify(policy, null, 2));
+}
+
+function contractBody() {
+  return [
+    "```repo-guard-yaml",
+    "change_type: bugfix",
+    "scope:",
+    "  - src/**",
+    "budgets:",
+    "  max_new_files: 5",
+    "  max_net_added_lines: 500",
+    "must_touch:",
+    "  - src/kernel.txt",
+    "must_not_touch:",
+    "  - governance.txt",
+    "expected_effects:",
+    "  - kernel change only",
+    "```",
+  ].join("\n");
+}
+
+function setupRepo() {
+  const root = mkdtempSync(join(tmpdir(), "repo-guard-current-base-"));
+  git(root, "init", "-b", "main");
+  git(root, "config", "user.email", "test@example.com");
+  git(root, "config", "user.name", "Test");
+  writePolicy(root);
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src/kernel.txt"), "base\n");
+  const oldBase = commit(root, "base");
+
+  writeFileSync(join(root, "governance.txt"), "landed-on-base\n");
+  const currentBase = commit(root, "advance base with unrelated governance");
+  git(root, "update-ref", "refs/remotes/origin/main", currentBase);
+
+  git(root, "switch", "-c", "feature");
+  writeFileSync(join(root, "src/kernel.txt"), "base\nfeature\n");
+  const head = commit(root, "feature kernel change");
+  return { root, oldBase, currentBase, head };
+}
+
+function runCheck(root, event) {
+  const eventFile = join(root, "event.json");
+  writeFileSync(eventFile, JSON.stringify(event));
+  return spawnSync(process.execPath, [repoGuard, "--repo-root", root, "--enforcement", "blocking", "check-pr"], {
+    cwd: root,
+    env: { ...process.env, GITHUB_EVENT_PATH: eventFile },
+    encoding: "utf-8",
+  });
+}
+
+{
+  const { root, oldBase, currentBase, head } = setupRepo();
+  const result = runCheck(root, {
+    pull_request: {
+      number: 100,
+      base: { sha: oldBase, ref: "main" },
+      head: { sha: head },
+      body: contractBody(),
+    },
+    repository: { full_name: "owner/repo" },
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  expect("advanced base: check-pr passes", result.status === 0);
+  expect("advanced base: diagnostic reports current base", output.includes(currentBase.slice(0, 7)));
+  expect("advanced base: old snapshot is recognized as stale", output.includes(oldBase.slice(0, 7)));
+  expect("advanced base: already-landed governance is not in PR diff", !output.includes("touched: governance.txt"));
+  rmSync(root, { recursive: true, force: true });
+}
+
+{
+  const { root, oldBase, currentBase } = setupRepo();
+  writeFileSync(join(root, "governance.txt"), "landed-on-base\nchanged-by-pr\n");
+  const head = commit(root, "feature also changes governance");
+  const result = runCheck(root, {
+    pull_request: {
+      number: 101,
+      base: { sha: oldBase, ref: "main" },
+      head: { sha: head },
+      body: contractBody(),
+    },
+    repository: { full_name: "owner/repo" },
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  expect("genuine governance delta: current base remains selected", output.includes(currentBase.slice(0, 7)));
+  expect("genuine governance delta: blocking check fails", result.status === 1);
+  expect("genuine governance delta: must-not-touch reports governance file", output.includes("governance.txt"));
+  rmSync(root, { recursive: true, force: true });
+}
+
+{
+  const { root, oldBase, head } = setupRepo();
+  const result = runCheck(root, {
+    pull_request: {
+      number: 102,
+      base: { sha: oldBase, ref: "missing-base" },
+      head: { sha: head },
+      body: contractBody(),
+    },
+    repository: { full_name: "owner/repo" },
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  expect("missing current base ref: check-pr fails closed", result.status === 1);
+  expect("missing current base ref: diagnostic is explicit", output.includes("cannot resolve current PR base ref missing-base"));
+  rmSync(root, { recursive: true, force: true });
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} current-base regression test(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll current-base regression tests passed");


### PR DESCRIPTION
## Summary

Fix `check-pr` so a long-lived PR is evaluated against the current commit of its GitHub base ref rather than a stale `pull_request.base.sha` snapshot.

The GitHub event base SHA remains useful for diagnostics, but when `pull_request.base.ref` is present the trusted boundary is resolved from `refs/remotes/origin/<baseRef>^{commit}`. Failure to resolve that current base ref is fatal. The resolved SHA is then used consistently for trusted base policy loading and diff analysis.

Fixes #100

## Change Contract

```repo-guard-yaml
change_type: bugfix
scope:
  - "src/git.mjs"
  - "src/github-pr.mjs"
  - "tests/test-current-base-ref.mjs"
  - "package.json"
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 260
must_touch:
  - "src/git.mjs"
  - "src/github-pr.mjs"
  - "tests/test-current-base-ref.mjs"
  - "package.json"
must_not_touch:
  - "schemas/**"
  - ".github/**"
  - "repo-policy.json"
expected_effects:
  - "check-pr uses the current fetched base branch head for trusted policy and diff evaluation"
  - "stale pull_request.base.sha snapshots no longer attribute already-merged base changes to the PR"
  - "an unresolvable current base ref fails closed"
  - "genuine PR governance changes remain visible to policy checks"
```

## Regression coverage

The new integration test constructs a local repository where:

1. the event snapshot base SHA is old;
2. `origin/main` advances with an unrelated governance file;
3. the feature head contains that new base plus one allowed kernel-like change.

`check-pr` must pass and report the advanced current base. A second case changes the governance file in the feature branch and must fail. A third points `base.ref` to a missing remote-tracking ref and must fail closed.