### PR TITLE
Контролировать аддитивный дрейф и язык Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "validate": "node src/repo-guard.mjs",
-    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-rule-registry.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-current-base-ref.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-integration-diagnostics.mjs && node tests/test-integration-fixtures.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-policy-profiles.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-release-ref.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-governance-paths.mjs && node tests/test-policy-delta-rules.mjs && node tests/test-self-hosting.mjs",
+    "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-compression-rules.mjs && node tests/test-rule-registry.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-current-base-ref.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-integration-diagnostics.mjs && node tests/test-integration-fixtures.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-policy-profiles.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-release-ref.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-governance-paths.mjs && node tests/test-policy-delta-rules.mjs && node tests/test-self-hosting.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:anchors": "node tests/test-anchor-extractors.mjs",
     "test:integration": "node tests/test-integration-extractors.mjs",
@@ -29,6 +29,7 @@
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
     "test:diff": "node tests/test-diff-rules.mjs",
+    "test:compression": "node tests/test-compression-rules.mjs",
     "test:registry": "node tests/test-rule-registry.mjs",
     "test:contract": "node tests/test-markdown-contract.mjs",
     "test:github-pr": "node tests/test-github-pr.mjs",

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -125,7 +125,7 @@
     },
     "size_rules": {
       "type": "array",
-      "description": "Absolute size constraints for files or directory subtrees, measured in lines or bytes.",
+      "description": "Absolute size and optional growth constraints for files or directory subtrees.",
       "items": { "$ref": "#/definitions/size_rule" }
     },
     "surfaces": {
@@ -294,22 +294,44 @@
     "content_rules": {
       "type": "array",
       "items": {
-        "type": "object",
-        "required": ["id", "glob", "mode", "forbid_regex"],
-        "additionalProperties": false,
-        "properties": {
-          "id": { "type": "string" },
-          "glob": { "type": "string" },
-          "mode": {
-            "type": "string",
-            "enum": ["added_lines"]
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["id", "glob", "mode", "forbid_regex"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "glob": { "type": "string" },
+              "mode": { "const": "added_lines" },
+              "forbid_regex": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 1
+              }
+            }
           },
-          "forbid_regex": {
-            "type": "array",
-            "items": { "type": "string" },
-            "minItems": 1
+          {
+            "type": "object",
+            "required": ["id", "glob", "mode", "language"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" },
+              "glob": { "type": "string" },
+              "mode": { "const": "markdown_language" },
+              "language": { "type": "string", "enum": ["ru"] },
+              "allow_words": {
+                "type": "array",
+                "items": { "type": "string", "minLength": 1 },
+                "uniqueItems": true
+              },
+              "max_unapproved_latin_words_per_line": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 1
+              }
+            }
           }
-        }
+        ]
       }
     },
     "cochange_rules": {
@@ -397,12 +419,16 @@
         },
         "metric": {
           "type": "string",
-          "enum": ["lines", "bytes"]
+          "enum": ["lines", "bytes", "files"]
         },
         "glob": { "$ref": "#/definitions/non_empty_string" },
         "max": {
           "type": "integer",
           "minimum": 0
+        },
+        "max_growth": {
+          "type": "integer",
+          "description": "Maximum allowed base-to-head growth for directory rules. Zero forbids growth; a negative value requires shrinkage. Supported for lines and files."
         },
         "count": {
           "type": "string",

--- a/src/checks/rules/content-rules.mjs
+++ b/src/checks/rules/content-rules.mjs
@@ -1,28 +1,87 @@
 import { matchesAny } from "../../utils/path-patterns.mjs";
+import { readRepositoryTextFile } from "../../utils/repository-files.mjs";
 
-export function checkContentRules(files, rules = []) {
+function checkRegexRule(files, rule) {
+  const violations = [];
+  const regexes = rule.forbid_regex.map((pattern) => new RegExp(pattern));
+  const glob = rule.glob || "**";
+
+  for (const file of files) {
+    if (!matchesAny(file.path, [glob])) continue;
+    for (const line of file.addedLines || []) {
+      for (let i = 0; i < regexes.length; i++) {
+        if (regexes[i].test(line)) {
+          violations.push({
+            kind: "regex",
+            rule_id: rule.id,
+            file: file.path,
+            line: line.trim(),
+            matched_regex: rule.forbid_regex[i],
+          });
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+function stripMarkdownProse(line) {
+  return line
+    .replace(/`[^`]*`/g, "")
+    .replace(/\]\([^)]*\)/g, "]")
+    .replace(/https?:\/\/\S+/g, "");
+}
+
+function markdownLanguageViolations(file, rule, options = {}) {
+  const content = readRepositoryTextFile(file.path, options);
+  const allowed = new Set(rule.allow_words || []);
+  const maxLatin = rule.max_unapproved_latin_words_per_line ?? 1;
+  const violations = [];
+  let inFence = false;
+
+  for (const [index, rawLine] of content.split(/\r?\n/).entries()) {
+    const stripped = rawLine.trim();
+    if (stripped.startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const line = stripMarkdownProse(rawLine);
+    const latin = [...line.matchAll(/(?<![\w])([A-Za-z][A-Za-z-]{2,})(?![\w])/g)]
+      .map((match) => match[1])
+      .filter((word) => !allowed.has(word));
+    const hasCyrillic = /[А-Яа-яЁё]{3,}/.test(line);
+
+    if (latin.length > maxLatin || (latin.length > 0 && !hasCyrillic)) {
+      violations.push({
+        kind: "language",
+        rule_id: rule.id,
+        file: file.path,
+        line_number: index + 1,
+        line: rawLine.trim(),
+        language: rule.language,
+        unapproved_words: latin,
+      });
+    }
+  }
+  return violations;
+}
+
+export function checkContentRules(files, rules = [], options = {}) {
   const violations = [];
 
   for (const rule of rules) {
-    if (!rule.forbid_regex || rule.mode !== "added_lines") continue;
+    if (rule.mode === "added_lines" && rule.forbid_regex) {
+      violations.push(...checkRegexRule(files, rule));
+      continue;
+    }
 
-    const regexes = rule.forbid_regex.map((pattern) => new RegExp(pattern));
-    const glob = rule.glob || "**";
-
-    for (const file of files) {
-      if (!matchesAny(file.path, [glob])) continue;
-
-      for (const line of file.addedLines) {
-        for (let i = 0; i < regexes.length; i++) {
-          if (regexes[i].test(line)) {
-            violations.push({
-              rule_id: rule.id,
-              file: file.path,
-              line: line.trim(),
-              matched_regex: rule.forbid_regex[i],
-            });
-          }
-        }
+    if (rule.mode === "markdown_language") {
+      const glob = rule.glob || "**/*.md";
+      for (const file of files) {
+        if (file.status === "deleted" || !matchesAny(file.path, [glob])) continue;
+        violations.push(...markdownLanguageViolations(file, rule, options));
       }
     }
   }
@@ -30,18 +89,31 @@ export function checkContentRules(files, rules = []) {
   return violations;
 }
 
+function formatViolation(violation) {
+  if (violation.kind === "language") {
+    return `[${violation.rule_id}] ${violation.file}:${violation.line_number}: unapproved ${violation.language} prose words: ${violation.unapproved_words.join(", ")}`;
+  }
+  return `[${violation.rule_id}] ${violation.file}: "${violation.line}" matched /${violation.matched_regex}/`;
+}
+
 export const contentRuleFamily = {
   id: "content-rules",
   evaluate(facts) {
-    const violations = checkContentRules(facts.diff.files.checked, facts.policy.content_rules);
+    const violations = checkContentRules(
+      facts.diff.files.checked,
+      facts.policy.content_rules,
+      {
+        repoRoot: facts.repositoryRoot,
+        readFile: facts.readFile,
+      }
+    );
     if (violations.length > 0) {
       return {
         name: "content-rules",
         check: {
           ok: false,
-          details: violations.map((violation) =>
-            `[${violation.rule_id}] ${violation.file}: "${violation.line}" matched /${violation.matched_regex}/`
-          ),
+          violations,
+          details: violations.map(formatViolation),
         },
       };
     }

--- a/src/checks/rules/size-rules.mjs
+++ b/src/checks/rules/size-rules.mjs
@@ -30,13 +30,13 @@ function ignoredBySizeRule(path, rule, options = {}) {
   return ignored.length > 0 && matchesAny(path, ignored);
 }
 
-function matchingSizeRulePaths(paths, rule, options = {}) {
+function matchesSizeRule(path, rule, options = {}) {
   const glob = rule.glob || "**";
-  return normalizePathList(paths).filter(
-    (path) =>
-      matchesAny(path, [glob]) &&
-      !ignoredBySizeRule(path, rule, options)
-  );
+  return matchesAny(path, [glob]) && !ignoredBySizeRule(path, rule, options);
+}
+
+function matchingSizeRulePaths(paths, rule, options = {}) {
+  return normalizePathList(paths).filter((path) => matchesSizeRule(path, rule, options));
 }
 
 function sizeRuleApplies(rule, options = {}) {
@@ -61,10 +61,21 @@ export function countTextLines(content) {
 }
 
 function measureSizeRuleFile(path, metric, options = {}) {
+  if (metric === "files") return { skipped: false, actual: 1 };
   const content = readRepositoryBufferFile(path, options);
   if (content === null) return { skipped: true, actual: 0 };
   if (metric === "bytes") return { skipped: false, actual: content.length };
   return { skipped: false, actual: countTextLines(content.toString("utf-8")) };
+}
+
+function measureDirectory(paths, rule, options = {}) {
+  if (rule.metric === "files") return paths.length;
+  let actual = 0;
+  for (const path of paths) {
+    const measured = measureSizeRuleFile(path, rule.metric, options);
+    if (!measured.skipped) actual += measured.actual;
+  }
+  return actual;
 }
 
 function directoryPathFromGlob(glob) {
@@ -78,9 +89,33 @@ function directoryPathFromGlob(glob) {
   return stableParts.length > 0 ? stableParts.join("/") : (normalized || ".");
 }
 
+function calculateGrowth(files, rule, options = {}) {
+  if (rule.max_growth === undefined) return null;
+  if (rule.scope !== "directory") {
+    throw new Error("max_growth is supported only for directory size rules");
+  }
+  if (rule.metric === "bytes") {
+    throw new Error("max_growth for bytes is not supported; use an absolute byte max together with line/file growth");
+  }
+
+  let delta = 0;
+  for (const file of files || []) {
+    if (!matchesSizeRule(file.path, rule, options)) continue;
+    if (rule.metric === "files") {
+      if (file.status === "added") delta += 1;
+      else if (file.status === "deleted") delta -= 1;
+      continue;
+    }
+    delta += (file.addedLines?.length || 0) - (file.deletedLines?.length || 0);
+  }
+  return delta;
+}
+
 function formatSizeViolation(violation) {
-  const unit = violation.metric;
-  return `[${violation.ruleId}] ${violation.path} has ${violation.actual} ${unit} (max ${violation.max})`;
+  if (violation.kind === "growth") {
+    return `[${violation.ruleId}] ${violation.path} changed ${violation.metric}: ${violation.before} -> ${violation.after} (delta ${violation.delta}, max growth ${violation.maxGrowth})`;
+  }
+  return `[${violation.ruleId}] ${violation.path} has ${violation.actual} ${violation.metric} (max ${violation.max})`;
 }
 
 export function checkSizeRules(files, rules = [], options = {}) {
@@ -91,12 +126,14 @@ export function checkSizeRules(files, rules = [], options = {}) {
       advisory_violations: [],
       failed_rules: [],
       details: [],
+      growth: [],
     };
   }
 
   const blockingViolations = [];
   const advisoryViolations = [];
   const errors = [];
+  const growthReports = [];
   const allPaths = allKnownPaths(files, options);
   const changedNonDeletedPaths = changedPaths(files);
   const changedIncludingDeletedPaths = changedPaths(files, { includeDeleted: true });
@@ -113,6 +150,9 @@ export function checkSizeRules(files, rules = [], options = {}) {
 
     try {
       if (rule.scope === "file") {
+        if (rule.metric === "files") {
+          throw new Error("metric=files is supported only for directory size rules");
+        }
         const sourcePaths = count === "changed_only" ? changedNonDeletedPaths : allPaths;
         const paths = matchingSizeRulePaths(sourcePaths, rule, options);
         for (const path of paths) {
@@ -121,6 +161,7 @@ export function checkSizeRules(files, rules = [], options = {}) {
           addViolation({
             ruleId: rule.id,
             rule_id: rule.id,
+            kind: "absolute",
             scope: "file",
             path,
             metric: rule.metric,
@@ -131,23 +172,16 @@ export function checkSizeRules(files, rules = [], options = {}) {
           });
         }
       } else if (rule.scope === "directory") {
-        if (
-          count === "changed_only" &&
-          matchingSizeRulePaths(changedIncludingDeletedPaths, rule, options).length === 0
-        ) {
-          continue;
-        }
+        const changedMatches = matchingSizeRulePaths(changedIncludingDeletedPaths, rule, options);
+        if (count === "changed_only" && changedMatches.length === 0) continue;
 
         const paths = matchingSizeRulePaths(allPaths, rule, options);
-        let actual = 0;
-        for (const path of paths) {
-          const measured = measureSizeRuleFile(path, rule.metric, options);
-          if (!measured.skipped) actual += measured.actual;
-        }
+        const actual = measureDirectory(paths, rule, options);
         if (actual > rule.max) {
           addViolation({
             ruleId: rule.id,
             rule_id: rule.id,
+            kind: "absolute",
             scope: "directory",
             path: directoryPathFromGlob(rule.glob),
             metric: rule.metric,
@@ -157,6 +191,27 @@ export function checkSizeRules(files, rules = [], options = {}) {
             level,
             files: paths,
           });
+        }
+
+        const delta = calculateGrowth(files, rule, options);
+        if (delta !== null) {
+          const report = {
+            ruleId: rule.id,
+            rule_id: rule.id,
+            scope: "directory",
+            path: directoryPathFromGlob(rule.glob),
+            metric: rule.metric,
+            before: actual - delta,
+            after: actual,
+            delta,
+            maxGrowth: rule.max_growth,
+            max_growth: rule.max_growth,
+            level,
+          };
+          growthReports.push(report);
+          if (delta > rule.max_growth) {
+            addViolation({ ...report, kind: "growth" });
+          }
         }
       }
     } catch (error) {
@@ -177,6 +232,7 @@ export function checkSizeRules(files, rules = [], options = {}) {
     details: blockingViolations.map(formatSizeViolation),
     advisory_details: advisoryViolations.map(formatSizeViolation),
     errors,
+    growth: growthReports,
   };
 }
 
@@ -205,6 +261,7 @@ export const sizeRuleFamily = {
           advisory: true,
           size_violations: result.advisory_violations,
           details: result.advisory_details,
+          growth: result.growth,
         },
       });
     }

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -94,6 +94,20 @@ expect("file-count delta is one", fileGrowth.growth[0].delta, 1);
 expect("file-count before is reconstructed", fileGrowth.growth[0].before, 1);
 expect("file-count after is current count", fileGrowth.growth[0].after, 2);
 
+const byteGrowth = checkSizeRules(balancedDiff, [{
+  id: "docs-bytes",
+  scope: "directory",
+  metric: "bytes",
+  glob: "docs/**",
+  max: 1000,
+  max_growth: 0,
+}], {
+  trackedFiles: ["docs/a.md", "docs/b.md"],
+  readFile,
+});
+expect("byte max_growth fails closed until exact base-byte measurement exists", byteGrowth.ok, false);
+expect("byte max_growth reports a read/evaluation error", byteGrowth.errors.length, 1);
+
 const russianRule = {
   id: "russian-docs",
   glob: "README.md",

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -1,0 +1,128 @@
+import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
+import { checkSizeRules } from "../src/checks/rules/size-rules.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${expected}, got: ${actual}`);
+  }
+}
+
+const currentFiles = new Map([
+  ["docs/a.md", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"],
+  ["docs/b.md", "a\nb\nc\n"],
+  ["README.md", "# Русский документ\n\nОбычный русский текст с `SomeClass` и API.\n\n```text\nCurrent production contract\n```\n"],
+]);
+
+const readFile = (path) => currentFiles.get(path) ?? null;
+
+const balancedDiff = [
+  {
+    path: "docs/a.md",
+    status: "modified",
+    addedLines: ["n1", "n2"],
+    deletedLines: ["o1", "o2", "o3", "o4", "o5"],
+  },
+  {
+    path: "docs/b.md",
+    status: "added",
+    addedLines: ["a", "b", "c"],
+    deletedLines: [],
+  },
+];
+
+const lineRule = {
+  id: "docs-lines",
+  scope: "directory",
+  metric: "lines",
+  glob: "docs/**",
+  max: 20,
+  max_growth: 0,
+};
+
+const lineResult = checkSizeRules(balancedDiff, [lineRule], {
+  trackedFiles: ["docs/a.md", "docs/b.md"],
+  readFile,
+});
+expect("line surface passes when net growth is zero", lineResult.ok, true);
+expect("line surface reports before", lineResult.growth[0].before, 13);
+expect("line surface reports after", lineResult.growth[0].after, 13);
+expect("line surface reports delta", lineResult.growth[0].delta, 0);
+
+const growingDiff = [
+  {
+    path: "docs/a.md",
+    status: "modified",
+    addedLines: ["n1", "n2"],
+    deletedLines: ["o1"],
+  },
+];
+const growingResult = checkSizeRules(growingDiff, [lineRule], {
+  trackedFiles: ["docs/a.md", "docs/b.md"],
+  readFile,
+});
+expect("line surface blocks positive growth", growingResult.ok, false);
+expect("line surface growth violation kind", growingResult.size_violations[0].kind, "growth");
+expect("line surface positive delta", growingResult.growth[0].delta, 1);
+
+const shrinkRequired = checkSizeRules(balancedDiff, [{ ...lineRule, max_growth: -1 }], {
+  trackedFiles: ["docs/a.md", "docs/b.md"],
+  readFile,
+});
+expect("negative max_growth can require shrinkage", shrinkRequired.ok, false);
+
+const fileRule = {
+  id: "contract-files",
+  scope: "directory",
+  metric: "files",
+  glob: "contracts/**",
+  max: 10,
+  max_growth: 0,
+};
+const fileGrowth = checkSizeRules([
+  { path: "contracts/new.json", status: "added", addedLines: ["{}"], deletedLines: [] },
+], [fileRule], {
+  trackedFiles: ["contracts/old.json", "contracts/new.json"],
+  readFile,
+});
+expect("file-count surface blocks a new file", fileGrowth.ok, false);
+expect("file-count delta is one", fileGrowth.growth[0].delta, 1);
+expect("file-count before is reconstructed", fileGrowth.growth[0].before, 1);
+expect("file-count after is current count", fileGrowth.growth[0].after, 2);
+
+const russianRule = {
+  id: "russian-docs",
+  glob: "README.md",
+  mode: "markdown_language",
+  language: "ru",
+  allow_words: ["API"],
+  max_unapproved_latin_words_per_line: 1,
+};
+const readmeChange = [{ path: "README.md", status: "modified", addedLines: ["изменение"], deletedLines: [] }];
+const russianResult = checkContentRules(readmeChange, [russianRule], { readFile });
+expect("Russian Markdown ignores inline/fenced code", russianResult.length, 0);
+
+currentFiles.set("README.md", "# Документ\n\nCurrent production contract.\n");
+const englishResult = checkContentRules(readmeChange, [russianRule], { readFile });
+expect("English prose is rejected", englishResult.length, 1);
+expect("language violation kind", englishResult[0].kind, "language");
+expect("language violation line", englishResult[0].line_number, 3);
+
+currentFiles.set("README.md", "# Документ\n\nИспользуется semantic contract.\n");
+const mixedResult = checkContentRules(readmeChange, [russianRule], { readFile });
+expect("multiple mixed Latin terms are rejected", mixedResult.length, 1);
+
+currentFiles.set("README.md", "# Документ\n\nИспользуется API.\n");
+const allowedResult = checkContentRules(readmeChange, [russianRule], { readFile });
+expect("allow-listed technical term passes", allowedResult.length, 0);
+
+if (failures > 0) {
+  console.error(`\n${failures} compression-rule test(s) failed`);
+  process.exit(1);
+}
+
+console.log("\nAll compression-rule tests passed");


### PR DESCRIPTION
Fixes #102.

Первый практический срез контроля аддитивного дрейфа на основе реального опыта с `anum_docs`.

## 1. Рост именованных поверхностей через существующие size_rules

`size_rules` теперь поддерживает `max_growth`: ноль запрещает рост, отрицательное значение требует сжатия, положительное допускает ограниченный рост. Результат содержит `before`, `after`, `delta`, `maxGrowth`.

Поддерживаемые относительные метрики: `lines` и `files`. Для `bytes` сохраняется абсолютный `max`; относительный byte-growth не симулируется неточно.

## 2. Русскоязычная Markdown-проза

`content_rules` получает режим `markdown_language` с `language: ru`, белым списком технических слов и пределом неразрешённых латинских слов в строке.

Проверяется целиком каждый изменённый Markdown-файл. Fenced code, inline code, URL и адреса Markdown-ссылок исключаются. Диагностика содержит файл, строку и найденные слова.

## 3. Архитектурная граница

Новой подсистемы не создано: расширены существующие `size-rules` и `content-rules`. Добавлен один общий тестовый файл для обеих возможностей и обновлена схема политики.

Это измеримые прокси когнитивного бюджета, а не эвристическая оценка «качества архитектуры».