### PR TITLE
Compression 4/9: свести path-set семантику к named selectors

### DIFF
--- a/src/checks/rules/cochange-rules.mjs
+++ b/src/checks/rules/cochange-rules.mjs
@@ -1,42 +1,20 @@
-import { matchesAny } from "../../utils/path-patterns.mjs";
+import { selectPaths } from "../../diff/classification.mjs";
 
 export function checkCochangeRules(files, rules = []) {
-  const changedPaths = files.map((file) => file.path);
-  const violations = [];
-
-  for (const rule of rules) {
-    const triggered = changedPaths.some((path) => matchesAny(path, rule.if_changed));
-    if (!triggered) continue;
-
-    const satisfied = changedPaths.some((path) => matchesAny(path, rule.must_change_any));
-    if (!satisfied) {
-      violations.push({
-        if_changed: rule.if_changed,
-        must_change_any: rule.must_change_any,
-      });
-    }
-  }
-
-  return violations;
+  return rules.flatMap((rule) =>
+    selectPaths(files, rule.if_changed).length > 0 && selectPaths(files, rule.must_change_any).length === 0
+      ? [{ if_changed: rule.if_changed, must_change_any: rule.must_change_any }]
+      : []);
 }
 
 export const cochangeRuleFamily = {
   id: "cochange-rules",
   evaluate(facts) {
     const violations = checkCochangeRules(facts.diff.files.checked, facts.policy.cochange_rules);
-    if (violations.length === 0) {
-      return {
-        name: "cochange-rules",
-        check: { ok: true },
-      };
-    }
-
+    if (violations.length === 0) return { name: "cochange-rules", check: { ok: true } };
     return violations.map((violation) => ({
       name: `cochange: ${violation.if_changed.join(",")} -> ${violation.must_change_any.join(",")}`,
-      check: {
-        ok: false,
-        must_touch: violation.must_change_any,
-      },
+      check: { ok: false, must_touch: violation.must_change_any },
     }));
   },
 };

--- a/src/checks/rules/contract-rules.mjs
+++ b/src/checks/rules/contract-rules.mjs
@@ -1,58 +1,31 @@
-import { matchesAny } from "../../utils/path-patterns.mjs";
+import { selectPaths } from "../../diff/classification.mjs";
 
 export function checkMustTouch(files, mustTouch) {
-  if (!mustTouch || mustTouch.length === 0) return { ok: true };
-
-  const changedPaths = files.map((file) => file.path);
-  const satisfied = mustTouch.some((pattern) =>
-    changedPaths.some((changedPath) => matchesAny(changedPath, [pattern]))
-  );
-
+  if (!mustTouch?.length) return { ok: true };
+  const changed = files.map((file) => file.path);
+  const satisfied = selectPaths(files, mustTouch).length > 0;
   return {
     ok: satisfied,
     must_touch: mustTouch,
-    changed: changedPaths,
+    changed,
     hint: satisfied ? undefined : "must_touch uses any-of semantics: at least one pattern must match a changed file",
   };
 }
 
 export function checkMustNotTouch(files, mustNotTouch) {
-  if (!mustNotTouch || mustNotTouch.length === 0) return { ok: true };
-
-  const changedPaths = files.map((file) => file.path);
-  const touched = [];
-
-  for (const pattern of mustNotTouch) {
-    for (const changedPath of changedPaths) {
-      if (matchesAny(changedPath, [pattern])) {
-        touched.push(changedPath);
-      }
-    }
-  }
-
-  return {
-    ok: touched.length === 0,
-    touched,
-    must_not_touch: mustNotTouch,
-  };
+  if (!mustNotTouch?.length) return { ok: true };
+  const touched = selectPaths(files, mustNotTouch);
+  return { ok: touched.length === 0, touched, must_not_touch: mustNotTouch };
 }
 
 export const contractRuleFamily = {
   id: "contract-rules",
-  applies(facts) {
-    return Boolean(facts.contract);
-  },
+  applies: (facts) => Boolean(facts.contract),
   evaluate(facts) {
     const files = facts.diff.files.checked;
     return [
-      {
-        name: "must-touch",
-        check: checkMustTouch(files, facts.contract.must_touch),
-      },
-      {
-        name: "must-not-touch",
-        check: checkMustNotTouch(files, facts.contract.must_not_touch),
-      },
+      { name: "must-touch", check: checkMustTouch(files, facts.contract.must_touch) },
+      { name: "must-not-touch", check: checkMustNotTouch(files, facts.contract.must_not_touch) },
     ];
   },
 };

--- a/src/checks/rules/paths.mjs
+++ b/src/checks/rules/paths.mjs
@@ -1,26 +1,13 @@
-import { matchesAny } from "../../utils/path-patterns.mjs";
+import { selectPaths } from "../../diff/classification.mjs";
 
 export function checkForbiddenPaths(files, forbidden) {
-  const violations = [];
-  for (const file of files) {
-    if (file.status === "deleted") continue;
-    if (matchesAny(file.path, forbidden)) {
-      violations.push(file.path);
-    }
-  }
-  return violations;
+  return selectPaths(files, forbidden, { excludeStatuses: ["deleted"] });
 }
 
 export const forbiddenPathsRuleFamily = {
   id: "forbidden-paths",
   evaluate(facts) {
-    const violations = checkForbiddenPaths(facts.diff.files.checked, facts.policy.paths.forbidden);
-    return {
-      name: "forbidden-paths",
-      check: {
-        ok: violations.length === 0,
-        files: violations,
-      },
-    };
+    const files = checkForbiddenPaths(facts.diff.files.checked, facts.policy.paths.forbidden);
+    return { name: "forbidden-paths", check: { ok: files.length === 0, files } };
   },
 };

--- a/src/diff/classification.mjs
+++ b/src/diff/classification.mjs
@@ -1,61 +1,57 @@
 import { uniqueSorted } from "../utils/collections.mjs";
 import { matchesAny } from "../utils/path-patterns.mjs";
 
-export function detectTouchedSurfaces(files, surfaces = {}) {
-  const filesBySurface = {};
-  const classifiedFiles = new Set();
+function statusAllowed(file, statuses) {
+  return !statuses || statuses.includes(file.status);
+}
 
-  for (const [surface, patterns] of Object.entries(surfaces || {})) {
-    const matchedFiles = uniqueSorted(
-      files
-        .filter((file) => matchesAny(file.path, patterns || []))
-        .map((file) => file.path)
-    );
+export function selectPaths(files, patterns = [], options = {}) {
+  const { statuses = null, excludeStatuses = [] } = options;
+  return uniqueSorted(files
+    .filter((file) => statusAllowed(file, statuses) && !excludeStatuses.includes(file.status))
+    .filter((file) => matchesAny(file.path, patterns || []))
+    .map((file) => file.path));
+}
 
-    if (matchedFiles.length > 0) {
-      filesBySurface[surface] = matchedFiles;
-      for (const file of matchedFiles) {
-        classifiedFiles.add(file);
-      }
-    }
+export function classifyPathSets(files, selectors = {}, options = {}) {
+  const candidates = files.filter((file) =>
+    statusAllowed(file, options.statuses || null) && !(options.excludeStatuses || []).includes(file.status));
+  const selectedPaths = uniqueSorted(candidates.map((file) => file.path));
+  const filesBySelector = {};
+  const selectorsByFile = {};
+
+  for (const [name, patterns] of Object.entries(selectors || {})) {
+    const matched = selectPaths(candidates, patterns);
+    if (matched.length === 0) continue;
+    filesBySelector[name] = matched;
+    for (const path of matched) (selectorsByFile[path] ||= []).push(name);
   }
-
-  const changedFiles = uniqueSorted(files.map((file) => file.path));
+  for (const names of Object.values(selectorsByFile)) names.sort();
 
   return {
-    touched_surfaces: Object.keys(filesBySurface).sort(),
-    files_by_surface: filesBySurface,
-    unclassified_files: changedFiles.filter((file) => !classifiedFiles.has(file)),
+    selected_paths: selectedPaths,
+    touched_selectors: Object.keys(filesBySelector).sort(),
+    files_by_selector: filesBySelector,
+    selectors_by_file: selectorsByFile,
+    unclassified_files: selectedPaths.filter((path) => !selectorsByFile[path]),
   };
 }
 
-export function classifyNewFiles(files, newFileClasses = {}) {
-  const filesByClass = {};
-  const classByFile = {};
-  const classifiedFiles = new Set();
-  const newFiles = uniqueSorted(files.filter((file) => file.status === "added").map((file) => file.path));
-
-  for (const [fileClass, patterns] of Object.entries(newFileClasses || {})) {
-    const matchedFiles = newFiles.filter((file) => matchesAny(file, patterns || []));
-
-    if (matchedFiles.length > 0) {
-      filesByClass[fileClass] = matchedFiles;
-      for (const file of matchedFiles) {
-        classifiedFiles.add(file);
-        if (!classByFile[file]) classByFile[file] = [];
-        classByFile[file].push(fileClass);
-      }
-    }
-  }
-
-  for (const classes of Object.values(classByFile)) {
-    classes.sort();
-  }
-
+export function detectTouchedSurfaces(files, surfaces = {}) {
+  const selected = classifyPathSets(files, surfaces);
   return {
-    new_files: newFiles,
-    files_by_class: filesByClass,
-    class_by_file: classByFile,
-    unclassified_files: newFiles.filter((file) => !classifiedFiles.has(file)),
+    touched_surfaces: selected.touched_selectors,
+    files_by_surface: selected.files_by_selector,
+    unclassified_files: selected.unclassified_files,
+  };
+}
+
+export function classifyNewFiles(files, classes = {}) {
+  const selected = classifyPathSets(files, classes, { statuses: ["added"] });
+  return {
+    new_files: selected.selected_paths,
+    files_by_class: selected.files_by_selector,
+    class_by_file: selected.selectors_by_file,
+    unclassified_files: selected.unclassified_files,
   };
 }

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -1,5 +1,6 @@
 import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
 import { checkSizeRules } from "../src/checks/rules/size-rules.mjs";
+import { classifyPathSets, selectPaths } from "../src/diff/classification.mjs";
 
 let failures = 0;
 
@@ -12,131 +13,75 @@ function expect(label, actual, expected) {
   }
 }
 
+const selectorFiles = [
+  { path: "src/a.mjs", status: "modified" },
+  { path: "tests/a.test.mjs", status: "added" },
+  { path: "docs/old.md", status: "deleted" },
+];
+const selected = classifyPathSets(selectorFiles, { source: ["src/**"], tests: ["tests/**"] });
+expect("named selectors expose touched sets", selected.touched_selectors.join(","), "source,tests");
+expect("named selectors expose unclassified files", selected.unclassified_files.join(","), "docs/old.md");
+expect("selector status view isolates additions", selectPaths(selectorFiles, ["**"], { statuses: ["added"] }).join(","), "tests/a.test.mjs");
+
 const currentFiles = new Map([
   ["docs/a.md", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"],
   ["docs/b.md", "a\nb\nc\n"],
   ["README.md", "# Русский документ\n\nОбычный русский текст с `SomeClass` и API.\n\n```text\nCurrent production contract\n```\n"],
 ]);
-
 const readFile = (path) => currentFiles.get(path) ?? null;
-
 const balancedDiff = [
-  {
-    path: "docs/a.md",
-    status: "modified",
-    addedLines: ["n1", "n2"],
-    deletedLines: ["o1", "o2", "o3", "o4", "o5"],
-  },
-  {
-    path: "docs/b.md",
-    status: "added",
-    addedLines: ["a", "b", "c"],
-    deletedLines: [],
-  },
+  { path: "docs/a.md", status: "modified", addedLines: ["n1", "n2"], deletedLines: ["o1", "o2", "o3", "o4", "o5"] },
+  { path: "docs/b.md", status: "added", addedLines: ["a", "b", "c"], deletedLines: [] },
 ];
-
-const lineRule = {
-  id: "docs-lines",
-  scope: "directory",
-  metric: "lines",
-  glob: "docs/**",
-  max: 20,
-  max_growth: 0,
-};
-
-const lineResult = checkSizeRules(balancedDiff, [lineRule], {
-  trackedFiles: ["docs/a.md", "docs/b.md"],
-  readFile,
-});
+const lineRule = { id: "docs-lines", scope: "directory", metric: "lines", glob: "docs/**", max: 20, max_growth: 0 };
+const lineResult = checkSizeRules(balancedDiff, [lineRule], { trackedFiles: ["docs/a.md", "docs/b.md"], readFile });
 expect("line surface passes when net growth is zero", lineResult.ok, true);
 expect("line surface reports before", lineResult.growth[0].before, 13);
 expect("line surface reports after", lineResult.growth[0].after, 13);
 expect("line surface reports delta", lineResult.growth[0].delta, 0);
 
-const growingDiff = [
-  {
-    path: "docs/a.md",
-    status: "modified",
-    addedLines: ["n1", "n2"],
-    deletedLines: ["o1"],
-  },
-];
-const growingResult = checkSizeRules(growingDiff, [lineRule], {
-  trackedFiles: ["docs/a.md", "docs/b.md"],
-  readFile,
-});
+const growingDiff = [{ path: "docs/a.md", status: "modified", addedLines: ["n1", "n2"], deletedLines: ["o1"] }];
+const growingResult = checkSizeRules(growingDiff, [lineRule], { trackedFiles: ["docs/a.md", "docs/b.md"], readFile });
 expect("line surface blocks positive growth", growingResult.ok, false);
 expect("line surface growth violation kind", growingResult.size_violations[0].kind, "growth");
 expect("line surface positive delta", growingResult.growth[0].delta, 1);
 
-const shrinkRequired = checkSizeRules(balancedDiff, [{ ...lineRule, max_growth: -1 }], {
-  trackedFiles: ["docs/a.md", "docs/b.md"],
-  readFile,
-});
+const shrinkRequired = checkSizeRules(balancedDiff, [{ ...lineRule, max_growth: -1 }], { trackedFiles: ["docs/a.md", "docs/b.md"], readFile });
 expect("negative max_growth can require shrinkage", shrinkRequired.ok, false);
 
-const fileRule = {
-  id: "contract-files",
-  scope: "directory",
-  metric: "files",
-  glob: "contracts/**",
-  max: 10,
-  max_growth: 0,
-};
+const fileRule = { id: "contract-files", scope: "directory", metric: "files", glob: "contracts/**", max: 10, max_growth: 0 };
 const fileGrowth = checkSizeRules([
   { path: "contracts/new.json", status: "added", addedLines: ["{}"], deletedLines: [] },
-], [fileRule], {
-  trackedFiles: ["contracts/old.json", "contracts/new.json"],
-  readFile,
-});
+], [fileRule], { trackedFiles: ["contracts/old.json", "contracts/new.json"], readFile });
 expect("file-count surface blocks a new file", fileGrowth.ok, false);
 expect("file-count delta is one", fileGrowth.growth[0].delta, 1);
 expect("file-count before is reconstructed", fileGrowth.growth[0].before, 1);
 expect("file-count after is current count", fileGrowth.growth[0].after, 2);
 
 const byteGrowth = checkSizeRules(balancedDiff, [{
-  id: "docs-bytes",
-  scope: "directory",
-  metric: "bytes",
-  glob: "docs/**",
-  max: 1000,
-  max_growth: 0,
-}], {
-  trackedFiles: ["docs/a.md", "docs/b.md"],
-  readFile,
-});
+  id: "docs-bytes", scope: "directory", metric: "bytes", glob: "docs/**", max: 1000, max_growth: 0,
+}], { trackedFiles: ["docs/a.md", "docs/b.md"], readFile });
 expect("byte max_growth fails closed until exact base-byte measurement exists", byteGrowth.ok, false);
 expect("byte max_growth reports a read/evaluation error", byteGrowth.errors.length, 1);
 
 const russianRule = {
-  id: "russian-docs",
-  glob: "README.md",
-  mode: "markdown_language",
-  language: "ru",
-  allow_words: ["API"],
-  max_unapproved_latin_words_per_line: 1,
+  id: "russian-docs", glob: "README.md", mode: "markdown_language", language: "ru",
+  allow_words: ["API"], max_unapproved_latin_words_per_line: 1,
 };
 const readmeChange = [{ path: "README.md", status: "modified", addedLines: ["изменение"], deletedLines: [] }];
-const russianResult = checkContentRules(readmeChange, [russianRule], { readFile });
-expect("Russian Markdown ignores inline/fenced code", russianResult.length, 0);
-
+expect("Russian Markdown ignores inline/fenced code", checkContentRules(readmeChange, [russianRule], { readFile }).length, 0);
 currentFiles.set("README.md", "# Документ\n\nCurrent production contract.\n");
 const englishResult = checkContentRules(readmeChange, [russianRule], { readFile });
 expect("English prose is rejected", englishResult.length, 1);
 expect("language violation kind", englishResult[0].kind, "language");
 expect("language violation line", englishResult[0].line_number, 3);
-
 currentFiles.set("README.md", "# Документ\n\nИспользуется semantic contract.\n");
-const mixedResult = checkContentRules(readmeChange, [russianRule], { readFile });
-expect("multiple mixed Latin terms are rejected", mixedResult.length, 1);
-
+expect("multiple mixed Latin terms are rejected", checkContentRules(readmeChange, [russianRule], { readFile }).length, 1);
 currentFiles.set("README.md", "# Документ\n\nИспользуется API.\n");
-const allowedResult = checkContentRules(readmeChange, [russianRule], { readFile });
-expect("allow-listed technical term passes", allowedResult.length, 0);
+expect("allow-listed technical term passes", checkContentRules(readmeChange, [russianRule], { readFile }).length, 0);
 
 if (failures > 0) {
   console.error(`\n${failures} compression-rule test(s) failed`);
   process.exit(1);
 }
-
 console.log("\nAll compression-rule tests passed");


### PR DESCRIPTION
Fixes #111
Parent: #107

Вводит одну внутреннюю модель выбора множеств путей без расширения публичного DSL:

- `classifyPathSets` классифицирует любой view файлов по именованным glob-наборам;
- `selectPaths` является общим predicate для changed/added/deleted views;
- прежние `surfaces` и `new_file_classes` теперь только frontend-представления над одним selector runtime;
- forbidden paths, contract `must_touch/must_not_touch` и cochange перестали иметь собственные glob loops;
- compatibility-функции `detectTouchedSurfaces` / `classifyNewFiles` являются тонкими преобразованиями результата общего selector-а, без второго алгоритма;
- новый public top-level `selectors` намеренно не добавлялся.

Этап снова имеет отрицательный structural diff: три отдельных path matching implementation удалены, а общий matcher компактнее их суммы.

```repo-guard-yaml
change_type: refactor
scope:
  - src/diff/classification.mjs
  - src/checks/rules/cochange-rules.mjs
  - src/checks/rules/contract-rules.mjs
  - src/checks/rules/paths.mjs
  - tests/test-compression-rules.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/diff/classification.mjs
must_not_touch:
  - schemas/**
  - repo-policy.json
  - .github/**
expected_effects:
  - surfaces и new_file_classes исполняются одним named-selector механизмом
  - contract cochange и forbidden rules используют тот же selector predicate
  - число независимых path-set реализаций уменьшается
```