### PR TITLE
Сохранять UTF-8 пути в git diff

### DIFF
--- a/src/git.mjs
+++ b/src/git.mjs
@@ -8,6 +8,17 @@ function childProcessMessage(error) {
   return error?.message || "command failed";
 }
 
+function gitSubcommand(args) {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "-c") {
+      i++;
+      continue;
+    }
+    if (!args[i].startsWith("-")) return args[i];
+  }
+  return "";
+}
+
 export function runGit(args, options = {}) {
   try {
     return execFileSync("git", args, {
@@ -16,7 +27,8 @@ export function runGit(args, options = {}) {
       stdio: options.stdio || "pipe",
     });
   } catch (error) {
-    const subcommand = args[0] ? ` ${args[0]}` : "";
+    const command = gitSubcommand(args);
+    const subcommand = command ? ` ${command}` : "";
     throw new Error(`git${subcommand} failed: ${childProcessMessage(error)}`);
   }
 }

--- a/src/git.mjs
+++ b/src/git.mjs
@@ -33,13 +33,17 @@ export function resolveRemoteBaseRef(baseRef, cwd, remote = "origin") {
   return sha;
 }
 
+function diffArgs(...args) {
+  return ["-c", "core.quotepath=false", "diff", ...args];
+}
+
 export function getDiff(base, head, cwd) {
   if (base && head) {
-    return runGit(["diff", `${base}...${head}`], { cwd });
+    return runGit(diffArgs(`${base}...${head}`), { cwd });
   }
-  const staged = runGit(["diff", "--cached"], { cwd });
+  const staged = runGit(diffArgs("--cached"), { cwd });
   if (staged.trim()) return staged;
-  return runGit(["diff", "HEAD"], { cwd });
+  return runGit(diffArgs("HEAD"), { cwd });
 }
 
 export function readFileAtRef(ref, path, cwd) {

--- a/tests/test-current-base-ref.mjs
+++ b/tests/test-current-base-ref.mjs
@@ -61,6 +61,26 @@ function contractBody() {
   ].join("\n");
 }
 
+function unicodeContractBody() {
+  return [
+    "```repo-guard-yaml",
+    "change_type: docs",
+    "scope:",
+    "  - docs/**",
+    "budgets:",
+    "  max_new_files: 5",
+    "  max_new_docs: 5",
+    "  max_net_added_lines: 500",
+    "must_touch:",
+    "  - docs/theory/Основания МТС.md",
+    "must_not_touch:",
+    "  - governance.txt",
+    "expected_effects:",
+    "  - UTF-8 path is preserved",
+    "```",
+  ].join("\n");
+}
+
 function setupRepo() {
   const root = mkdtempSync(join(tmpdir(), "repo-guard-current-base-"));
   git(root, "init", "-b", "main");
@@ -144,6 +164,26 @@ function runCheck(root, event) {
   const output = `${result.stdout || ""}${result.stderr || ""}`;
   expect("missing current base ref: check-pr fails closed", result.status === 1);
   expect("missing current base ref: diagnostic is explicit", output.includes("cannot resolve current PR base ref missing-base"));
+  rmSync(root, { recursive: true, force: true });
+}
+
+{
+  const { root, oldBase } = setupRepo();
+  mkdirSync(join(root, "docs/theory"), { recursive: true });
+  writeFileSync(join(root, "docs/theory/Основания МТС.md"), "# Основания МТС\n");
+  const head = commit(root, "add Cyrillic documentation path");
+  const result = runCheck(root, {
+    pull_request: {
+      number: 103,
+      base: { sha: oldBase, ref: "main" },
+      head: { sha: head },
+      body: unicodeContractBody(),
+    },
+    repository: { full_name: "owner/repo" },
+  });
+  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  expect("UTF-8 diff path: check-pr passes", result.status === 0);
+  expect("UTF-8 diff path: must-touch does not lose Cyrillic filename", !output.includes("FAIL: must-touch"));
   rmSync(root, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
Fixes #119.

Боевой запуск в `anum_docs#291` показал, что Git quoting ломает кириллические пути до стадии `must_touch`.

Исправление делается в единой точке: `getDiff()` теперь запускает `git -c core.quotepath=false diff ...`, поэтому все семейства правил получают реальные UTF-8 пути.

В существующий `test-current-base-ref.mjs` добавлена end-to-end регрессия с `docs/theory/Основания МТС.md` в `must_touch`. Новых файлов и схем нет.