### PR TITLE
Compression 1/9: включить self-compression gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Report architecture compression metrics
+        run: npm run compression:metrics
+
       - name: Validate repo-policy.json
         run: npx repo-guard
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "validate": "node src/repo-guard.mjs",
     "test": "node tests/validate-schemas.mjs && node tests/test-diff-rules.mjs && node tests/test-compression-rules.mjs && node tests/test-documentation-language.mjs && node tests/test-rule-registry.mjs && node tests/test-markdown-contract.mjs && node tests/test-github-pr.mjs && node tests/test-current-base-ref.mjs && node tests/test-hardening.mjs && node tests/test-anchor-extractors.mjs && node tests/test-integration-extractors.mjs && node tests/test-integration-diagnostics.mjs && node tests/test-integration-fixtures.mjs && node tests/test-trace-evidence-rules.mjs && node tests/test-policy-profiles.mjs && node tests/test-repo-root.mjs && node tests/test-init.mjs && node tests/test-release-ref.mjs && node tests/test-doctor.mjs && node tests/test-enforcement-mode.mjs && node tests/test-structured-output.mjs && node tests/test-pipeline.mjs && node tests/test-governance-paths.mjs && node tests/test-policy-delta-rules.mjs && node tests/test-self-hosting.mjs",
+    "compression:metrics": "node scripts/compression-metrics.mjs",
     "test:hardening": "node tests/test-hardening.mjs",
     "test:anchors": "node tests/test-anchor-extractors.mjs",
     "test:integration": "node tests/test-integration-extractors.mjs",

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -158,6 +158,10 @@
       "allow_unclassified_surfaces": true,
       "new_files": {
         "allow_classes": ["source", "test", "doc", "script"]
+      },
+      "budgets": {
+        "max_new_docs": 0,
+        "max_net_added_lines": 0
       }
     },
     "docs": {
@@ -183,6 +187,28 @@
       "max": 900,
       "count": "all_tracked",
       "level": "advisory"
+    },
+    {
+      "id": "refactor-source-no-growth",
+      "scope": "directory",
+      "metric": "lines",
+      "glob": "src/**",
+      "max": 50000,
+      "max_growth": 0,
+      "count": "all_tracked",
+      "level": "blocking",
+      "applies_to_change_types": ["refactor"]
+    },
+    {
+      "id": "refactor-schema-no-growth",
+      "scope": "directory",
+      "metric": "lines",
+      "glob": "schemas/**",
+      "max": 20000,
+      "max_growth": 0,
+      "count": "all_tracked",
+      "level": "blocking",
+      "applies_to_change_types": ["refactor"]
     }
   ],
   "diff_rules": {

--- a/scripts/compression-metrics.mjs
+++ b/scripts/compression-metrics.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const args = process.argv.slice(2);
+
+function argValue(name, fallback = null) {
+  const index = args.indexOf(name);
+  return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
+}
+
+const ref = argValue("--ref", "HEAD");
+const compareRef = argValue("--compare");
+
+function git(arguments_) {
+  return execFileSync("git", arguments_, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function pathsAt(targetRef, roots) {
+  const output = git(["ls-tree", "-r", "--name-only", targetRef, "--", ...roots]);
+  return output.split(/\r?\n/).filter(Boolean).sort();
+}
+
+function textAt(targetRef, path) {
+  return git(["show", `${targetRef}:${path}`]);
+}
+
+function countLines(text) {
+  if (text.length === 0) return 0;
+  const newlines = (text.match(/\n/g) || []).length;
+  return newlines + (text.endsWith("\n") ? 0 : 1);
+}
+
+function physicalMetrics(targetRef, roots) {
+  const files = pathsAt(targetRef, roots);
+  let lines = 0;
+  let bytes = 0;
+  for (const path of files) {
+    const content = textAt(targetRef, path);
+    lines += countLines(content);
+    bytes += Buffer.byteLength(content);
+  }
+  return { files: files.length, lines, bytes };
+}
+
+function jsonAt(targetRef, path) {
+  return JSON.parse(textAt(targetRef, path));
+}
+
+function ruleFamilyCount(targetRef) {
+  const text = textAt(targetRef, "src/checks/default-rule-families.mjs");
+  const match = text.match(/defaultRuleFamilies\s*=\s*\[([\s\S]*?)\]/);
+  if (!match) return 0;
+  return (match[1].match(/\b[A-Za-z][A-Za-z0-9]*RuleFamily\b/g) || []).length;
+}
+
+function markdownParserFiles(targetRef) {
+  const markers = [
+    "parseMarkdown(",
+    "FENCE_RE",
+    "markdownHeadingLevel(",
+    "stripMarkdownProse(",
+  ];
+  const files = pathsAt(targetRef, ["src"]);
+  return files.filter((path) => {
+    if (!/\.(?:mjs|js)$/.test(path)) return false;
+    const content = textAt(targetRef, path);
+    return markers.some((marker) => content.includes(marker));
+  });
+}
+
+function architectureMetrics(targetRef) {
+  const policy = jsonAt(targetRef, "repo-policy.json");
+  const pkg = jsonAt(targetRef, "package.json");
+  const coverage = jsonAt(targetRef, "docs/self-hosting-coverage.json");
+  const coverageText = JSON.stringify(coverage);
+  const testCommand = pkg.scripts?.test || "";
+  const parserFiles = markdownParserFiles(targetRef);
+
+  return {
+    ref: targetRef,
+    physical: {
+      src: physicalMetrics(targetRef, ["src"]),
+      schemas: physicalMetrics(targetRef, ["schemas"]),
+      tests: physicalMetrics(targetRef, ["tests"]),
+    },
+    architecture: {
+      rule_families: ruleFamilyCount(targetRef),
+      declared_surfaces: Object.keys(policy.surfaces || {}).length,
+      declared_new_file_classes: Object.keys(policy.new_file_classes || {}).length,
+      markdown_parser_files: parserFiles.length,
+      markdown_parser_paths: parserFiles,
+      manual_test_script_entries: (testCommand.match(/node\s+tests\//g) || []).length,
+      self_hosting_status_entries: (coverageText.match(/"status":/g) || []).length,
+    },
+  };
+}
+
+function subtract(after, before) {
+  if (typeof after === "number" && typeof before === "number") return after - before;
+  if (after && before && typeof after === "object" && typeof before === "object" && !Array.isArray(after) && !Array.isArray(before)) {
+    const result = {};
+    for (const key of Object.keys(after)) {
+      if (Object.hasOwn(before, key)) result[key] = subtract(after[key], before[key]);
+    }
+    return result;
+  }
+  return undefined;
+}
+
+const current = architectureMetrics(ref);
+if (!compareRef) {
+  console.log(JSON.stringify(current, null, 2));
+} else {
+  const baseline = architectureMetrics(compareRef);
+  console.log(JSON.stringify({ baseline, current, delta: subtract(current, baseline) }, null, 2));
+}


### PR DESCRIPTION
Fixes #108
Parent: #107

Первый gate Architecture Compression. Добавляет воспроизводимый measurement script, включает его в CI и, главное, делает сжатие исполняемым правилом самого `repo-guard`: для `change_type: refactor` чистый рост строк запрещён, а `src/**` и `schemas/**` получают blocking `max_growth: 0`.

Baseline не хранится как вручную синхронизируемая таблица: `compression:metrics` умеет измерять любой git ref и сравнивать его с другим ref через `--compare`. Поэтому финальный audit сможет вычислить `e50d3ce... → final` непосредственно из Git-истории.

```repo-guard-yaml
change_type: feature
scope:
  - repo-policy.json
  - package.json
  - scripts/compression-metrics.mjs
  - .github/workflows/ci.yml
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 400
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - repo-policy.json
must_not_touch:
  - schemas/**
expected_effects:
  - последующие refactor PR автоматически блокируются при положительном net growth
  - src и schemas не могут расти в refactor без смены типа/явного governance решения
  - архитектурные метрики воспроизводимы для любого git ref
```