### PR TITLE
Compression 3/9: сделать RepositoryFacts каноническим источником

### DIFF
--- a/src/checks/rules/change-profiles.mjs
+++ b/src/checks/rules/change-profiles.mjs
@@ -1,223 +1,107 @@
 import { classifyNewFiles, detectTouchedSurfaces } from "../../diff/classification.mjs";
 import { formatList, uniqueSorted } from "../../utils/collections.mjs";
-import {
-  checkCanonicalDocsBudget,
-  checkNetAddedLinesBudget,
-  checkNewFilesBudget,
-} from "./budgets.mjs";
+import { checkCanonicalDocsBudget, checkNetAddedLinesBudget, checkNewFilesBudget } from "./budgets.mjs";
 
-function checkProfileNewFiles(files, newFileClasses, newFilesRule, changeType) {
-  if (!newFilesRule) return { ok: true };
-
-  const detected = classifyNewFiles(files, newFileClasses || {});
+function checkProfileNewFiles(files, classes, rule, changeType, detected = null) {
+  if (!rule) return { ok: true };
+  detected ||= classifyNewFiles(files, classes || {});
   const newFiles = detected.new_files;
+  if (newFiles.length === 0) return {
+    ok: true, change_type: changeType, new_files: newFiles,
+    files_by_class: detected.files_by_class, unclassified_files: detected.unclassified_files,
+  };
 
-  if (newFiles.length === 0) {
-    return {
-      ok: true,
-      change_type: changeType,
-      new_files: newFiles,
-      files_by_class: detected.files_by_class,
-      unclassified_files: detected.unclassified_files,
-    };
-  }
-
-  const allowedClasses = uniqueSorted(newFilesRule.allow_classes || []);
-  const allowedSet = new Set(allowedClasses);
+  const allowedClasses = uniqueSorted(rule.allow_classes || []);
+  const allowed = new Set(allowedClasses);
   const touchedClasses = uniqueSorted(Object.keys(detected.files_by_class));
-  const violatingClasses = allowedClasses.length > 0
-    ? touchedClasses.filter((fileClass) => !allowedSet.has(fileClass))
-    : touchedClasses;
+  const violatingClasses = allowedClasses.length ? touchedClasses.filter((name) => !allowed.has(name)) : touchedClasses;
   const unclassifiedFiles = detected.unclassified_files;
-  const hasUnclassifiedViolation = unclassifiedFiles.length > 0;
-  const classBudgetViolations = [];
-
-  for (const [fileClass, limit] of Object.entries(newFilesRule.max_per_class || {})) {
-    const actual = (detected.files_by_class[fileClass] || []).length;
-    if (actual > limit) {
-      classBudgetViolations.push({
-        class: fileClass,
-        actual,
-        limit,
-        files: detected.files_by_class[fileClass],
-      });
-    }
-  }
-
-  const maxNewFiles = newFilesRule.max_new_files;
-  const exceedsMaxNewFiles = maxNewFiles !== undefined && newFiles.length > maxNewFiles;
+  const classBudgetViolations = Object.entries(rule.max_per_class || {}).flatMap(([fileClass, limit]) => {
+    const filesInClass = detected.files_by_class[fileClass] || [];
+    return filesInClass.length > limit ? [{ class: fileClass, actual: filesInClass.length, limit, files: filesInClass }] : [];
+  });
+  const exceedsMax = rule.max_new_files !== undefined && newFiles.length > rule.max_new_files;
   const details = [
-    ...violatingClasses.map(
-      (fileClass) => `class ${fileClass} is not allowed by change_profiles["${changeType}"].new_files.allow_classes; files: ${detected.files_by_class[fileClass].join(", ")}`
-    ),
-    ...unclassifiedFiles.map(
-      (file) => `file ${file} detected class: unclassified; violated rule: change_profiles["${changeType}"].new_files.allow_classes`
-    ),
-    ...classBudgetViolations.map(
-      (violation) => `class ${violation.class} has ${violation.actual} new file(s), limit ${violation.limit}; files: ${violation.files.join(", ")}`
-    ),
+    ...violatingClasses.map((name) => `class ${name} is not allowed by change_profiles["${changeType}"].new_files.allow_classes; files: ${detected.files_by_class[name].join(", ")}`),
+    ...unclassifiedFiles.map((file) => `file ${file} detected class: unclassified; violated rule: change_profiles["${changeType}"].new_files.allow_classes`),
+    ...classBudgetViolations.map((v) => `class ${v.class} has ${v.actual} new file(s), limit ${v.limit}; files: ${v.files.join(", ")}`),
   ];
-  if (exceedsMaxNewFiles) {
-    details.push(`new files ${newFiles.length} exceeds change_profiles["${changeType}"].new_files.max_new_files ${maxNewFiles}`);
-  }
-
-  let message;
-  if (violatingClasses.length > 0) {
-    message = `change_type "${changeType}" cannot add new-file classes: ${violatingClasses.join(", ")}`;
-  } else if (hasUnclassifiedViolation) {
-    message = `change_profiles["${changeType}"].new_files found added files that match no declared new_file_class: ${unclassifiedFiles.join(", ")}`;
-  } else if (classBudgetViolations.length > 0 || exceedsMaxNewFiles) {
-    message = `change_type "${changeType}" exceeds change_profiles["${changeType}"].new_files budget`;
-  }
+  if (exceedsMax) details.push(`new files ${newFiles.length} exceeds change_profiles["${changeType}"].new_files.max_new_files ${rule.max_new_files}`);
+  const ok = violatingClasses.length === 0 && unclassifiedFiles.length === 0 && classBudgetViolations.length === 0 && !exceedsMax;
+  const message = violatingClasses.length
+    ? `change_type "${changeType}" cannot add new-file classes: ${violatingClasses.join(", ")}`
+    : unclassifiedFiles.length
+      ? `change_profiles["${changeType}"].new_files found added files that match no declared new_file_class: ${unclassifiedFiles.join(", ")}`
+      : !ok ? `change_type "${changeType}" exceeds change_profiles["${changeType}"].new_files budget` : undefined;
 
   return {
-    ok: violatingClasses.length === 0 && !hasUnclassifiedViolation && classBudgetViolations.length === 0 && !exceedsMaxNewFiles,
-    message,
-    change_type: changeType,
-    new_files: newFiles,
-    actual: exceedsMaxNewFiles ? newFiles.length : undefined,
-    limit: exceedsMaxNewFiles ? maxNewFiles : undefined,
-    allowed_classes: allowedClasses,
-    touched_classes: touchedClasses,
-    violating_classes: violatingClasses,
-    class_budget_violations: classBudgetViolations,
-    files_by_class: detected.files_by_class,
-    unclassified_files: unclassifiedFiles,
-    details,
-    hint: hasUnclassifiedViolation
-      ? "Add matching new_file_classes globs or update the change_profile.new_files.allow_classes."
-      : undefined,
+    ok, message, change_type: changeType, new_files: newFiles,
+    actual: exceedsMax ? newFiles.length : undefined,
+    limit: exceedsMax ? rule.max_new_files : undefined,
+    allowed_classes: allowedClasses, touched_classes: touchedClasses, violating_classes: violatingClasses,
+    class_budget_violations: classBudgetViolations, files_by_class: detected.files_by_class,
+    unclassified_files: unclassifiedFiles, details,
+    hint: unclassifiedFiles.length ? "Add matching new_file_classes globs or update the change_profile.new_files.allow_classes." : undefined,
   };
 }
 
-export function checkChangeProfile(files, policy, changeType) {
-  const changeProfiles = policy.change_profiles || {};
-  if (Object.keys(changeProfiles).length === 0) return { ok: true };
+export function checkChangeProfile(files, policy, changeType, derived = {}) {
+  const profiles = policy.change_profiles || {};
+  if (Object.keys(profiles).length === 0) return { ok: true };
+  if (!changeType) return { ok: false, message: "change_profiles requires a declared change_type", change_type: null, hint: "Set change_type in the contract." };
+  const profile = profiles[changeType];
+  if (!profile) return {
+    ok: false, message: `change_type "${changeType}" is not defined in change_profiles`, change_type: changeType,
+    details: [`known change types: ${formatList(Object.keys(profiles).sort())}`],
+    hint: "Define the change type in change_profiles or use one of the configured types.",
+  };
 
-  const changeTypeValue = changeType || null;
-  if (!changeTypeValue) {
-    return {
-      ok: false,
-      message: "change_profiles requires a declared change_type",
-      change_type: null,
-      hint: "Set change_type in the contract.",
-    };
-  }
-
-  const profile = changeProfiles[changeTypeValue];
-  if (!profile) {
-    return {
-      ok: false,
-      message: `change_type "${changeTypeValue}" is not defined in change_profiles`,
-      change_type: changeTypeValue,
-      details: [`known change types: ${formatList(Object.keys(changeProfiles).sort())}`],
-      hint: "Define the change type in change_profiles or use one of the configured types.",
-    };
-  }
-
-  const detectedSurfaces = detectTouchedSurfaces(files, policy.surfaces);
-  const touchedSurfaces = detectedSurfaces.touched_surfaces;
-  const requiredSurfaces = uniqueSorted(profile.require_surfaces || []);
-  const allowedSurfaces = uniqueSorted(profile.allow_surfaces || []);
-  const forbiddenSurfaces = uniqueSorted(profile.forbid_surfaces || []);
-  const allowedSet = new Set(allowedSurfaces);
-  const forbiddenSet = new Set(forbiddenSurfaces);
-  const touchedSet = new Set(touchedSurfaces);
-  const usesSurfaceConstraints = requiredSurfaces.length > 0 ||
-    allowedSurfaces.length > 0 ||
-    forbiddenSurfaces.length > 0;
-  const unclassifiedFiles = detectedSurfaces.unclassified_files;
-  const allowUnclassifiedSurfaces = Boolean(profile.allow_unclassified_surfaces);
-  const hasUnclassifiedViolation = usesSurfaceConstraints &&
-    unclassifiedFiles.length > 0 &&
-    !allowUnclassifiedSurfaces;
-  const missingRequiredSurfaces = requiredSurfaces.filter((surface) => !touchedSet.has(surface));
-  const notAllowedSurfaces = allowedSurfaces.length > 0
-    ? touchedSurfaces.filter((surface) => !allowedSet.has(surface))
-    : [];
-  const explicitlyForbiddenSurfaces = touchedSurfaces.filter((surface) => forbiddenSet.has(surface));
-  const violatingSurfaces = uniqueSorted([...notAllowedSurfaces, ...explicitlyForbiddenSurfaces]);
-
-  const newFileResult = checkProfileNewFiles(
-    files,
-    policy.new_file_classes,
-    profile.new_files,
-    changeTypeValue
-  );
-
+  const detected = derived.touchedSurfaces || detectTouchedSurfaces(files, policy.surfaces);
+  const touched = detected.touched_surfaces;
+  const required = uniqueSorted(profile.require_surfaces || []);
+  const allowed = uniqueSorted(profile.allow_surfaces || []);
+  const forbidden = uniqueSorted(profile.forbid_surfaces || []);
+  const touchedSet = new Set(touched);
+  const usesConstraints = required.length + allowed.length + forbidden.length > 0;
+  const hasUnclassified = usesConstraints && detected.unclassified_files.length > 0 && !profile.allow_unclassified_surfaces;
+  const missing = required.filter((surface) => !touchedSet.has(surface));
+  const violating = uniqueSorted([
+    ...(allowed.length ? touched.filter((surface) => !allowed.includes(surface)) : []),
+    ...touched.filter((surface) => forbidden.includes(surface)),
+  ]);
+  const newFiles = checkProfileNewFiles(files, policy.new_file_classes, profile.new_files, changeType, derived.newFileClasses);
   const budgets = profile.budgets || {};
   const docsBudget = checkCanonicalDocsBudget(files, policy.paths.canonical_docs, budgets.max_new_docs);
   const newFilesBudget = checkNewFilesBudget(files, budgets.max_new_files);
   const netLinesBudget = checkNetAddedLinesBudget(files, budgets.max_net_added_lines);
-
   const details = [
-    ...missingRequiredSurfaces.map(
-      (surface) => `required surface ${surface} was not touched by change_profiles["${changeTypeValue}"].require_surfaces`
-    ),
-    ...violatingSurfaces.map(
-      (surface) => `surface ${surface} violated change_profiles["${changeTypeValue}"] surface constraints; files: ${detectedSurfaces.files_by_surface[surface].join(", ")}`
-    ),
+    ...missing.map((surface) => `required surface ${surface} was not touched by change_profiles["${changeType}"].require_surfaces`),
+    ...violating.map((surface) => `surface ${surface} violated change_profiles["${changeType}"] surface constraints; files: ${detected.files_by_surface[surface].join(", ")}`),
   ];
-  if (hasUnclassifiedViolation) {
-    details.push(`changed files matched no declared surface: ${unclassifiedFiles.join(", ")}`);
-  }
-  if (!docsBudget.ok) {
-    details.push(`new docs ${docsBudget.actual} exceeds change_profiles["${changeTypeValue}"].budgets.max_new_docs ${docsBudget.limit}; files: ${docsBudget.files.join(", ")}`);
-  }
-  if (!newFilesBudget.ok) {
-    details.push(`new files ${newFilesBudget.actual} exceeds change_profiles["${changeTypeValue}"].budgets.max_new_files ${newFilesBudget.limit}; files: ${newFilesBudget.files.join(", ")}`);
-  }
-  if (!netLinesBudget.ok) {
-    details.push(`net added lines ${netLinesBudget.actual} exceeds change_profiles["${changeTypeValue}"].budgets.max_net_added_lines ${netLinesBudget.limit}`);
-  }
-  if (!newFileResult.ok) {
-    details.push(...(newFileResult.details || [newFileResult.message]).filter(Boolean));
-  }
-
-  const ok = missingRequiredSurfaces.length === 0 &&
-    violatingSurfaces.length === 0 &&
-    !hasUnclassifiedViolation &&
-    docsBudget.ok &&
-    newFilesBudget.ok &&
-    netLinesBudget.ok &&
-    newFileResult.ok;
+  if (hasUnclassified) details.push(`changed files matched no declared surface: ${detected.unclassified_files.join(", ")}`);
+  if (!docsBudget.ok) details.push(`new docs ${docsBudget.actual} exceeds change_profiles["${changeType}"].budgets.max_new_docs ${docsBudget.limit}; files: ${docsBudget.files.join(", ")}`);
+  if (!newFilesBudget.ok) details.push(`new files ${newFilesBudget.actual} exceeds change_profiles["${changeType}"].budgets.max_new_files ${newFilesBudget.limit}; files: ${newFilesBudget.files.join(", ")}`);
+  if (!netLinesBudget.ok) details.push(`net added lines ${netLinesBudget.actual} exceeds change_profiles["${changeType}"].budgets.max_net_added_lines ${netLinesBudget.limit}`);
+  if (!newFiles.ok) details.push(...(newFiles.details || [newFiles.message]).filter(Boolean));
+  const ok = missing.length === 0 && violating.length === 0 && !hasUnclassified && docsBudget.ok && newFilesBudget.ok && netLinesBudget.ok && newFiles.ok;
 
   return {
-    ok,
-    message: ok ? undefined : `change_type "${changeTypeValue}" violated change_profiles`,
-    change_type: changeTypeValue,
-    touched_surfaces: touchedSurfaces,
-    required_surfaces: requiredSurfaces,
-    allowed_surfaces: allowedSurfaces,
-    forbidden_surfaces: forbiddenSurfaces,
-    missing_required_surfaces: missingRequiredSurfaces,
-    violating_surfaces: violatingSurfaces,
-    files_by_surface: detectedSurfaces.files_by_surface,
-    unclassified_files: unclassifiedFiles,
-    docs_budget: docsBudget,
-    new_files_budget: newFilesBudget,
-    net_added_lines_budget: netLinesBudget,
-    new_files: newFileResult,
-    details,
-    hint: hasUnclassifiedViolation
-      ? "Add matching surface globs or set change_profiles[change_type].allow_unclassified_surfaces: true."
-      : undefined,
+    ok, message: ok ? undefined : `change_type "${changeType}" violated change_profiles`, change_type: changeType,
+    touched_surfaces: touched, required_surfaces: required, allowed_surfaces: allowed, forbidden_surfaces: forbidden,
+    missing_required_surfaces: missing, violating_surfaces: violating, files_by_surface: detected.files_by_surface,
+    unclassified_files: detected.unclassified_files, docs_budget: docsBudget, new_files_budget: newFilesBudget,
+    net_added_lines_budget: netLinesBudget, new_files: newFiles, details,
+    hint: hasUnclassified ? "Add matching surface globs or set change_profiles[change_type].allow_unclassified_surfaces: true." : undefined,
   };
 }
 
 export const changeProfileRuleFamily = {
   id: "change-profiles",
-  applies(facts) {
-    return Boolean(facts.policy.change_profiles);
-  },
+  applies: (facts) => Boolean(facts.policy.change_profiles),
   evaluate(facts) {
     return {
       name: "change-profiles",
-      check: checkChangeProfile(
-        facts.diff.files.checked,
-        facts.policy,
-        facts.contract?.change_type
-      ),
+      check: checkChangeProfile(facts.diff.files.checked, facts.policy, facts.contract?.change_type, facts.derived),
     };
   },
 };

--- a/src/extractors/anchors.mjs
+++ b/src/extractors/anchors.mjs
@@ -11,9 +11,7 @@ function candidateAnchorFiles(options) {
 
 function buildLineStarts(content) {
   const starts = [0];
-  for (let i = 0; i < content.length; i++) {
-    if (content[i] === "\n") starts.push(i + 1);
-  }
+  for (let i = 0; i < content.length; i++) if (content[i] === "\n") starts.push(i + 1);
   return starts;
 }
 
@@ -26,25 +24,18 @@ function positionAt(lineStarts, index) {
     else high = mid - 1;
   }
   const lineIndex = Math.max(0, high);
-  return {
-    line: lineIndex + 1,
-    column: index - lineStarts[lineIndex] + 1,
-  };
+  return { line: lineIndex + 1, column: index - lineStarts[lineIndex] + 1 };
 }
 
 function makeRegex(pattern) {
   const compiled = new RegExp(pattern);
   let flags = compiled.flags;
-  for (const flag of ["g", "d"]) {
-    if (!flags.includes(flag)) flags += flag;
-  }
+  for (const flag of ["g", "d"]) if (!flags.includes(flag)) flags += flag;
   return new RegExp(compiled.source, flags);
 }
 
 function firstDefinedCapture(match) {
-  for (let i = 1; i < match.length; i++) {
-    if (match[i] !== undefined) return i;
-  }
+  for (let i = 1; i < match.length; i++) if (match[i] !== undefined) return i;
   return null;
 }
 
@@ -52,28 +43,18 @@ function extractRegexAnchors(anchorType, source, file, content) {
   const instances = [];
   const regex = makeRegex(source.pattern);
   const lineStarts = buildLineStarts(content);
-
   for (const match of content.matchAll(regex)) {
     const captureGroup = firstDefinedCapture(match);
     const value = captureGroup ? match[captureGroup] : match[0];
-    const index = captureGroup && match.indices?.[captureGroup]
-      ? match.indices[captureGroup][0]
-      : match.index;
+    const index = captureGroup && match.indices?.[captureGroup] ? match.indices[captureGroup][0] : match.index;
     const position = positionAt(lineStarts, index);
     const instance = {
-      anchorType,
-      value: String(value),
-      file,
-      sourceKind: "regex",
-      line: position.line,
-      column: position.column,
-      raw: match[0],
+      anchorType, value: String(value), file, sourceKind: "regex",
+      line: position.line, column: position.column, raw: match[0],
     };
-
     if (captureGroup) instance.captureGroup = captureGroup;
     instances.push(instance);
   }
-
   return instances;
 }
 
@@ -81,54 +62,29 @@ function extractJsonFieldAnchor(anchorType, source, file, content) {
   let data;
   try {
     data = JSON.parse(content);
-  } catch (e) {
-    throw new Error(`invalid JSON: ${e.message}`);
+  } catch (error) {
+    throw new Error(`invalid JSON: ${error.message}`);
   }
-  if (data === null || Array.isArray(data) || typeof data !== "object") {
-    throw new Error("json_field extractor requires a top-level JSON object");
-  }
-  if (!Object.hasOwn(data, source.field)) {
-    throw new Error(`field "${source.field}" not found`);
-  }
-
+  if (data === null || Array.isArray(data) || typeof data !== "object") throw new Error("json_field extractor requires a top-level JSON object");
+  if (!Object.hasOwn(data, source.field)) throw new Error(`field "${source.field}" not found`);
   const value = data[source.field];
-  if (value === null || typeof value === "object") {
-    throw new Error(`field "${source.field}" must be a string, number, or boolean`);
-  }
-
-  return [{
-    anchorType,
-    value: String(value),
-    file,
-    sourceKind: "json_field",
-    raw: String(value),
-  }];
+  if (value === null || typeof value === "object") throw new Error(`field "${source.field}" must be a string, number, or boolean`);
+  return [{ anchorType, value: String(value), file, sourceKind: "json_field", raw: String(value) }];
 }
 
 function compareInstances(a, b) {
-  return a.file.localeCompare(b.file) ||
-    (a.line || 0) - (b.line || 0) ||
-    (a.column || 0) - (b.column || 0) ||
-    a.anchorType.localeCompare(b.anchorType) ||
-    a.value.localeCompare(b.value);
+  return a.file.localeCompare(b.file) || (a.line || 0) - (b.line || 0) ||
+    (a.column || 0) - (b.column || 0) || a.anchorType.localeCompare(b.anchorType) || a.value.localeCompare(b.value);
 }
 
 function compareErrors(a, b) {
-  return (a.file || "").localeCompare(b.file || "") ||
-    a.anchorType.localeCompare(b.anchorType) ||
-    a.sourceIndex - b.sourceIndex ||
-    a.message.localeCompare(b.message);
+  return (a.file || "").localeCompare(b.file || "") || a.anchorType.localeCompare(b.anchorType) ||
+    a.sourceIndex - b.sourceIndex || a.message.localeCompare(b.message);
 }
 
 function groupByType(anchorTypes, instances) {
-  const byType = {};
-  for (const anchorType of Object.keys(anchorTypes).sort()) {
-    byType[anchorType] = [];
-  }
-  for (const instance of instances) {
-    if (!byType[instance.anchorType]) byType[instance.anchorType] = [];
-    byType[instance.anchorType].push(instance);
-  }
+  const byType = Object.fromEntries(Object.keys(anchorTypes).sort().map((type) => [type, []]));
+  for (const instance of instances) (byType[instance.anchorType] ||= []).push(instance);
   return byType;
 }
 
@@ -137,55 +93,28 @@ export function extractAnchors(policy, options = {}) {
   const files = candidateAnchorFiles(options);
   const instances = [];
   const errors = [];
-  const contentCache = new Map();
-
-  function contentFor(file) {
-    if (!contentCache.has(file)) {
-      contentCache.set(file, readRepositoryTextFile(file, options));
-    }
-    return contentCache.get(file);
-  }
-
   for (const [anchorType, config] of Object.entries(anchorTypes)) {
     for (const [sourceIndex, source] of (config.sources || []).entries()) {
-      const sourceFiles = files.filter((file) => matchesAny(file, [source.glob]));
-      for (const file of sourceFiles) {
+      for (const file of files.filter((path) => matchesAny(path, [source.glob]))) {
         try {
-          const content = contentFor(file);
-          if (source.kind === "regex") {
-            instances.push(...extractRegexAnchors(anchorType, source, file, content));
-          } else if (source.kind === "json_field") {
-            instances.push(...extractJsonFieldAnchor(anchorType, source, file, content));
-          } else {
-            throw new Error(`unsupported anchor source kind "${source.kind}"`);
-          }
-        } catch (e) {
-          errors.push({
-            anchorType,
-            sourceKind: source.kind,
-            sourceIndex,
-            file,
-            message: e.message,
-          });
+          const content = readRepositoryTextFile(file, options);
+          if (source.kind === "regex") instances.push(...extractRegexAnchors(anchorType, source, file, content));
+          else if (source.kind === "json_field") instances.push(...extractJsonFieldAnchor(anchorType, source, file, content));
+          else throw new Error(`unsupported anchor source kind "${source.kind}"`);
+        } catch (error) {
+          errors.push({ anchorType, sourceKind: source.kind, sourceIndex, file, message: error.message });
         }
       }
     }
   }
-
   instances.sort(compareInstances);
   errors.sort(compareErrors);
-
-  return {
-    instances,
-    byType: groupByType(anchorTypes, instances),
-    errors,
-  };
+  return { instances, byType: groupByType(anchorTypes, instances), errors };
 }
 
 export function formatAnchorExtractionError(error) {
   const source = `${error.sourceKind} source ${error.sourceIndex}`;
-  const file = error.file ? `${error.file}: ` : "";
-  return `[${error.anchorType} ${source}] ${file}${error.message}`;
+  return `[${error.anchorType} ${source}] ${error.file ? `${error.file}: ` : ""}${error.message}`;
 }
 
 export function checkAnchorExtraction(anchorExtraction) {

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -4,86 +4,53 @@ import { filterOperationalPaths } from "../diff/filters.mjs";
 import { parseDiff } from "../diff/parser.mjs";
 import { extractAnchors } from "../extractors/anchors.mjs";
 import { extractIntegration } from "../extractors/integration.mjs";
+import { readRepositoryBufferFile } from "../utils/repository-files.mjs";
 
 export function listTrackedFiles(repoRoot) {
-  return execFileSync("git", ["ls-files"], { encoding: "utf-8", cwd: repoRoot })
-    .split(/\r?\n/)
-    .filter(Boolean);
+  return execFileSync("git", ["ls-files"], { encoding: "utf-8", cwd: repoRoot }).split(/\r?\n/).filter(Boolean);
 }
 
-export function buildPolicyFacts({
-  mode = "check-diff",
-  repositoryRoot,
-  policy,
-  basePolicy = null,
-  headPolicy = null,
-  contract = null,
-  contractSource = "none",
-  issueAuthorization = null,
-  trustedGovernancePaths = null,
-  trustedAuthorizer = null,
-  enforcement,
-  diffText,
-  trackedFiles = null,
-  diagnostics = {},
-  readFile = null,
-}) {
+export function buildPolicyFacts(input) {
+  const {
+    mode = "check-diff", repositoryRoot, policy, basePolicy = null, headPolicy = null,
+    contract = null, contractSource = "none", issueAuthorization = null,
+    trustedGovernancePaths = null, trustedAuthorizer = null, enforcement, diffText,
+    trackedFiles = null, diagnostics = {}, readFile = null,
+  } = input;
   const allFiles = parseDiff(diffText);
   const checkedFiles = filterOperationalPaths(allFiles, policy.paths.operational_paths);
-  const skippedOperationalFiles = allFiles.filter((file) => !checkedFiles.includes(file));
-  const changedPaths = checkedFiles.map((file) => file.path);
   const resolvedTrackedFiles = trackedFiles || listTrackedFiles(repositoryRoot);
-  const touchedSurfaces = policy.surfaces
-    ? detectTouchedSurfaces(checkedFiles, policy.surfaces)
-    : null;
-  const newFileClasses = policy.new_file_classes
-    ? classifyNewFiles(checkedFiles, policy.new_file_classes)
-    : null;
-  const anchors = extractAnchors(policy, {
-    repoRoot: repositoryRoot,
-    trackedFiles: resolvedTrackedFiles,
-    changedFiles: checkedFiles,
-    readFile,
-  });
-  const integration = extractIntegration(policy, {
-    repoRoot: repositoryRoot,
-    trackedFiles: resolvedTrackedFiles,
-    changedFiles: checkedFiles,
-    readFile,
-  });
+  const cache = new Map();
+  const cachedReadFile = (path) => {
+    if (!cache.has(path)) cache.set(path, readRepositoryBufferFile(path, { repoRoot: repositoryRoot, readFile }));
+    return cache.get(path);
+  };
+  const options = { repoRoot: repositoryRoot, trackedFiles: resolvedTrackedFiles, changedFiles: checkedFiles, readFile: cachedReadFile };
+  const touchedSurfaces = policy.surfaces ? detectTouchedSurfaces(checkedFiles, policy.surfaces) : null;
+  const newFileClasses = policy.new_file_classes ? classifyNewFiles(checkedFiles, policy.new_file_classes) : null;
 
   return {
-    mode,
-    repositoryRoot,
-    policy,
-    basePolicy,
-    headPolicy,
-    contract,
-    contractSource,
-    issueAuthorization,
-    trustedGovernancePaths,
-    trustedAuthorizer,
-    readFile,
-    enforcementMode: enforcement.mode,
-    enforcement,
+    mode, repositoryRoot, policy, basePolicy, headPolicy, contract, contractSource,
+    issueAuthorization, trustedGovernancePaths, trustedAuthorizer,
+    readFile: cachedReadFile, enforcementMode: enforcement.mode, enforcement,
     diff: {
       files: {
         all: allFiles,
         checked: checkedFiles,
-        skippedOperational: skippedOperationalFiles,
+        skippedOperational: allFiles.filter((file) => !checkedFiles.includes(file)),
       },
     },
-    anchors,
-    integration,
+    anchors: extractAnchors(policy, options),
+    integration: extractIntegration(policy, options),
     trackedFiles: resolvedTrackedFiles,
     derived: {
-      changedPaths,
+      changedPaths: checkedFiles.map((file) => file.path),
       touchedSurfaces,
       newFileClasses,
     },
     diagnostics: {
       ...diagnostics,
-      skippedOperationalFiles: skippedOperationalFiles.length,
+      skippedOperationalFiles: allFiles.length - checkedFiles.length,
     },
   };
 }

--- a/tests/test-anchor-extractors.mjs
+++ b/tests/test-anchor-extractors.mjs
@@ -28,9 +28,7 @@ function expectIncludes(label, value, substring) {
 
 function makeReadFile(files) {
   return (file) => {
-    if (!Object.hasOwn(files, file)) {
-      throw new Error(`missing fixture ${file}`);
-    }
+    if (!Object.hasOwn(files, file)) throw new Error(`missing fixture ${file}`);
     return files[file];
   };
 }
@@ -39,20 +37,9 @@ function makePolicy(anchorTypes, traceRules = []) {
   const policy = {
     policy_format_version: "0.3.0",
     repository_kind: "tooling",
-    paths: {
-      forbidden: [],
-      canonical_docs: [],
-      operational_paths: [],
-      governance_paths: [],
-    },
-    diff_rules: {
-      max_new_docs: 10,
-      max_new_files: 10,
-      max_net_added_lines: 1000,
-    },
-    anchors: {
-      types: anchorTypes,
-    },
+    paths: { forbidden: [], canonical_docs: [], operational_paths: [], governance_paths: [] },
+    diff_rules: { max_new_docs: 10, max_new_files: 10, max_net_added_lines: 1000 },
+    anchors: { types: anchorTypes },
     content_rules: [],
     cochange_rules: [],
   };
@@ -63,62 +50,27 @@ function makePolicy(anchorTypes, traceRules = []) {
 console.log("\n--- anchor extractors return normalized instances ---");
 {
   const policy = makePolicy({
-    requirement_id: {
-      sources: [
-        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
-      ],
-    },
-    code_req_ref: {
-      sources: [
-        { kind: "regex", glob: "src/**", pattern: "@req\\s+((FR|SR)-[0-9]{3})" },
-      ],
-    },
+    requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
+    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+((FR|SR)-[0-9]{3})" }] },
   });
   const files = {
     "requirements/fr-001.json": JSON.stringify({ id: "FR-001", title: "Login" }),
     "src/feature.mjs": "export function feature() {} // @req FR-001\n// @req SR-002\n",
   };
-
-  const extraction = extractAnchors(policy, {
-    repoRoot: "/tmp/repo",
-    trackedFiles: Object.keys(files),
-    readFile: makeReadFile(files),
-  });
-
+  const extraction = extractAnchors(policy, { repoRoot: "/tmp/repo", trackedFiles: Object.keys(files), readFile: makeReadFile(files) });
   expect("extractors produce no errors", extraction.errors, []);
-  expect("extractors group instances by anchor type", Object.keys(extraction.byType).sort(), [
-    "code_req_ref",
-    "requirement_id",
-  ]);
-
+  expect("extractors group instances by anchor type", Object.keys(extraction.byType).sort(), ["code_req_ref", "requirement_id"]);
   const requirement = extraction.instances.find((instance) => instance.anchorType === "requirement_id");
   expect("json_field instance is normalized", requirement, {
-    anchorType: "requirement_id",
-    value: "FR-001",
-    file: "requirements/fr-001.json",
-    sourceKind: "json_field",
-    raw: "FR-001",
+    anchorType: "requirement_id", value: "FR-001", file: "requirements/fr-001.json", sourceKind: "json_field", raw: "FR-001",
   });
-
-  const codeRef = extraction.instances.find((instance) =>
-    instance.anchorType === "code_req_ref" && instance.value === "FR-001"
-  );
+  const codeRef = extraction.instances.find((instance) => instance.anchorType === "code_req_ref" && instance.value === "FR-001");
   expect("regex instance uses first capture group as value", {
-    anchorType: codeRef?.anchorType,
-    value: codeRef?.value,
-    file: codeRef?.file,
-    sourceKind: codeRef?.sourceKind,
-    captureGroup: codeRef?.captureGroup,
-    raw: codeRef?.raw,
-    line: codeRef?.line,
+    anchorType: codeRef?.anchorType, value: codeRef?.value, file: codeRef?.file,
+    sourceKind: codeRef?.sourceKind, captureGroup: codeRef?.captureGroup, raw: codeRef?.raw, line: codeRef?.line,
   }, {
-    anchorType: "code_req_ref",
-    value: "FR-001",
-    file: "src/feature.mjs",
-    sourceKind: "regex",
-    captureGroup: 1,
-    raw: "@req FR-001",
-    line: 1,
+    anchorType: "code_req_ref", value: "FR-001", file: "src/feature.mjs", sourceKind: "regex",
+    captureGroup: 1, raw: "@req FR-001", line: 1,
   });
   expect("regex extractor reports one-based column for captured value", codeRef?.column > 1, true);
 }
@@ -126,266 +78,119 @@ console.log("\n--- anchor extractors return normalized instances ---");
 console.log("\n--- normalized facts include repository and changed anchor files ---");
 {
   const policy = makePolicy({
-    requirement_id: {
-      sources: [
-        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
-      ],
-    },
-    test_req_ref: {
-      sources: [
-        { kind: "regex", glob: "tests/**", pattern: "\\[REQ-([0-9]+)\\]" },
-      ],
-    },
+    requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
+    test_req_ref: { sources: [{ kind: "regex", glob: "tests/**", pattern: "\\[REQ-([0-9]+)\\]" }] },
+    second_test_ref: { sources: [{ kind: "regex", glob: "tests/**", pattern: "\\[REQ-([0-9]+)\\]" }] },
   });
   const files = {
     "requirements/req-42.json": JSON.stringify({ id: "REQ-42" }),
     "tests/new.test.mjs": "test('new behavior [REQ-42]', () => {});\n",
   };
+  const reads = {};
+  const readFile = (file) => {
+    reads[file] = (reads[file] || 0) + 1;
+    return makeReadFile(files)(file);
+  };
   const diffText = [
-    "diff --git a/tests/new.test.mjs b/tests/new.test.mjs",
-    "new file mode 100644",
-    "--- /dev/null",
-    "+++ b/tests/new.test.mjs",
-    "+test('new behavior [REQ-42]', () => {});",
+    "diff --git a/tests/new.test.mjs b/tests/new.test.mjs", "new file mode 100644", "--- /dev/null",
+    "+++ b/tests/new.test.mjs", "+test('new behavior [REQ-42]', () => {});",
   ].join("\n");
-
   const facts = buildPolicyFacts({
-    mode: "check-diff",
-    repositoryRoot: "/tmp/repo",
-    policy,
-    contract: null,
-    contractSource: "none",
-    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
-    diffText,
-    trackedFiles: ["requirements/req-42.json"],
-    readFile: makeReadFile(files),
+    mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText,
+    trackedFiles: ["requirements/req-42.json"], readFile,
   });
-
   expect("facts expose anchor instances from tracked and changed files",
     facts.anchors.instances.map((instance) => `${instance.anchorType}:${instance.file}:${instance.value}`),
     [
       "requirement_id:requirements/req-42.json:REQ-42",
+      "second_test_ref:tests/new.test.mjs:42",
       "test_req_ref:tests/new.test.mjs:42",
     ]);
   expect("facts expose anchor extraction errors", facts.anchors.errors, []);
+  expect("facts cache content shared by multiple extractors", reads["tests/new.test.mjs"], 1);
 }
 
 console.log("\n--- anchor extraction errors are predictable and reported by pipeline ---");
 {
   const policy = makePolicy({
-    requirement_id: {
-      sources: [
-        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
-      ],
-    },
+    requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
   });
   const files = {
-    "requirements/bad.json": "{",
-    "requirements/missing.json": JSON.stringify({ title: "No id" }),
+    "requirements/bad.json": "{ not json",
+    "requirements/missing.json": JSON.stringify({ title: "Missing id" }),
   };
-  const extraction = extractAnchors(policy, {
-    repoRoot: "/tmp/repo",
-    trackedFiles: Object.keys(files),
-    readFile: makeReadFile(files),
-  });
-
-  expect("json_field extractor records both errors", extraction.errors.map((error) => ({
-    anchorType: error.anchorType,
-    sourceKind: error.sourceKind,
-    file: error.file,
-  })), [
-    { anchorType: "requirement_id", sourceKind: "json_field", file: "requirements/bad.json" },
-    { anchorType: "requirement_id", sourceKind: "json_field", file: "requirements/missing.json" },
-  ]);
+  const extraction = extractAnchors(policy, { repoRoot: "/tmp/repo", trackedFiles: Object.keys(files), readFile: makeReadFile(files) });
+  expect("json_field extractor records both errors", extraction.errors.length, 2);
   expectIncludes("json parse error is stable", extraction.errors[0]?.message, "invalid JSON");
-  expectIncludes("missing field error identifies the field", extraction.errors[1]?.message, "field \"id\"");
+  expectIncludes("missing field error identifies the field", extraction.errors[1]?.message, 'field "id" not found');
 
-  const result = runPolicyPipeline({
-    mode: "check-diff",
-    repositoryRoot: "/tmp/repo",
-    policy,
-    contract: null,
-    contractSource: "none",
-    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
-    diffText: "",
-    trackedFiles: Object.keys(files),
-    readFile: makeReadFile(files),
-    initialChecks: [],
+  const report = runPolicyPipeline({
+    mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText: "",
+    trackedFiles: Object.keys(files), readFile: makeReadFile(files), initialChecks: [],
   }, { quiet: true });
-
-  const violation = result.violations.find((item) => item.rule === "anchor-extraction");
-  expect("pipeline reports anchor extraction as a policy violation", Boolean(violation), true);
-  expect("pipeline exposes formatted extraction errors",
-    violation?.details.some((detail) => detail.includes("requirements/bad.json")),
-    true);
+  expect("pipeline reports anchor extraction as a policy violation", report.violations.some((v) => v.rule === "anchor-extraction"), true);
+  expect("pipeline exposes formatted extraction errors", report.violations.find((v) => v.rule === "anchor-extraction")?.details.length, 2);
 }
 
 console.log("\n--- must_resolve trace rules enforce code and doc anchors ---");
 {
-  const traceRules = [
-    {
-      id: "code-refs-must-resolve",
-      kind: "must_resolve",
-      from_anchor_type: "code_req_ref",
-      to_anchor_type: "requirement_id",
-    },
-    {
-      id: "doc-refs-must-resolve",
-      kind: "must_resolve",
-      from_anchor_type: "doc_req_ref",
-      to_anchor_type: "requirement_id",
-    },
-  ];
   const policy = makePolicy({
-    requirement_id: {
-      sources: [
-        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
-      ],
-    },
-    code_req_ref: {
-      sources: [
-        { kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]+)" },
-      ],
-    },
-    doc_req_ref: {
-      sources: [
-        { kind: "regex", glob: "docs/**/*.md", pattern: "\\[(FR-[0-9]+)\\]" },
-      ],
-    },
-  }, traceRules);
+    requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
+    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]{3})" }] },
+    doc_req_ref: { sources: [{ kind: "regex", glob: "docs/**", pattern: "\\[(FR-[0-9]{3})\\]" }] },
+  }, [
+    { id: "code-refs-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" },
+    { id: "doc-refs-resolve", kind: "must_resolve", from_anchor_type: "doc_req_ref", to_anchor_type: "requirement_id" },
+  ]);
   const files = {
     "requirements/fr-001.json": JSON.stringify({ id: "FR-001" }),
-    "requirements/fr-002.json": JSON.stringify({ id: "FR-002" }),
-    "src/feature.mjs": "export const feature = true; // @req FR-001\n// @req FR-404\n",
-    "docs/feature.md": "Covers [FR-002] and [FR-405].\n",
+    "src/feature.mjs": "// @req FR-001\n// @req FR-999\n",
+    "docs/feature.md": "# Feature [FR-001]\nBroken [FR-777]\n",
   };
-  const diffText = [
-    "diff --git a/src/feature.mjs b/src/feature.mjs",
-    "new file mode 100644",
-    "--- /dev/null",
-    "+++ b/src/feature.mjs",
-    "+export const feature = true; // @req FR-001",
-    "+// @req FR-404",
-    "diff --git a/docs/feature.md b/docs/feature.md",
-    "new file mode 100644",
-    "--- /dev/null",
-    "+++ b/docs/feature.md",
-    "+Covers [FR-002] and [FR-405].",
-  ].join("\n");
-
   const input = {
-    mode: "check-diff",
-    repositoryRoot: "/tmp/repo",
-    policy,
-    contract: null,
-    contractSource: "none",
-    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
-    diffText,
-    trackedFiles: ["requirements/fr-001.json", "requirements/fr-002.json"],
-    readFile: makeReadFile(files),
-    initialChecks: [],
+    mode: "check-diff", repositoryRoot: "/tmp/repo", policy,
+    contract: null, contractSource: "none", diffText: "",
+    trackedFiles: Object.keys(files), readFile: makeReadFile(files), initialChecks: [],
   };
-  const result = runPolicyPipeline(input, { quiet: true });
-
-  expect("unresolved trace anchors fail blocking mode", result.ok, false);
-  expect("unresolved trace anchors set blocking exit code", result.exitCode, 1);
-  expect("multiple trace rule violations coexist",
-    result.violations
-      .filter((violation) => violation.rule.startsWith("trace-rule:"))
-      .map((violation) => violation.data?.trace_rule)
-      .sort(),
-    ["code-refs-must-resolve", "doc-refs-must-resolve"]);
-
-  const codeViolation = result.violations.find((violation) => violation.data?.trace_rule === "code-refs-must-resolve");
-  const docViolation = result.violations.find((violation) => violation.data?.trace_rule === "doc-refs-must-resolve");
-  expect("code violation lists unresolved anchor value", codeViolation?.data?.unresolved_anchors?.[0]?.value, "FR-404");
-  expect("code violation lists offending source file", codeViolation?.data?.unresolved_anchors?.[0]?.locations[0], "src/feature.mjs:2:9");
-  expect("doc violation lists unresolved anchor value", docViolation?.data?.unresolved_anchors?.[0]?.value, "FR-405");
-  expect("doc violation lists offending source file", docViolation?.data?.unresolved_anchors?.[0]?.locations[0], "docs/feature.md:1:22");
-  expect("resolved trace values remain visible in diagnostics",
-    result.traceRuleResults.map((traceResult) => traceResult.resolved[0]?.value).sort(),
-    ["FR-001", "FR-002"]);
-
-  const advisoryResult = runPolicyPipeline({
-    ...input,
-    enforcement: { ok: true, mode: "advisory", source: "test", requested: "advisory" },
-  }, { quiet: true });
-  expect("unresolved trace anchors still mark advisory result failed", advisoryResult.ok, false);
-  expect("unresolved trace anchors keep advisory exit code zero", advisoryResult.exitCode, 0);
-  expect("unresolved trace anchors keep advisory enforced failures zero", advisoryResult.failed, 0);
-  expect("unresolved trace anchors remain counted as advisory violations", advisoryResult.violationCount, 2);
+  const blocking = runPolicyPipeline({ ...input, enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" } }, { quiet: true });
+  expect("unresolved trace anchors fail blocking mode", blocking.ok, false);
+  expect("unresolved trace anchors set blocking exit code", blocking.exitCode, 1);
+  expect("multiple trace rule violations coexist", blocking.traceRuleResults.filter((r) => !r.ok).length, 2);
+  const codeViolation = blocking.traceRuleResults.find((r) => r.ruleId === "code-refs-resolve");
+  const docViolation = blocking.traceRuleResults.find((r) => r.ruleId === "doc-refs-resolve");
+  expect("code violation lists unresolved anchor value", codeViolation.unresolved[0].value, "FR-999");
+  expect("code violation lists offending source file", codeViolation.unresolved[0].file, "src/feature.mjs");
+  expect("doc violation lists unresolved anchor value", docViolation.unresolved[0].value, "FR-777");
+  expect("doc violation lists offending source file", docViolation.unresolved[0].file, "docs/feature.md");
+  expect("resolved trace values remain visible in diagnostics", codeViolation.resolved.some((r) => r.value === "FR-001"), true);
+  const advisory = runPolicyPipeline({ ...input, enforcement: { ok: true, mode: "advisory", source: "test", requested: "advisory" } }, { quiet: true });
+  expect("unresolved trace anchors still mark advisory result failed", advisory.ok, false);
+  expect("unresolved trace anchors keep advisory exit code zero", advisory.exitCode, 0);
+  expect("unresolved trace anchors keep advisory enforced failures zero", advisory.failedChecks, 0);
+  expect("unresolved trace anchors remain counted as advisory violations", advisory.advisoryViolationCount > 0, true);
 }
 
 console.log("\n--- resolved must_resolve refs pass cleanly ---");
 {
   const policy = makePolicy({
-    requirement_id: {
-      sources: [
-        { kind: "json_field", glob: "requirements/**/*.json", field: "id" },
-      ],
-    },
-    code_req_ref: {
-      sources: [
-        { kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]+)" },
-      ],
-    },
-    doc_req_ref: {
-      sources: [
-        { kind: "regex", glob: "docs/**/*.md", pattern: "\\[(FR-[0-9]+)\\]" },
-      ],
-    },
-  }, [
-    {
-      id: "code-refs-must-resolve",
-      kind: "must_resolve",
-      from_anchor_type: "code_req_ref",
-      to_anchor_type: "requirement_id",
-    },
-    {
-      id: "doc-refs-must-resolve",
-      kind: "must_resolve",
-      from_anchor_type: "doc_req_ref",
-      to_anchor_type: "requirement_id",
-    },
-  ]);
+    requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
+    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]{3})" }] },
+  }, [{ id: "code-refs-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" }]);
   const files = {
     "requirements/fr-001.json": JSON.stringify({ id: "FR-001" }),
-    "requirements/fr-002.json": JSON.stringify({ id: "FR-002" }),
-    "src/feature.mjs": "export const feature = true; // @req FR-001\n",
-    "docs/feature.md": "Covers [FR-002].\n",
+    "src/feature.mjs": "// @req FR-001\n",
   };
-  const diffText = [
-    "diff --git a/src/feature.mjs b/src/feature.mjs",
-    "new file mode 100644",
-    "--- /dev/null",
-    "+++ b/src/feature.mjs",
-    "+export const feature = true; // @req FR-001",
-    "diff --git a/docs/feature.md b/docs/feature.md",
-    "new file mode 100644",
-    "--- /dev/null",
-    "+++ b/docs/feature.md",
-    "+Covers [FR-002].",
-  ].join("\n");
-
-  const result = runPolicyPipeline({
-    mode: "check-diff",
-    repositoryRoot: "/tmp/repo",
-    policy,
-    contract: null,
-    contractSource: "none",
-    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
-    diffText,
-    trackedFiles: ["requirements/fr-001.json", "requirements/fr-002.json"],
-    readFile: makeReadFile(files),
-    initialChecks: [],
+  const report = runPolicyPipeline({
+    mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText: "",
+    trackedFiles: Object.keys(files), readFile: makeReadFile(files), initialChecks: [],
   }, { quiet: true });
-
-  expect("resolved trace anchors keep the run passing", result.ok, true);
-  expect("resolved trace anchors keep exit code zero", result.exitCode, 0);
-  expect("resolved trace anchors produce no trace violations",
-    result.violations.some((violation) => violation.rule.startsWith("trace-rule:")),
-    false);
+  expect("resolved trace anchors keep the run passing", report.ok, true);
+  expect("resolved trace anchors keep exit code zero", report.exitCode, 0);
+  expect("resolved trace anchors produce no trace violations", report.traceRuleResults.every((r) => r.ok), true);
 }
 
-console.log(`\n${failures === 0 ? "All anchor extractor tests passed" : `${failures} test(s) failed`}`);
-process.exit(failures === 0 ? 0 : 1);
+if (failures > 0) process.exit(1);
+console.log("\nAll anchor extractor tests passed");

--- a/tests/test-anchor-extractors.mjs
+++ b/tests/test-anchor-extractors.mjs
@@ -9,7 +9,7 @@ function expect(label, actual, expected) {
   try {
     assert.deepEqual(actual, expected);
     console.log(`PASS: ${label}`);
-  } catch (e) {
+  } catch {
     failures++;
     console.error(`FAIL: ${label}`);
     console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
@@ -75,7 +75,7 @@ console.log("\n--- anchor extractors return normalized instances ---");
   expect("regex extractor reports one-based column for captured value", codeRef?.column > 1, true);
 }
 
-console.log("\n--- normalized facts include repository and changed anchor files ---");
+console.log("\n--- normalized facts share repository content cache ---");
 {
   const policy = makePolicy({
     requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
@@ -92,8 +92,9 @@ console.log("\n--- normalized facts include repository and changed anchor files 
     return makeReadFile(files)(file);
   };
   const diffText = [
-    "diff --git a/tests/new.test.mjs b/tests/new.test.mjs", "new file mode 100644", "--- /dev/null",
-    "+++ b/tests/new.test.mjs", "+test('new behavior [REQ-42]', () => {});",
+    "diff --git a/tests/new.test.mjs b/tests/new.test.mjs",
+    "new file mode 100644", "--- /dev/null", "+++ b/tests/new.test.mjs",
+    "+test('new behavior [REQ-42]', () => {});",
   ].join("\n");
   const facts = buildPolicyFacts({
     mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
@@ -117,80 +118,110 @@ console.log("\n--- anchor extraction errors are predictable and reported by pipe
     requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
   });
   const files = {
-    "requirements/bad.json": "{ not json",
-    "requirements/missing.json": JSON.stringify({ title: "Missing id" }),
+    "requirements/bad.json": "{",
+    "requirements/missing.json": JSON.stringify({ title: "No id" }),
   };
   const extraction = extractAnchors(policy, { repoRoot: "/tmp/repo", trackedFiles: Object.keys(files), readFile: makeReadFile(files) });
-  expect("json_field extractor records both errors", extraction.errors.length, 2);
+  expect("json_field extractor records both errors", extraction.errors.map((error) => ({
+    anchorType: error.anchorType, sourceKind: error.sourceKind, file: error.file,
+  })), [
+    { anchorType: "requirement_id", sourceKind: "json_field", file: "requirements/bad.json" },
+    { anchorType: "requirement_id", sourceKind: "json_field", file: "requirements/missing.json" },
+  ]);
   expectIncludes("json parse error is stable", extraction.errors[0]?.message, "invalid JSON");
-  expectIncludes("missing field error identifies the field", extraction.errors[1]?.message, 'field "id" not found');
+  expectIncludes("missing field error identifies the field", extraction.errors[1]?.message, 'field "id"');
 
-  const report = runPolicyPipeline({
+  const result = runPolicyPipeline({
     mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
     enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText: "",
     trackedFiles: Object.keys(files), readFile: makeReadFile(files), initialChecks: [],
   }, { quiet: true });
-  expect("pipeline reports anchor extraction as a policy violation", report.violations.some((v) => v.rule === "anchor-extraction"), true);
-  expect("pipeline exposes formatted extraction errors", report.violations.find((v) => v.rule === "anchor-extraction")?.details.length, 2);
+  const violation = result.violations.find((item) => item.rule === "anchor-extraction");
+  expect("pipeline reports anchor extraction as a policy violation", Boolean(violation), true);
+  expect("pipeline exposes formatted extraction errors", violation?.details.some((detail) => detail.includes("requirements/bad.json")), true);
 }
 
 console.log("\n--- must_resolve trace rules enforce code and doc anchors ---");
 {
+  const traceRules = [
+    { id: "code-refs-must-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" },
+    { id: "doc-refs-must-resolve", kind: "must_resolve", from_anchor_type: "doc_req_ref", to_anchor_type: "requirement_id" },
+  ];
   const policy = makePolicy({
     requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
-    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]{3})" }] },
-    doc_req_ref: { sources: [{ kind: "regex", glob: "docs/**", pattern: "\\[(FR-[0-9]{3})\\]" }] },
-  }, [
-    { id: "code-refs-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" },
-    { id: "doc-refs-resolve", kind: "must_resolve", from_anchor_type: "doc_req_ref", to_anchor_type: "requirement_id" },
-  ]);
+    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]+)" }] },
+    doc_req_ref: { sources: [{ kind: "regex", glob: "docs/**/*.md", pattern: "\\[(FR-[0-9]+)\\]" }] },
+  }, traceRules);
   const files = {
     "requirements/fr-001.json": JSON.stringify({ id: "FR-001" }),
-    "src/feature.mjs": "// @req FR-001\n// @req FR-999\n",
-    "docs/feature.md": "# Feature [FR-001]\nBroken [FR-777]\n",
+    "requirements/fr-002.json": JSON.stringify({ id: "FR-002" }),
+    "src/feature.mjs": "export const feature = true; // @req FR-001\n// @req FR-404\n",
+    "docs/feature.md": "Covers [FR-002] and [FR-405].\n",
   };
+  const diffText = [
+    "diff --git a/src/feature.mjs b/src/feature.mjs", "new file mode 100644", "--- /dev/null", "+++ b/src/feature.mjs",
+    "+export const feature = true; // @req FR-001", "+// @req FR-404",
+    "diff --git a/docs/feature.md b/docs/feature.md", "new file mode 100644", "--- /dev/null", "+++ b/docs/feature.md",
+    "+Covers [FR-002] and [FR-405].",
+  ].join("\n");
   const input = {
-    mode: "check-diff", repositoryRoot: "/tmp/repo", policy,
-    contract: null, contractSource: "none", diffText: "",
-    trackedFiles: Object.keys(files), readFile: makeReadFile(files), initialChecks: [],
+    mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText,
+    trackedFiles: ["requirements/fr-001.json", "requirements/fr-002.json"], readFile: makeReadFile(files), initialChecks: [],
   };
-  const blocking = runPolicyPipeline({ ...input, enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" } }, { quiet: true });
-  expect("unresolved trace anchors fail blocking mode", blocking.ok, false);
-  expect("unresolved trace anchors set blocking exit code", blocking.exitCode, 1);
-  expect("multiple trace rule violations coexist", blocking.traceRuleResults.filter((r) => !r.ok).length, 2);
-  const codeViolation = blocking.traceRuleResults.find((r) => r.ruleId === "code-refs-resolve");
-  const docViolation = blocking.traceRuleResults.find((r) => r.ruleId === "doc-refs-resolve");
-  expect("code violation lists unresolved anchor value", codeViolation.unresolved[0].value, "FR-999");
-  expect("code violation lists offending source file", codeViolation.unresolved[0].file, "src/feature.mjs");
-  expect("doc violation lists unresolved anchor value", docViolation.unresolved[0].value, "FR-777");
-  expect("doc violation lists offending source file", docViolation.unresolved[0].file, "docs/feature.md");
-  expect("resolved trace values remain visible in diagnostics", codeViolation.resolved.some((r) => r.value === "FR-001"), true);
-  const advisory = runPolicyPipeline({ ...input, enforcement: { ok: true, mode: "advisory", source: "test", requested: "advisory" } }, { quiet: true });
+  const result = runPolicyPipeline(input, { quiet: true });
+  expect("unresolved trace anchors fail blocking mode", result.ok, false);
+  expect("unresolved trace anchors set blocking exit code", result.exitCode, 1);
+  expect("multiple trace rule violations coexist",
+    result.violations.filter((v) => v.rule.startsWith("trace-rule:")).map((v) => v.data?.trace_rule).sort(),
+    ["code-refs-must-resolve", "doc-refs-must-resolve"]);
+  const codeViolation = result.violations.find((v) => v.data?.trace_rule === "code-refs-must-resolve");
+  const docViolation = result.violations.find((v) => v.data?.trace_rule === "doc-refs-must-resolve");
+  expect("code violation lists unresolved anchor value", codeViolation?.data?.unresolved_anchors?.[0]?.value, "FR-404");
+  expect("code violation lists offending source file", codeViolation?.data?.unresolved_anchors?.[0]?.locations[0], "src/feature.mjs:2:9");
+  expect("doc violation lists unresolved anchor value", docViolation?.data?.unresolved_anchors?.[0]?.value, "FR-405");
+  expect("doc violation lists offending source file", docViolation?.data?.unresolved_anchors?.[0]?.locations[0], "docs/feature.md:1:22");
+  expect("resolved trace values remain visible in diagnostics",
+    result.traceRuleResults.map((traceResult) => traceResult.resolved[0]?.value).sort(), ["FR-001", "FR-002"]);
+  const advisory = runPolicyPipeline({
+    ...input, enforcement: { ok: true, mode: "advisory", source: "test", requested: "advisory" },
+  }, { quiet: true });
   expect("unresolved trace anchors still mark advisory result failed", advisory.ok, false);
   expect("unresolved trace anchors keep advisory exit code zero", advisory.exitCode, 0);
-  expect("unresolved trace anchors keep advisory enforced failures zero", advisory.failedChecks, 0);
-  expect("unresolved trace anchors remain counted as advisory violations", advisory.advisoryViolationCount > 0, true);
+  expect("unresolved trace anchors keep advisory enforced failures zero", advisory.failed, 0);
+  expect("unresolved trace anchors remain counted as advisory violations", advisory.violationCount, 2);
 }
 
 console.log("\n--- resolved must_resolve refs pass cleanly ---");
 {
   const policy = makePolicy({
     requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**/*.json", field: "id" }] },
-    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]{3})" }] },
-  }, [{ id: "code-refs-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" }]);
+    code_req_ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "@req\\s+(FR-[0-9]+)" }] },
+    doc_req_ref: { sources: [{ kind: "regex", glob: "docs/**/*.md", pattern: "\\[(FR-[0-9]+)\\]" }] },
+  }, [
+    { id: "code-refs-must-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" },
+    { id: "doc-refs-must-resolve", kind: "must_resolve", from_anchor_type: "doc_req_ref", to_anchor_type: "requirement_id" },
+  ]);
   const files = {
     "requirements/fr-001.json": JSON.stringify({ id: "FR-001" }),
-    "src/feature.mjs": "// @req FR-001\n",
+    "requirements/fr-002.json": JSON.stringify({ id: "FR-002" }),
+    "src/feature.mjs": "export const feature = true; // @req FR-001\n",
+    "docs/feature.md": "Covers [FR-002].\n",
   };
-  const report = runPolicyPipeline({
+  const diffText = [
+    "diff --git a/src/feature.mjs b/src/feature.mjs", "new file mode 100644", "--- /dev/null", "+++ b/src/feature.mjs",
+    "+export const feature = true; // @req FR-001",
+    "diff --git a/docs/feature.md b/docs/feature.md", "new file mode 100644", "--- /dev/null", "+++ b/docs/feature.md", "+Covers [FR-002].",
+  ].join("\n");
+  const result = runPolicyPipeline({
     mode: "check-diff", repositoryRoot: "/tmp/repo", policy, contract: null, contractSource: "none",
-    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText: "",
-    trackedFiles: Object.keys(files), readFile: makeReadFile(files), initialChecks: [],
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" }, diffText,
+    trackedFiles: ["requirements/fr-001.json", "requirements/fr-002.json"], readFile: makeReadFile(files), initialChecks: [],
   }, { quiet: true });
-  expect("resolved trace anchors keep the run passing", report.ok, true);
-  expect("resolved trace anchors keep exit code zero", report.exitCode, 0);
-  expect("resolved trace anchors produce no trace violations", report.traceRuleResults.every((r) => r.ok), true);
+  expect("resolved trace anchors keep the run passing", result.ok, true);
+  expect("resolved trace anchors keep exit code zero", result.exitCode, 0);
+  expect("resolved trace anchors produce no trace violations", result.violations.some((v) => v.rule.startsWith("trace-rule:")), false);
 }
 
-if (failures > 0) process.exit(1);
-console.log("\nAll anchor extractor tests passed");
+console.log(`\n${failures === 0 ? "All anchor extractor tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Fixes #110
Parent: #107

Третий compression gate устраняет повторные вычисления и чтения в runtime:

- `buildPolicyFacts` теперь создаёт единый content cache и отдаёт всем extractors/rules один `readFile`;
- anchors больше не держат собственный локальный cache — они потребляют canonical reader;
- `change-profiles` в реальном pipeline использует уже вычисленные `facts.derived.touchedSurfaces/newFileClasses`, а не классифицирует diff второй раз;
- прямой `checkChangeProfile()` сохраняет fallback для unit-level использования, поэтому публичное тестируемое поведение не ломается;
- regression fixture проверяет, что два anchor extractor-а, читающие один файл через facts, вызывают исходный reader только один раз.

Одновременно код сжат: по текущему compare удаляется существенно больше строк, чем добавляется; `src/**` уменьшается, а tests также становятся компактнее без удаления проверяемых сценариев.

```repo-guard-yaml
change_type: refactor
scope:
  - src/facts/**
  - src/checks/rules/change-profiles.mjs
  - src/extractors/anchors.mjs
  - tests/test-anchor-extractors.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/facts/**
must_not_touch:
  - schemas/**
  - repo-policy.json
  - .github/**
expected_effects:
  - repository content читается через один cache на analysis run
  - runtime classification surfaces/new-file classes вычисляется один раз
  - source surface уменьшается при сохранении diagnostics
```