### PR TITLE
Compression 6/9: свести Markdown JSON YAML к DocumentFacts

### DIFF
--- a/src/checks/rules/content-rules.mjs
+++ b/src/checks/rules/content-rules.mjs
@@ -1,67 +1,35 @@
+import { createDocumentReader, stripMarkdownInline } from "../../document-facts.mjs";
 import { matchesAny } from "../../utils/path-patterns.mjs";
-import { readRepositoryTextFile } from "../../utils/repository-files.mjs";
 
 function checkRegexRule(files, rule) {
   const violations = [];
   const regexes = rule.forbid_regex.map((pattern) => new RegExp(pattern));
-  const glob = rule.glob || "**";
-
   for (const file of files) {
-    if (!matchesAny(file.path, [glob])) continue;
+    if (!matchesAny(file.path, [rule.glob || "**"])) continue;
     for (const line of file.addedLines || []) {
-      for (let i = 0; i < regexes.length; i++) {
-        if (regexes[i].test(line)) {
-          violations.push({
-            kind: "regex",
-            rule_id: rule.id,
-            file: file.path,
-            line: line.trim(),
-            matched_regex: rule.forbid_regex[i],
-          });
-        }
-      }
+      regexes.forEach((regex, index) => {
+        if (regex.test(line)) violations.push({
+          kind: "regex", rule_id: rule.id, file: file.path, line: line.trim(), matched_regex: rule.forbid_regex[index],
+        });
+      });
     }
   }
   return violations;
 }
 
-function stripMarkdownProse(line) {
-  return line
-    .replace(/`[^`]*`/g, "")
-    .replace(/\]\([^)]*\)/g, "]")
-    .replace(/https?:\/\/\S+/g, "");
-}
-
-function markdownLanguageViolations(file, rule, options = {}) {
-  const content = readRepositoryTextFile(file.path, options);
+function markdownLanguageViolations(file, rule, documents) {
   const allowed = new Set(rule.allow_words || []);
   const maxLatin = rule.max_unapproved_latin_words_per_line ?? 1;
   const violations = [];
-  let inFence = false;
-
-  for (const [index, rawLine] of content.split(/\r?\n/).entries()) {
-    const stripped = rawLine.trim();
-    if (stripped.startsWith("```")) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
-    const line = stripMarkdownProse(rawLine);
+  for (const prose of documents.markdown(file.path).proseLines) {
+    const line = stripMarkdownInline(prose.text);
     const latin = [...line.matchAll(/(?<![\w])([A-Za-z][A-Za-z-]{2,})(?![\w])/g)]
-      .map((match) => match[1])
-      .filter((word) => !allowed.has(word));
+      .map((match) => match[1]).filter((word) => !allowed.has(word));
     const hasCyrillic = /[А-Яа-яЁё]{3,}/.test(line);
-
     if (latin.length > maxLatin || (latin.length > 0 && !hasCyrillic)) {
       violations.push({
-        kind: "language",
-        rule_id: rule.id,
-        file: file.path,
-        line_number: index + 1,
-        line: rawLine.trim(),
-        language: rule.language,
-        unapproved_words: latin,
+        kind: "language", rule_id: rule.id, file: file.path, line_number: prose.line,
+        line: prose.text.trim(), language: rule.language, unapproved_words: latin,
       });
     }
   }
@@ -70,57 +38,34 @@ function markdownLanguageViolations(file, rule, options = {}) {
 
 export function checkContentRules(files, rules = [], options = {}) {
   const violations = [];
-
+  const documents = options.documents || createDocumentReader(options);
   for (const rule of rules) {
-    if (rule.mode === "added_lines" && rule.forbid_regex) {
-      violations.push(...checkRegexRule(files, rule));
-      continue;
-    }
-
-    if (rule.mode === "markdown_language") {
-      const glob = rule.glob || "**/*.md";
+    if (rule.mode === "added_lines" && rule.forbid_regex) violations.push(...checkRegexRule(files, rule));
+    else if (rule.mode === "markdown_language") {
       for (const file of files) {
-        if (file.status === "deleted" || !matchesAny(file.path, [glob])) continue;
-        violations.push(...markdownLanguageViolations(file, rule, options));
+        if (file.status !== "deleted" && matchesAny(file.path, [rule.glob || "**/*.md"])) {
+          violations.push(...markdownLanguageViolations(file, rule, documents));
+        }
       }
     }
   }
-
   return violations;
 }
 
 function formatViolation(violation) {
-  if (violation.kind === "language") {
-    return `[${violation.rule_id}] ${violation.file}:${violation.line_number}: unapproved ${violation.language} prose words: ${violation.unapproved_words.join(", ")}`;
-  }
-  return `[${violation.rule_id}] ${violation.file}: "${violation.line}" matched /${violation.matched_regex}/`;
+  return violation.kind === "language"
+    ? `[${violation.rule_id}] ${violation.file}:${violation.line_number}: unapproved ${violation.language} prose words: ${violation.unapproved_words.join(", ")}`
+    : `[${violation.rule_id}] ${violation.file}: "${violation.line}" matched /${violation.matched_regex}/`;
 }
 
 export const contentRuleFamily = {
   id: "content-rules",
   evaluate(facts) {
-    const violations = checkContentRules(
-      facts.diff.files.checked,
-      facts.policy.content_rules,
-      {
-        repoRoot: facts.repositoryRoot,
-        readFile: facts.readFile,
-      }
-    );
-    if (violations.length > 0) {
-      return {
-        name: "content-rules",
-        check: {
-          ok: false,
-          violations,
-          details: violations.map(formatViolation),
-        },
-      };
-    }
-
-    return {
-      name: "content-rules",
-      check: { ok: true },
-    };
+    const violations = checkContentRules(facts.diff.files.checked, facts.policy.content_rules, {
+      repoRoot: facts.repositoryRoot, readFile: facts.readFile, documents: facts.documents,
+    });
+    return violations.length
+      ? { name: "content-rules", check: { ok: false, violations, details: violations.map(formatViolation) } }
+      : { name: "content-rules", check: { ok: true } };
   },
 };

--- a/src/checks/rules/registry-rules.mjs
+++ b/src/checks/rules/registry-rules.mjs
@@ -1,184 +1,84 @@
+import { createDocumentReader, markdownSection } from "../../document-facts.mjs";
 import { formatList, uniqueSorted } from "../../utils/collections.mjs";
 import { normalizePathEntry } from "../../utils/path-patterns.mjs";
-import { readRepositoryTextFile } from "../../utils/repository-files.mjs";
 
-function uniqueSortedNormalized(values) {
-  return uniqueSorted(values.map(normalizePathEntry).filter(Boolean));
-}
-
-function decodeJsonPointerPart(part) {
-  return part.replace(/~1/g, "/").replace(/~0/g, "~");
-}
+const normalizeAll = (values) => uniqueSorted(values.map(normalizePathEntry).filter(Boolean));
 
 function resolveJsonPointer(data, pointer) {
   if (pointer === "") return data;
-  if (!pointer || !pointer.startsWith("/")) {
-    throw new Error(`invalid json_pointer "${pointer}"`);
-  }
-
+  if (!pointer?.startsWith("/")) throw new Error(`invalid json_pointer "${pointer}"`);
   let current = data;
-  for (const rawPart of pointer.slice(1).split("/")) {
-    const part = decodeJsonPointerPart(rawPart);
-    if (current === null || current === undefined || !Object.prototype.hasOwnProperty.call(current, part)) {
-      throw new Error(`json_pointer "${pointer}" does not exist`);
-    }
+  for (const raw of pointer.slice(1).split("/")) {
+    const part = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (current == null || !Object.prototype.hasOwnProperty.call(current, part)) throw new Error(`json_pointer "${pointer}" does not exist`);
     current = current[part];
   }
   return current;
 }
 
-function markdownHeadingLevel(line, section) {
-  const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
-  if (!match) return null;
-  return match[2].trim().toLowerCase() === section.trim().toLowerCase()
-    ? match[1].length
-    : null;
-}
-
-function extractMarkdownSection(content, section) {
-  const lines = content.split(/\r?\n/);
-  let inSection = false;
-  let level = null;
-  const sectionLines = [];
-
-  for (const line of lines) {
-    const heading = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
-    if (!inSection) {
-      const matchedLevel = markdownHeadingLevel(line, section);
-      if (matchedLevel) {
-        inSection = true;
-        level = matchedLevel;
-      }
-      continue;
-    }
-
-    if (heading && heading[1].length <= level) break;
-    sectionLines.push(line);
-  }
-
-  if (!inSection) {
-    throw new Error(`markdown section "${section}" not found`);
-  }
-  return sectionLines.join("\n");
-}
-
 function normalizeMarkdownLinkTarget(target, source) {
-  const cleanTarget = normalizePathEntry(target.split("#")[0].split("?")[0]);
-  if (!cleanTarget || /^[a-z][a-z0-9+.-]*:/i.test(cleanTarget) || cleanTarget.startsWith("#")) {
-    return "";
-  }
-
-  const sourceDir = source.file.includes("/")
-    ? source.file.split("/").slice(0, -1).join("/")
-    : "";
-  const withSourceDir = cleanTarget.startsWith("/")
-    ? cleanTarget.slice(1)
-    : normalizePathEntry(`${sourceDir}/${cleanTarget}`);
+  const clean = normalizePathEntry(target.split("#")[0].split("?")[0]);
+  if (!clean || /^[a-z][a-z0-9+.-]*:/i.test(clean) || clean.startsWith("#")) return "";
+  const sourceDir = source.file.includes("/") ? source.file.split("/").slice(0, -1).join("/") : "";
+  const candidate = clean.startsWith("/") ? clean.slice(1) : normalizePathEntry(`${sourceDir}/${clean}`);
   const parts = [];
-  for (const part of withSourceDir.split("/")) {
+  for (const part of candidate.split("/")) {
     if (!part || part === ".") continue;
     if (part === "..") parts.pop();
     else parts.push(part);
   }
-  return parts.join("/");
-}
-
-function applyMarkdownLinkPrefix(target, source) {
-  if (!source.prefix) return target;
-  const prefix = normalizePathEntry(source.prefix);
-  if (target.startsWith(prefix)) return target;
-  const sourceDir = source.file.includes("/")
-    ? `${source.file.split("/").slice(0, -1).join("/")}/`
-    : "";
-  if (sourceDir && target.startsWith(sourceDir)) {
-    return normalizePathEntry(`${prefix}${target.slice(sourceDir.length)}`);
+  let result = parts.join("/");
+  if (source.prefix) {
+    const prefix = normalizePathEntry(source.prefix);
+    if (!result.startsWith(prefix) && sourceDir && result.startsWith(`${sourceDir}/`)) result = normalizePathEntry(`${prefix}${result.slice(sourceDir.length + 1)}`);
   }
-  return target;
+  return result;
 }
 
-function readRegistrySource(source, options = {}) {
-  const content = readRepositoryTextFile(source.file, options);
-
+function readRegistrySource(source, documents) {
   if (source.type === "json_array") {
-    const data = JSON.parse(content);
-    const value = resolveJsonPointer(data, source.json_pointer);
-    if (!Array.isArray(value)) {
-      throw new Error(`${source.file}${source.json_pointer} is not a JSON array`);
-    }
-    if (value.some((entry) => typeof entry !== "string")) {
-      throw new Error(`${source.file}${source.json_pointer} must contain only strings`);
-    }
-    return uniqueSortedNormalized(value);
+    const value = resolveJsonPointer(documents.json(source.file), source.json_pointer);
+    if (!Array.isArray(value)) throw new Error(`${source.file}${source.json_pointer} is not a JSON array`);
+    if (value.some((entry) => typeof entry !== "string")) throw new Error(`${source.file}${source.json_pointer} must contain only strings`);
+    return normalizeAll(value);
   }
-
   if (source.type === "markdown_section_links") {
-    const section = extractMarkdownSection(content, source.section);
-    const links = [];
-    const linkPattern = /\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
-    for (const match of section.matchAll(linkPattern)) {
-      const normalized = normalizeMarkdownLinkTarget(match[1], source);
-      if (!normalized) continue;
-      links.push(applyMarkdownLinkPrefix(normalized, source));
-    }
-    return uniqueSortedNormalized(links);
+    const section = markdownSection(documents.markdown(source.file), source.section);
+    return normalizeAll(section.links.map((link) => normalizeMarkdownLinkTarget(link.target, source)).filter(Boolean));
   }
-
   throw new Error(`unsupported registry source type "${source.type}"`);
 }
 
-export function checkRegistryRules(registryRules = [], options = {}) {
-  if (!registryRules || registryRules.length === 0) return { ok: true, results: [] };
-
-  const results = [];
-  for (const rule of registryRules) {
+export function checkRegistryRules(rules = [], options = {}) {
+  if (!rules?.length) return { ok: true, results: [] };
+  const documents = options.documents || createDocumentReader(options);
+  const results = rules.map((rule) => {
     try {
-      const leftEntries = readRegistrySource(rule.left, options);
-      const rightEntries = readRegistrySource(rule.right, options);
-      const leftSet = new Set(leftEntries);
-      const rightSet = new Set(rightEntries);
-      const missingFromRight = leftEntries.filter((entry) => !rightSet.has(entry));
-      const extraInRight = rightEntries.filter((entry) => !leftSet.has(entry));
-      let ok;
-      if (rule.kind === "set_equality") {
-        ok = missingFromRight.length === 0 && extraInRight.length === 0;
-      } else if (rule.kind === "left_subset_of_right") {
-        ok = missingFromRight.length === 0;
-      } else if (rule.kind === "right_subset_of_left") {
-        ok = extraInRight.length === 0;
-      } else {
-        throw new Error(`unsupported registry rule kind "${rule.kind}"`);
-      }
-
-      results.push({
-        ok,
-        rule_id: rule.id,
-        kind: rule.kind,
-        left_entries: leftEntries,
-        right_entries: rightEntries,
-        missing_from_right: missingFromRight,
-        extra_in_right: extraInRight,
+      const leftEntries = readRegistrySource(rule.left, documents);
+      const rightEntries = readRegistrySource(rule.right, documents);
+      const left = new Set(leftEntries);
+      const right = new Set(rightEntries);
+      const missing = leftEntries.filter((entry) => !right.has(entry));
+      const extra = rightEntries.filter((entry) => !left.has(entry));
+      const ok = rule.kind === "set_equality" ? !missing.length && !extra.length
+        : rule.kind === "left_subset_of_right" ? !missing.length
+          : rule.kind === "right_subset_of_left" ? !extra.length
+            : (() => { throw new Error(`unsupported registry rule kind "${rule.kind}"`); })();
+      return {
+        ok, rule_id: rule.id, kind: rule.kind, left_entries: leftEntries, right_entries: rightEntries,
+        missing_from_right: missing, extra_in_right: extra,
         message: ok ? undefined : `registry rule "${rule.id}" failed ${rule.kind}`,
-      });
+      };
     } catch (error) {
-      results.push({
-        ok: false,
-        rule_id: rule.id,
-        kind: rule.kind,
-        left_entries: [],
-        right_entries: [],
-        missing_from_right: [],
-        extra_in_right: [],
-        message: `registry rule "${rule.id}" could not be evaluated`,
-        details: [error.message],
-      });
+      return {
+        ok: false, rule_id: rule.id, kind: rule.kind, left_entries: [], right_entries: [],
+        missing_from_right: [], extra_in_right: [], message: `registry rule "${rule.id}" could not be evaluated`, details: [error.message],
+      };
     }
-  }
-
+  });
   const failed = results.filter((result) => !result.ok);
   return {
-    ok: failed.length === 0,
-    results,
-    failed_rules: failed.map((result) => result.rule_id),
+    ok: failed.length === 0, results, failed_rules: failed.map((result) => result.rule_id),
     details: failed.flatMap((result) => [
       `[${result.rule_id}] ${result.message}`,
       `left entries: ${formatList(result.left_entries)}`,
@@ -196,8 +96,7 @@ export const registryRuleFamily = {
     return {
       name: "registry-rules",
       check: checkRegistryRules(facts.policy.registry_rules, {
-        repoRoot: facts.repositoryRoot,
-        readFile: facts.readFile,
+        repoRoot: facts.repositoryRoot, readFile: facts.readFile, documents: facts.documents,
       }),
     };
   },

--- a/src/document-facts.mjs
+++ b/src/document-facts.mjs
@@ -31,9 +31,12 @@ export function parseMarkdown(content) {
   for (const [offset, line] of lines.entries()) {
     const lineNumber = offset + 1;
     if (!fence) {
-      const opening = line.match(/^[ \t]*(`{3,}|~{3,})(.*)$/);
+      const opening = line.match(/^([ \t]*)(`{3,}|~{3,})(.*)$/);
       if (opening) {
-        fence = { marker: opening[1][0], length: opening[1].length, infoString: opening[2].trim(), startLine: lineNumber, contentLines: [] };
+        fence = {
+          indent: opening[1], marker: opening[2][0], length: opening[2].length,
+          infoString: opening[3].trim(), startLine: lineNumber, contentLines: [],
+        };
         continue;
       }
       const heading = line.match(/^[ \t]{0,3}(#{1,6})(?:[ \t]+|$)(.*)$/);
@@ -54,7 +57,7 @@ export function parseMarkdown(content) {
       codeBlocks.push({ language, infoString: fence.infoString, startLine: fence.startLine, endLine: lineNumber, content: fence.contentLines.join("\n") });
       fence = null;
     } else {
-      fence.contentLines.push(line.replace(/^[ \t]+/, (indent) => indent));
+      fence.contentLines.push(fence.indent && line.startsWith(fence.indent) ? line.slice(fence.indent.length) : line);
     }
   }
   if (fence) errors.push({ message: `unclosed Markdown fence starting at line ${fence.startLine}` });
@@ -66,8 +69,7 @@ export function markdownSection(markdown, section) {
   if (!heading) throw new Error(`markdown section "${section}" not found`);
   const end = markdown.headings.find((item) => item.line > heading.line && item.level <= heading.level)?.line || markdown.lines.length + 1;
   return {
-    startLine: heading.line + 1,
-    endLine: end - 1,
+    startLine: heading.line + 1, endLine: end - 1,
     lines: markdown.lines.slice(heading.line, end - 1),
     links: markdown.links.filter((link) => link.line > heading.line && link.line < end),
   };

--- a/src/document-facts.mjs
+++ b/src/document-facts.mjs
@@ -31,7 +31,7 @@ export function parseMarkdown(content) {
   for (const [offset, line] of lines.entries()) {
     const lineNumber = offset + 1;
     if (!fence) {
-      const opening = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+      const opening = line.match(/^[ \t]*(`{3,}|~{3,})(.*)$/);
       if (opening) {
         fence = { marker: opening[1][0], length: opening[1].length, infoString: opening[2].trim(), startLine: lineNumber, contentLines: [] };
         continue;
@@ -48,13 +48,13 @@ export function parseMarkdown(content) {
       continue;
     }
 
-    const closing = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
+    const closing = line.match(/^[ \t]*(`{3,}|~{3,})[ \t]*$/);
     if (closing && closing[1][0] === fence.marker && closing[1].length >= fence.length) {
       const language = fence.infoString.split(/\s+/).filter(Boolean)[0] || "";
       codeBlocks.push({ language, infoString: fence.infoString, startLine: fence.startLine, endLine: lineNumber, content: fence.contentLines.join("\n") });
       fence = null;
     } else {
-      fence.contentLines.push(line);
+      fence.contentLines.push(line.replace(/^[ \t]+/, (indent) => indent));
     }
   }
   if (fence) errors.push({ message: `unclosed Markdown fence starting at line ${fence.startLine}` });

--- a/src/document-facts.mjs
+++ b/src/document-facts.mjs
@@ -1,0 +1,93 @@
+import { parseDocument } from "yaml";
+import { readRepositoryTextFile } from "./utils/repository-files.mjs";
+
+function collapseMessage(message) {
+  return String(message || "").replace(/\s+/g, " ").trim();
+}
+
+export function parseYaml(content) {
+  const doc = parseDocument(content, { prettyErrors: false });
+  if (doc.errors.length) throw new Error(`invalid YAML: ${doc.errors.map((e) => collapseMessage(e.message)).join("; ")}`);
+  return doc.toJSON();
+}
+
+export function parseJson(content) {
+  return JSON.parse(content);
+}
+
+export function stripMarkdownInline(line) {
+  return line.replace(/`[^`]*`/g, "").replace(/\]\([^)]*\)/g, "]").replace(/https?:\/\/\S+/g, "");
+}
+
+export function parseMarkdown(content) {
+  const lines = String(content || "").split(/\r?\n/);
+  const headings = [];
+  const codeBlocks = [];
+  const proseLines = [];
+  const links = [];
+  const errors = [];
+  let fence = null;
+
+  for (const [offset, line] of lines.entries()) {
+    const lineNumber = offset + 1;
+    if (!fence) {
+      const opening = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
+      if (opening) {
+        fence = { marker: opening[1][0], length: opening[1].length, infoString: opening[2].trim(), startLine: lineNumber, contentLines: [] };
+        continue;
+      }
+      const heading = line.match(/^[ \t]{0,3}(#{1,6})(?:[ \t]+|$)(.*)$/);
+      if (heading) {
+        const text = heading[2].replace(/[ \t]+#+[ \t]*$/, "").trim();
+        if (text) headings.push({ level: heading[1].length, text, line: lineNumber });
+      }
+      for (const match of line.matchAll(/\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)) {
+        links.push({ target: match[1], line: lineNumber, column: match.index + 1 });
+      }
+      proseLines.push({ line: lineNumber, text: line });
+      continue;
+    }
+
+    const closing = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
+    if (closing && closing[1][0] === fence.marker && closing[1].length >= fence.length) {
+      const language = fence.infoString.split(/\s+/).filter(Boolean)[0] || "";
+      codeBlocks.push({ language, infoString: fence.infoString, startLine: fence.startLine, endLine: lineNumber, content: fence.contentLines.join("\n") });
+      fence = null;
+    } else {
+      fence.contentLines.push(line);
+    }
+  }
+  if (fence) errors.push({ message: `unclosed Markdown fence starting at line ${fence.startLine}` });
+  return { lines, headings, codeBlocks, proseLines, links, errors };
+}
+
+export function markdownSection(markdown, section) {
+  const heading = markdown.headings.find((item) => item.text.toLowerCase() === section.trim().toLowerCase());
+  if (!heading) throw new Error(`markdown section "${section}" not found`);
+  const end = markdown.headings.find((item) => item.line > heading.line && item.level <= heading.level)?.line || markdown.lines.length + 1;
+  return {
+    startLine: heading.line + 1,
+    endLine: end - 1,
+    lines: markdown.lines.slice(heading.line, end - 1),
+    links: markdown.links.filter((link) => link.line > heading.line && link.line < end),
+  };
+}
+
+export function createDocumentReader(options = {}) {
+  const textCache = new Map();
+  const parsed = { markdown: new Map(), json: new Map(), yaml: new Map() };
+  const text = (path) => {
+    if (!textCache.has(path)) textCache.set(path, readRepositoryTextFile(path, options));
+    return textCache.get(path);
+  };
+  const cached = (kind, path, parser) => {
+    if (!parsed[kind].has(path)) parsed[kind].set(path, parser(text(path)));
+    return parsed[kind].get(path);
+  };
+  return {
+    text,
+    markdown: (path) => cached("markdown", path, parseMarkdown),
+    json: (path) => cached("json", path, parseJson),
+    yaml: (path) => cached("yaml", path, parseYaml),
+  };
+}

--- a/src/extractors/anchors.mjs
+++ b/src/extractors/anchors.mjs
@@ -1,12 +1,11 @@
+import { parseJson } from "../document-facts.mjs";
 import { uniqueSorted } from "../utils/collections.mjs";
 import { matchesAny } from "../utils/path-patterns.mjs";
 import { readRepositoryTextFile } from "../utils/repository-files.mjs";
 
 function candidateAnchorFiles(options) {
-  const changedPaths = (options.changedFiles || [])
-    .filter((file) => file.status !== "deleted")
-    .map((file) => file.path);
-  return uniqueSorted([...(options.trackedFiles || []), ...changedPaths].filter(Boolean));
+  const changed = (options.changedFiles || []).filter((file) => file.status !== "deleted").map((file) => file.path);
+  return uniqueSorted([...(options.trackedFiles || []), ...changed].filter(Boolean));
 }
 
 function buildLineStarts(content) {
@@ -15,16 +14,16 @@ function buildLineStarts(content) {
   return starts;
 }
 
-function positionAt(lineStarts, index) {
+function positionAt(starts, index) {
   let low = 0;
-  let high = lineStarts.length - 1;
+  let high = starts.length - 1;
   while (low <= high) {
     const mid = Math.floor((low + high) / 2);
-    if (lineStarts[mid] <= index) low = mid + 1;
+    if (starts[mid] <= index) low = mid + 1;
     else high = mid - 1;
   }
   const lineIndex = Math.max(0, high);
-  return { line: lineIndex + 1, column: index - lineStarts[lineIndex] + 1 };
+  return { line: lineIndex + 1, column: index - starts[lineIndex] + 1 };
 }
 
 function makeRegex(pattern) {
@@ -34,24 +33,16 @@ function makeRegex(pattern) {
   return new RegExp(compiled.source, flags);
 }
 
-function firstDefinedCapture(match) {
-  for (let i = 1; i < match.length; i++) if (match[i] !== undefined) return i;
-  return null;
-}
-
 function extractRegexAnchors(anchorType, source, file, content) {
   const instances = [];
-  const regex = makeRegex(source.pattern);
-  const lineStarts = buildLineStarts(content);
-  for (const match of content.matchAll(regex)) {
-    const captureGroup = firstDefinedCapture(match);
+  const starts = buildLineStarts(content);
+  for (const match of content.matchAll(makeRegex(source.pattern))) {
+    let captureGroup = null;
+    for (let i = 1; i < match.length; i++) if (match[i] !== undefined) { captureGroup = i; break; }
     const value = captureGroup ? match[captureGroup] : match[0];
     const index = captureGroup && match.indices?.[captureGroup] ? match.indices[captureGroup][0] : match.index;
-    const position = positionAt(lineStarts, index);
-    const instance = {
-      anchorType, value: String(value), file, sourceKind: "regex",
-      line: position.line, column: position.column, raw: match[0],
-    };
+    const position = positionAt(starts, index);
+    const instance = { anchorType, value: String(value), file, sourceKind: "regex", ...position, raw: match[0] };
     if (captureGroup) instance.captureGroup = captureGroup;
     instances.push(instance);
   }
@@ -61,7 +52,7 @@ function extractRegexAnchors(anchorType, source, file, content) {
 function extractJsonFieldAnchor(anchorType, source, file, content) {
   let data;
   try {
-    data = JSON.parse(content);
+    data = parseJson(content);
   } catch (error) {
     throw new Error(`invalid JSON: ${error.message}`);
   }
@@ -73,19 +64,8 @@ function extractJsonFieldAnchor(anchorType, source, file, content) {
 }
 
 function compareInstances(a, b) {
-  return a.file.localeCompare(b.file) || (a.line || 0) - (b.line || 0) ||
-    (a.column || 0) - (b.column || 0) || a.anchorType.localeCompare(b.anchorType) || a.value.localeCompare(b.value);
-}
-
-function compareErrors(a, b) {
-  return (a.file || "").localeCompare(b.file || "") || a.anchorType.localeCompare(b.anchorType) ||
-    a.sourceIndex - b.sourceIndex || a.message.localeCompare(b.message);
-}
-
-function groupByType(anchorTypes, instances) {
-  const byType = Object.fromEntries(Object.keys(anchorTypes).sort().map((type) => [type, []]));
-  for (const instance of instances) (byType[instance.anchorType] ||= []).push(instance);
-  return byType;
+  return a.file.localeCompare(b.file) || (a.line || 0) - (b.line || 0) || (a.column || 0) - (b.column || 0) ||
+    a.anchorType.localeCompare(b.anchorType) || a.value.localeCompare(b.value);
 }
 
 export function extractAnchors(policy, options = {}) {
@@ -93,11 +73,12 @@ export function extractAnchors(policy, options = {}) {
   const files = candidateAnchorFiles(options);
   const instances = [];
   const errors = [];
+  const text = (file) => options.documents?.text(file) ?? readRepositoryTextFile(file, options);
   for (const [anchorType, config] of Object.entries(anchorTypes)) {
     for (const [sourceIndex, source] of (config.sources || []).entries()) {
       for (const file of files.filter((path) => matchesAny(path, [source.glob]))) {
         try {
-          const content = readRepositoryTextFile(file, options);
+          const content = text(file);
           if (source.kind === "regex") instances.push(...extractRegexAnchors(anchorType, source, file, content));
           else if (source.kind === "json_field") instances.push(...extractJsonFieldAnchor(anchorType, source, file, content));
           else throw new Error(`unsupported anchor source kind "${source.kind}"`);
@@ -108,20 +89,17 @@ export function extractAnchors(policy, options = {}) {
     }
   }
   instances.sort(compareInstances);
-  errors.sort(compareErrors);
-  return { instances, byType: groupByType(anchorTypes, instances), errors };
+  errors.sort((a, b) => (a.file || "").localeCompare(b.file || "") || a.anchorType.localeCompare(b.anchorType) || a.sourceIndex - b.sourceIndex || a.message.localeCompare(b.message));
+  const byType = Object.fromEntries(Object.keys(anchorTypes).sort().map((type) => [type, []]));
+  for (const instance of instances) (byType[instance.anchorType] ||= []).push(instance);
+  return { instances, byType, errors };
 }
 
 export function formatAnchorExtractionError(error) {
-  const source = `${error.sourceKind} source ${error.sourceIndex}`;
-  return `[${error.anchorType} ${source}] ${error.file ? `${error.file}: ` : ""}${error.message}`;
+  return `[${error.anchorType} ${error.sourceKind} source ${error.sourceIndex}] ${error.file ? `${error.file}: ` : ""}${error.message}`;
 }
 
 export function checkAnchorExtraction(anchorExtraction) {
   const errors = anchorExtraction?.errors || [];
-  return {
-    ok: errors.length === 0,
-    message: errors.length > 0 ? "anchor extraction failed" : undefined,
-    errors: errors.map(formatAnchorExtractionError),
-  };
+  return { ok: errors.length === 0, message: errors.length ? "anchor extraction failed" : undefined, errors: errors.map(formatAnchorExtractionError) };
 }

--- a/src/extractors/integration.mjs
+++ b/src/extractors/integration.mjs
@@ -1,87 +1,55 @@
-import { parseDocument } from "yaml";
+import { createDocumentReader, parseJson, parseMarkdown, parseYaml } from "../document-facts.mjs";
 import { uniqueSorted } from "../utils/collections.mjs";
-import { readRepositoryTextFile } from "../utils/repository-files.mjs";
 
 function isPlainObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function collapseMessage(message) {
-  return String(message || "").replace(/\s+/g, " ").trim();
-}
-
-function parseYamlFile(content) {
-  const doc = parseDocument(content, { prettyErrors: false });
-  if (doc.errors.length > 0) {
-    throw new Error(`invalid YAML: ${doc.errors.map((error) => collapseMessage(error.message)).join("; ")}`);
-  }
-  return doc.toJSON();
 }
 
 function normalizeValue(value) {
   if (value === undefined) return "";
   if (value === null) return "null";
   if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return String(value);
-  }
+  if (["number", "boolean", "bigint"].includes(typeof value)) return String(value);
   return JSON.stringify(value);
 }
 
 function normalizeMap(value) {
   if (!isPlainObject(value)) return null;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, item]) => [key, normalizeValue(item)])
-  );
+  return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => [key, normalizeValue(item)]));
 }
 
 function extractTriggerEvents(onValue) {
   if (typeof onValue === "string") return [onValue];
-  if (Array.isArray(onValue)) {
-    return onValue
-      .filter((item) => item !== null && item !== undefined)
-      .map((item) => normalizeValue(item));
-  }
-  if (isPlainObject(onValue)) return Object.keys(onValue);
-  return [];
+  if (Array.isArray(onValue)) return onValue.filter((item) => item != null).map(normalizeValue);
+  return isPlainObject(onValue) ? Object.keys(onValue) : [];
 }
 
 function extractTriggerEventTypes(onValue) {
   if (!isPlainObject(onValue)) return [];
-
-  const result = [];
-  for (const [event, config] of Object.entries(onValue)) {
-    if (!isPlainObject(config) || !Object.hasOwn(config, "types")) continue;
-    const rawTypes = Array.isArray(config.types) ? config.types : [config.types];
-    const types = rawTypes
-      .filter((item) => item !== null && item !== undefined)
-      .map((item) => normalizeValue(item));
-    if (types.length > 0) {
-      result.push({ event, types });
-    }
-  }
-  return result;
+  return Object.entries(onValue).flatMap(([event, config]) => {
+    if (!isPlainObject(config) || !Object.hasOwn(config, "types")) return [];
+    const types = (Array.isArray(config.types) ? config.types : [config.types]).filter((item) => item != null).map(normalizeValue);
+    return types.length ? [{ event, types }] : [];
+  });
 }
 
-function collectEnvVars(envValue, scope, extra = {}) {
-  const env = normalizeMap(envValue);
-  if (!env) return [];
-  return Object.entries(env).map(([name, value]) => ({
-    scope,
-    ...extra,
-    name,
-    value,
-  }));
+function collectEnvVars(value, scope, extra = {}) {
+  const env = normalizeMap(value);
+  return env ? Object.entries(env).map(([name, item]) => ({ scope, ...extra, name, value: item })) : [];
+}
+
+function detectSummaryPublishingMode(run) {
+  if (run == null || !String(run).includes("GITHUB_STEP_SUMMARY")) return null;
+  const text = String(run);
+  const target = String.raw`["']?\$?\{?GITHUB_STEP_SUMMARY\}?["']?`;
+  if (new RegExp(`>>\\s*${target}`).test(text) || new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*>>`).test(text)) return "append";
+  if (new RegExp(`(^|[^>])>\\s*${target}`).test(text) || new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*(^|[^>])>`).test(text)) return "write";
+  return "mentions";
 }
 
 function collectWorkflowFacts(entry, content) {
-  const data = parseYamlFile(content);
-  if (!isPlainObject(data)) {
-    throw new Error("workflow YAML must be a mapping");
-  }
-
+  const data = parseYaml(content);
+  if (!isPlainObject(data)) throw new Error("workflow YAML must be a mapping");
   const jobs = isPlainObject(data.jobs) ? data.jobs : {};
   const actionUses = [];
   const stepInputs = [];
@@ -94,259 +62,77 @@ function collectWorkflowFacts(entry, content) {
 
   for (const [jobId, job] of Object.entries(jobs)) {
     if (!isPlainObject(job)) continue;
-
-    const jobPermission = normalizeMap(job.permissions);
-    if (jobPermission) {
-      jobPermissions.push({ jobId, permissions: jobPermission });
-    } else if (typeof job.permissions === "string") {
-      jobPermissions.push({ jobId, permissions: job.permissions });
-    }
-
+    const permission = normalizeMap(job.permissions);
+    if (permission || typeof job.permissions === "string") jobPermissions.push({ jobId, permissions: permission || job.permissions });
     envVars.push(...collectEnvVars(job.env, "job", { jobId }));
-
-    if (job.if !== undefined) {
-      ifConditions.push({
-        scope: "job",
-        jobId,
-        condition: normalizeValue(job.if),
-      });
-    }
-
-    if (job["continue-on-error"] !== undefined) {
-      continueOnError.push({
-        scope: "job",
-        jobId,
-        value: normalizeValue(job["continue-on-error"]),
-      });
-    }
-
+    if (job.if !== undefined) ifConditions.push({ scope: "job", jobId, condition: normalizeValue(job.if) });
+    if (job["continue-on-error"] !== undefined) continueOnError.push({ scope: "job", jobId, value: normalizeValue(job["continue-on-error"]) });
     if (job.uses !== undefined) {
       const uses = normalizeValue(job.uses);
       actionUses.push({ scope: "job", jobId, uses });
       const inputs = normalizeMap(job.with);
-      if (inputs) {
-        stepInputs.push({ scope: "job", jobId, uses, inputs });
-      }
+      if (inputs) stepInputs.push({ scope: "job", jobId, uses, inputs });
     }
-
     if (!Array.isArray(job.steps)) continue;
-
-    for (const [stepOffset, step] of job.steps.entries()) {
+    for (const [offset, step] of job.steps.entries()) {
       if (!isPlainObject(step)) continue;
-      const stepIndex = stepOffset + 1;
-      const stepName = step.name ? normalizeValue(step.name) : undefined;
-      const stepBase = { jobId, stepIndex };
-      if (stepName) stepBase.stepName = stepName;
-
+      const base = { jobId, stepIndex: offset + 1 };
+      if (step.name) base.stepName = normalizeValue(step.name);
       if (step.uses !== undefined) {
         const uses = normalizeValue(step.uses);
-        actionUses.push({ ...stepBase, uses });
+        actionUses.push({ ...base, uses });
         const inputs = normalizeMap(step.with);
-        if (inputs) {
-          stepInputs.push({ ...stepBase, uses, inputs });
-        }
+        if (inputs) stepInputs.push({ ...base, uses, inputs });
       }
-
-      envVars.push(...collectEnvVars(step.env, "step", stepBase));
-
-      if (step.if !== undefined) {
-        ifConditions.push({
-          scope: "step",
-          ...stepBase,
-          condition: normalizeValue(step.if),
-        });
-      }
-
-      if (step["continue-on-error"] !== undefined) {
-        continueOnError.push({
-          ...stepBase,
-          value: normalizeValue(step["continue-on-error"]),
-        });
-      }
-
-      if (step.run !== undefined) {
-        runCommands.push({
-          ...stepBase,
-          run: normalizeValue(step.run),
-        });
-      }
-
-      const summaryMode = detectSummaryPublishingMode(step.run);
-      if (summaryMode) {
-        summaryPublishing.push({
-          ...stepBase,
-          mode: summaryMode,
-        });
-      }
+      envVars.push(...collectEnvVars(step.env, "step", base));
+      if (step.if !== undefined) ifConditions.push({ scope: "step", ...base, condition: normalizeValue(step.if) });
+      if (step["continue-on-error"] !== undefined) continueOnError.push({ ...base, value: normalizeValue(step["continue-on-error"]) });
+      if (step.run !== undefined) runCommands.push({ ...base, run: normalizeValue(step.run) });
+      const summary = detectSummaryPublishingMode(step.run);
+      if (summary) summaryPublishing.push({ ...base, mode: summary });
     }
   }
-
-  const workflowPermission = normalizeMap(data.permissions) ||
-    (typeof data.permissions === "string" ? data.permissions : null);
 
   return {
-    id: entry.id,
-    kind: entry.kind,
-    path: entry.path,
-    role: entry.role,
-    expect: entry.expect || null,
-    triggerEvents: extractTriggerEvents(data.on),
-    triggerEventTypes: extractTriggerEventTypes(data.on),
-    permissions: {
-      workflow: workflowPermission,
-      jobs: jobPermissions,
-    },
-    actionUses,
-    stepInputs,
-    envVars,
-    ifConditions,
-    runCommands,
-    summaryPublishing,
-    continueOnError,
+    id: entry.id, kind: entry.kind, path: entry.path, role: entry.role, expect: entry.expect || null,
+    triggerEvents: extractTriggerEvents(data.on), triggerEventTypes: extractTriggerEventTypes(data.on),
+    permissions: { workflow: normalizeMap(data.permissions) || (typeof data.permissions === "string" ? data.permissions : null), jobs: jobPermissions },
+    actionUses, stepInputs, envVars, ifConditions, runCommands, summaryPublishing, continueOnError,
   };
-}
-
-function detectSummaryPublishingMode(run) {
-  if (run === undefined || run === null) return null;
-  const text = String(run);
-  if (!text.includes("GITHUB_STEP_SUMMARY")) return null;
-  const summaryTarget = String.raw`["']?\$?\{?GITHUB_STEP_SUMMARY\}?["']?`;
-  const appendBeforeTarget = new RegExp(`>>\\s*${summaryTarget}`).test(text);
-  const appendAfterTarget = new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*>>`).test(text);
-  if (appendBeforeTarget || appendAfterTarget) return "append";
-  const writeBeforeTarget = new RegExp(`(^|[^>])>\\s*${summaryTarget}`).test(text);
-  const writeAfterTarget = new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*(^|[^>])>`).test(text);
-  if (writeBeforeTarget || writeAfterTarget) return "write";
-  return "mentions";
-}
-
-function parseMarkdown(content) {
-  const lines = String(content || "").split(/\r?\n/);
-  const headings = [];
-  const codeBlocks = [];
-  const errors = [];
-  let fence = null;
-
-  for (const [offset, line] of lines.entries()) {
-    const lineNumber = offset + 1;
-
-    if (!fence) {
-      const heading = line.match(/^[ \t]{0,3}(#{1,6})(?:[ \t]+|$)(.*)$/);
-      if (heading) {
-        const text = heading[2].replace(/[ \t]+#+[ \t]*$/, "").trim();
-        if (text) headings.push({ level: heading[1].length, text, line: lineNumber });
-      }
-
-      const openingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})(.*)$/);
-      if (openingFence) {
-        fence = {
-          marker: openingFence[1][0],
-          length: openingFence[1].length,
-          infoString: openingFence[2].trim(),
-          startLine: lineNumber,
-          contentLines: [],
-        };
-      }
-      continue;
-    }
-
-    const closingFence = line.match(/^[ \t]{0,3}(`{3,}|~{3,})[ \t]*$/);
-    if (
-      closingFence &&
-      closingFence[1][0] === fence.marker &&
-      closingFence[1].length >= fence.length
-    ) {
-      const language = fence.infoString.split(/\s+/).filter(Boolean)[0] || "";
-      codeBlocks.push({
-        language,
-        infoString: fence.infoString,
-        startLine: fence.startLine,
-        endLine: lineNumber,
-        content: fence.contentLines.join("\n"),
-      });
-      fence = null;
-      continue;
-    }
-
-    fence.contentLines.push(line);
-  }
-
-  if (fence) {
-    errors.push({
-      message: `unclosed Markdown fence starting at line ${fence.startLine}`,
-    });
-  }
-
-  return { headings, codeBlocks, errors };
 }
 
 function publicCodeBlock(block) {
-  return {
-    language: block.language,
-    infoString: block.infoString,
-    startLine: block.startLine,
-    endLine: block.endLine,
-  };
+  return { language: block.language, infoString: block.infoString, startLine: block.startLine, endLine: block.endLine };
 }
 
 function fieldPathsFromObject(value, prefix = "") {
   if (!isPlainObject(value)) return [];
-  const paths = [];
-  for (const key of Object.keys(value).sort()) {
+  return Object.keys(value).sort().flatMap((key) => {
     const path = prefix ? `${prefix}.${key}` : key;
-    paths.push(path);
-    paths.push(...fieldPathsFromObject(value[key], path));
-  }
-  return paths;
+    return [path, ...fieldPathsFromObject(value[key], path)];
+  });
 }
 
 function parseContractBlock(block) {
   try {
-    let data;
-    if (block.language === "repo-guard-json") {
-      data = JSON.parse(block.content);
-    } else {
-      data = parseYamlFile(block.content);
-    }
-    const fieldPaths = uniqueSorted(fieldPathsFromObject(data));
-    return {
-      ok: true,
-      fieldNames: isPlainObject(data) ? Object.keys(data).sort() : [],
-      fieldPaths,
-    };
-  } catch (e) {
-    return {
-      ok: false,
-      message: `invalid ${block.language} block at line ${block.startLine}: ${e.message}`,
-    };
+    const data = block.language === "repo-guard-json" ? parseJson(block.content) : parseYaml(block.content);
+    return { ok: true, fieldNames: isPlainObject(data) ? Object.keys(data).sort() : [], fieldPaths: uniqueSorted(fieldPathsFromObject(data)) };
+  } catch (error) {
+    return { ok: false, message: `invalid ${block.language} block at line ${block.startLine}: ${error.message}` };
   }
 }
 
 function extractContractBlocks(markdown) {
   const blocks = [];
   const errors = [];
-
-  for (const block of markdown.codeBlocks) {
-    if (block.language !== "repo-guard-yaml" && block.language !== "repo-guard-json") {
-      continue;
-    }
-
+  for (const block of markdown.codeBlocks.filter((item) => ["repo-guard-yaml", "repo-guard-json"].includes(item.language))) {
     const parsed = parseContractBlock(block);
-    const fact = {
-      format: block.language,
-      startLine: block.startLine,
-      endLine: block.endLine,
-      ok: parsed.ok,
-      fieldNames: parsed.fieldNames || [],
-      fieldPaths: parsed.fieldPaths || [],
-    };
-    blocks.push(fact);
-
-    if (!parsed.ok) {
-      errors.push({ message: parsed.message });
-    }
+    blocks.push({
+      format: block.language, startLine: block.startLine, endLine: block.endLine, ok: parsed.ok,
+      fieldNames: parsed.fieldNames || [], fieldPaths: parsed.fieldPaths || [],
+    });
+    if (!parsed.ok) errors.push({ message: parsed.message });
   }
-
   return { blocks, errors };
 }
 
@@ -354,103 +140,59 @@ function templateFactFromMarkdown(entry, markdown) {
   const { blocks, errors } = extractContractBlocks(markdown);
   return {
     fact: {
-      id: entry.id,
-      kind: entry.kind,
-      path: entry.path,
-      present: true,
-      optional: Boolean(entry.optional),
-      requiresContractBlock: Boolean(entry.requires_contract_block),
-      requiredBlockKind: entry.required_block_kind || null,
+      id: entry.id, kind: entry.kind, path: entry.path, present: true, optional: Boolean(entry.optional),
+      requiresContractBlock: Boolean(entry.requires_contract_block), requiredBlockKind: entry.required_block_kind || null,
       requiredContractFields: entry.required_contract_fields || [],
       hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
       hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
-      contractBlocks: blocks,
-      contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
-      headings: markdown.headings,
-      codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
-    },
-    errors,
+      contractBlocks: blocks, contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
+      headings: markdown.headings, codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+    }, errors,
   };
 }
 
 function collectStringValues(value, sourcePath = "$") {
   if (typeof value === "string") return [{ sourcePath, value }];
-  if (Array.isArray(value)) {
-    return value.flatMap((item, index) => collectStringValues(item, `${sourcePath}[${index}]`));
-  }
-  if (isPlainObject(value)) {
-    return Object.entries(value).flatMap(([key, item]) => collectStringValues(item, `${sourcePath}.${key}`));
-  }
-  return [];
+  if (Array.isArray(value)) return value.flatMap((item, index) => collectStringValues(item, `${sourcePath}[${index}]`));
+  return isPlainObject(value) ? Object.entries(value).flatMap(([key, item]) => collectStringValues(item, `${sourcePath}.${key}`)) : [];
 }
 
 function collectIssueFormTemplateFacts(entry, content) {
-  const data = parseYamlFile(content);
   const blocks = [];
   const errors = [];
-
-  for (const source of collectStringValues(data)) {
+  for (const source of collectStringValues(parseYaml(content))) {
     const markdown = parseMarkdown(source.value);
-    errors.push(...markdown.errors.map((error) => ({
-      message: `${source.sourcePath}: ${error.message}`,
-    })));
-
+    errors.push(...markdown.errors.map((error) => ({ message: `${source.sourcePath}: ${error.message}` })));
     const extracted = extractContractBlocks(markdown);
-    blocks.push(...extracted.blocks.map((block) => ({
-      ...block,
-      sourcePath: source.sourcePath,
-    })));
-    errors.push(...extracted.errors.map((error) => ({
-      message: `${source.sourcePath}: ${error.message}`,
-    })));
+    blocks.push(...extracted.blocks.map((block) => ({ ...block, sourcePath: source.sourcePath })));
+    errors.push(...extracted.errors.map((error) => ({ message: `${source.sourcePath}: ${error.message}` })));
   }
-
   return {
     fact: {
-      id: entry.id,
-      kind: entry.kind,
-      path: entry.path,
-      present: true,
-      optional: Boolean(entry.optional),
-      requiresContractBlock: Boolean(entry.requires_contract_block),
-      requiredBlockKind: entry.required_block_kind || null,
+      id: entry.id, kind: entry.kind, path: entry.path, present: true, optional: Boolean(entry.optional),
+      requiresContractBlock: Boolean(entry.requires_contract_block), requiredBlockKind: entry.required_block_kind || null,
       requiredContractFields: entry.required_contract_fields || [],
       hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
       hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
-      contractBlocks: blocks,
-      contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
-    },
-    errors,
+      contractBlocks: blocks, contractFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
+    }, errors,
   };
 }
 
 function missingOptionalTemplateFact(entry) {
   return {
-    id: entry.id,
-    kind: entry.kind,
-    path: entry.path,
-    present: false,
-    optional: true,
-    requiresContractBlock: Boolean(entry.requires_contract_block),
-    requiredBlockKind: entry.required_block_kind || null,
-    requiredContractFields: entry.required_contract_fields || [],
-    hasRepoGuardYamlBlock: false,
-    hasRepoGuardJsonBlock: false,
-    contractBlocks: [],
-    contractFieldNames: [],
-    headings: [],
-    codeBlocks: [],
+    id: entry.id, kind: entry.kind, path: entry.path, present: false, optional: true,
+    requiresContractBlock: Boolean(entry.requires_contract_block), requiredBlockKind: entry.required_block_kind || null,
+    requiredContractFields: entry.required_contract_fields || [], hasRepoGuardYamlBlock: false, hasRepoGuardJsonBlock: false,
+    contractBlocks: [], contractFieldNames: [], headings: [], codeBlocks: [],
   };
 }
 
-function collectTemplateFacts(entry, content) {
-  if (entry.kind === "github_issue_form") {
-    return collectIssueFormTemplateFacts(entry, content);
-  }
-
-  const markdown = parseMarkdown(content);
-  const result = templateFactFromMarkdown(entry, markdown);
-  result.errors.push(...markdown.errors);
+function collectTemplateFacts(entry, content, markdown = null) {
+  if (entry.kind === "github_issue_form") return collectIssueFormTemplateFacts(entry, content);
+  const parsed = markdown || parseMarkdown(content);
+  const result = templateFactFromMarkdown(entry, parsed);
+  result.errors.push(...parsed.errors);
   return result;
 }
 
@@ -458,7 +200,6 @@ function findLiteralOccurrences(content, term) {
   if (!term) return [];
   const needle = String(term).toLowerCase();
   const locations = [];
-
   for (const [offset, line] of String(content || "").split(/\r?\n/).entries()) {
     const haystack = line.toLowerCase();
     let index = 0;
@@ -467,48 +208,33 @@ function findLiteralOccurrences(content, term) {
       index += Math.max(needle.length, 1);
     }
   }
-
   return locations;
 }
 
 function mentionFact(content, term) {
   const locations = findLiteralOccurrences(content, term);
-  return {
-    term,
-    present: locations.length > 0,
-    count: locations.length,
-    locations,
-  };
+  return { term, present: locations.length > 0, count: locations.length, locations };
 }
 
-function collectDocFacts(entry, content) {
-  const markdown = parseMarkdown(content);
+function collectDocFacts(entry, content, markdown) {
   return {
     fact: {
-      id: entry.id,
-      path: entry.path,
-      headings: markdown.headings,
-      codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+      id: entry.id, path: entry.path, headings: markdown.headings, codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
       hasCodeBlocks: markdown.codeBlocks.length > 0,
       mentions: (entry.must_mention || []).map((term) => mentionFact(content, term)),
       fileReferences: (entry.must_reference_files || []).map((term) => mentionFact(content, term)),
       profileMentions: (entry.must_mention_profiles || []).map((term) => mentionFact(content, term)),
       contractFieldMentions: (entry.must_mention_contract_fields || []).map((term) => mentionFact(content, term)),
-    },
-    errors: markdown.errors,
+    }, errors: markdown.errors,
   };
 }
 
 function collectRegexFacts(content, regexes) {
   const facts = [];
   const seen = new Set();
-  const lines = String(content || "").split(/\r?\n/);
-
-  for (const [offset, line] of lines.entries()) {
-    for (const sourceRegex of regexes) {
-      const regex = new RegExp(sourceRegex.source, sourceRegex.flags.includes("g")
-        ? sourceRegex.flags
-        : `${sourceRegex.flags}g`);
+  for (const [offset, line] of String(content || "").split(/\r?\n/).entries()) {
+    for (const source of regexes) {
+      const regex = new RegExp(source.source, source.flags.includes("g") ? source.flags : `${source.flags}g`);
       let match;
       while ((match = regex.exec(line)) !== null) {
         const value = match[1];
@@ -522,150 +248,99 @@ function collectRegexFacts(content, regexes) {
       }
     }
   }
-
   return facts;
 }
 
 function profileReferenceFacts(content, profileId) {
-  const values = uniqueSorted([
-    profileId,
-    String(profileId || "").replace(/[-_.]+/g, " ").trim(),
-  ].filter(Boolean));
+  const values = uniqueSorted([profileId, String(profileId || "").replace(/[-_.]+/g, " ").trim()].filter(Boolean));
   const facts = [];
   const seen = new Set();
-
   for (const value of values) {
     for (const location of findLiteralOccurrences(content, value)) {
       const key = `${profileId}:${location.line}:${location.column}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      facts.push({ value: profileId, ...location });
+      if (!seen.has(key)) {
+        seen.add(key);
+        facts.push({ value: profileId, ...location });
+      }
     }
   }
-
-  facts.sort((left, right) => left.line - right.line || left.column - right.column || left.value.localeCompare(right.value));
-  return facts;
+  return facts.sort((a, b) => a.line - b.line || a.column - b.column || a.value.localeCompare(b.value));
 }
 
-function collectProfileFacts(entry, content) {
-  const markdown = parseMarkdown(content);
-  const identifiers = collectRegexFacts(content, [
-    /\bprofile[ _-]?id\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
-    /\bprofile\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
-  ]);
-  const migrationTargets = collectRegexFacts(content, [
-    /\bmigration[ _-]?target\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
-    /\bmigrat(?:e|es|ed|ing)\s+to\s+`?([A-Za-z0-9_.-]+)/i,
-  ]);
-
+function collectProfileFacts(entry, content, markdown) {
   return {
     fact: {
-      id: entry.id,
-      docPath: entry.doc_path,
-      headings: markdown.headings,
-      codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
-      identifiers,
-      migrationTargets,
+      id: entry.id, docPath: entry.doc_path, headings: markdown.headings, codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+      identifiers: collectRegexFacts(content, [
+        /\bprofile[ _-]?id\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+        /\bprofile\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+      ]),
+      migrationTargets: collectRegexFacts(content, [
+        /\bmigration[ _-]?target\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+        /\bmigrat(?:e|es|ed|ing)\s+to\s+`?([A-Za-z0-9_.-]+)/i,
+      ]),
       profileNameReferences: profileReferenceFacts(content, entry.id),
-    },
-    errors: markdown.errors,
+    }, errors: markdown.errors,
   };
 }
 
-function compareErrors(left, right) {
-  return left.section.localeCompare(right.section) ||
-    (left.path || "").localeCompare(right.path || "") ||
-    (left.id || "").localeCompare(right.id || "") ||
-    left.message.localeCompare(right.message);
+function compareErrors(a, b) {
+  return a.section.localeCompare(b.section) || (a.path || "").localeCompare(b.path || "") ||
+    (a.id || "").localeCompare(b.id || "") || a.message.localeCompare(b.message);
 }
 
 function withErrorContext(section, entry, message) {
-  return {
-    section,
-    id: entry.id,
-    kind: entry.kind,
-    path: entry.path || entry.doc_path,
-    message,
-  };
+  return { section, id: entry.id, kind: entry.kind, path: entry.path || entry.doc_path, message };
 }
 
 function isMissingRepositoryFileError(error, entry) {
   const message = String(error?.message || "");
-  return error?.code === "ENOENT" ||
-    message.includes("ENOENT") ||
-    message.includes("no such file or directory") ||
-    message === `cannot read ${entry.path}` ||
-    message.includes(`missing fixture ${entry.path}`);
+  return error?.code === "ENOENT" || message.includes("ENOENT") || message.includes("no such file or directory") ||
+    message === `cannot read ${entry.path}` || message.includes(`missing fixture ${entry.path}`);
 }
 
 export function extractIntegration(policy, options = {}) {
   const integration = policy.integration;
-  const result = {
-    workflows: [],
-    templates: [],
-    docs: [],
-    profiles: [],
-    errors: [],
-  };
-
+  const result = { workflows: [], templates: [], docs: [], profiles: [], errors: [] };
   if (!integration) return result;
-
-  const contentCache = new Map();
-  function contentFor(file) {
-    if (!contentCache.has(file)) {
-      contentCache.set(file, readRepositoryTextFile(file, options));
-    }
-    return contentCache.get(file);
-  }
+  const documents = options.documents || createDocumentReader(options);
 
   for (const entry of integration.workflows || []) {
     try {
-      result.workflows.push(collectWorkflowFacts(entry, contentFor(entry.path)));
-    } catch (e) {
-      result.errors.push(withErrorContext("workflows", entry, e.message));
+      result.workflows.push(collectWorkflowFacts(entry, documents.text(entry.path)));
+    } catch (error) {
+      result.errors.push(withErrorContext("workflows", entry, error.message));
     }
   }
-
   for (const entry of integration.templates || []) {
     try {
-      const extracted = collectTemplateFacts(entry, contentFor(entry.path));
+      const content = documents.text(entry.path);
+      const extracted = collectTemplateFacts(entry, content, entry.kind === "markdown" ? documents.markdown(entry.path) : null);
       result.templates.push(extracted.fact);
-      result.errors.push(...extracted.errors.map((error) =>
-        withErrorContext("templates", entry, error.message)
-      ));
-    } catch (e) {
-      if (entry.optional === true && isMissingRepositoryFileError(e, entry)) {
-        result.templates.push(missingOptionalTemplateFact(entry));
-      } else {
-        result.errors.push(withErrorContext("templates", entry, e.message));
-      }
+      result.errors.push(...extracted.errors.map((error) => withErrorContext("templates", entry, error.message)));
+    } catch (error) {
+      if (entry.optional === true && isMissingRepositoryFileError(error, entry)) result.templates.push(missingOptionalTemplateFact(entry));
+      else result.errors.push(withErrorContext("templates", entry, error.message));
     }
   }
-
   for (const entry of integration.docs || []) {
     try {
-      const extracted = collectDocFacts(entry, contentFor(entry.path));
+      const extracted = collectDocFacts(entry, documents.text(entry.path), documents.markdown(entry.path));
       result.docs.push(extracted.fact);
-      result.errors.push(...extracted.errors.map((error) =>
-        withErrorContext("docs", entry, error.message)
-      ));
-    } catch (e) {
-      result.errors.push(withErrorContext("docs", entry, e.message));
+      result.errors.push(...extracted.errors.map((error) => withErrorContext("docs", entry, error.message)));
+    } catch (error) {
+      result.errors.push(withErrorContext("docs", entry, error.message));
     }
   }
-
   for (const entry of integration.profiles || []) {
     try {
-      const extracted = collectProfileFacts(entry, contentFor(entry.doc_path));
+      const extracted = collectProfileFacts(entry, documents.text(entry.doc_path), documents.markdown(entry.doc_path));
       result.profiles.push(extracted.fact);
-      result.errors.push(...extracted.errors.map((error) =>
-        withErrorContext("profiles", entry, error.message)
-      ));
-    } catch (e) {
-      result.errors.push(withErrorContext("profiles", entry, e.message));
+      result.errors.push(...extracted.errors.map((error) => withErrorContext("profiles", entry, error.message)));
+    } catch (error) {
+      result.errors.push(withErrorContext("profiles", entry, error.message));
     }
   }
-
   result.errors.sort(compareErrors);
   return result;
 }

--- a/src/facts/input.mjs
+++ b/src/facts/input.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createDocumentReader } from "../document-facts.mjs";
 import { classifyNewFiles, detectTouchedSurfaces } from "../diff/classification.mjs";
 import { filterOperationalPaths } from "../diff/filters.mjs";
 import { parseDiff } from "../diff/parser.mjs";
@@ -25,14 +26,18 @@ export function buildPolicyFacts(input) {
     if (!cache.has(path)) cache.set(path, readRepositoryBufferFile(path, { repoRoot: repositoryRoot, readFile }));
     return cache.get(path);
   };
-  const options = { repoRoot: repositoryRoot, trackedFiles: resolvedTrackedFiles, changedFiles: checkedFiles, readFile: cachedReadFile };
+  const documents = createDocumentReader({ repoRoot: repositoryRoot, readFile: cachedReadFile });
+  const options = {
+    repoRoot: repositoryRoot, trackedFiles: resolvedTrackedFiles, changedFiles: checkedFiles,
+    readFile: cachedReadFile, documents,
+  };
   const touchedSurfaces = policy.surfaces ? detectTouchedSurfaces(checkedFiles, policy.surfaces) : null;
   const newFileClasses = policy.new_file_classes ? classifyNewFiles(checkedFiles, policy.new_file_classes) : null;
 
   return {
     mode, repositoryRoot, policy, basePolicy, headPolicy, contract, contractSource,
     issueAuthorization, trustedGovernancePaths, trustedAuthorizer,
-    readFile: cachedReadFile, enforcementMode: enforcement.mode, enforcement,
+    readFile: cachedReadFile, documents, enforcementMode: enforcement.mode, enforcement,
     diff: {
       files: {
         all: allFiles,
@@ -48,9 +53,6 @@ export function buildPolicyFacts(input) {
       touchedSurfaces,
       newFileClasses,
     },
-    diagnostics: {
-      ...diagnostics,
-      skippedOperationalFiles: allFiles.length - checkedFiles.length,
-    },
+    diagnostics: { ...diagnostics, skippedOperationalFiles: allFiles.length - checkedFiles.length },
   };
 }

--- a/src/markdown-contract.mjs
+++ b/src/markdown-contract.mjs
@@ -1,113 +1,70 @@
-import { parse as parseYaml } from "yaml";
+import { parseJson, parseMarkdown, parseYaml } from "./document-facts.mjs";
 
-const FENCE_RE = /^[ \t]*```(repo-guard-json|repo-guard-yaml)\s*\n([\s\S]*?)^[ \t]*```\s*$/gm;
-const FORMAT_LABELS = {
-  "repo-guard-json": "JSON",
-  "repo-guard-yaml": "YAML",
-};
+const FORMAT_LABELS = { "repo-guard-json": "JSON", "repo-guard-yaml": "YAML" };
 
 function parseContractBlock(block) {
   try {
-    if (block.format === "repo-guard-json") {
-      return { ok: true, contract: JSON.parse(block.content) };
-    }
-    return { ok: true, contract: parseYaml(block.content) };
-  } catch (e) {
-    const format = FORMAT_LABELS[block.format];
+    return {
+      ok: true,
+      contract: block.language === "repo-guard-json" ? parseJson(block.content) : parseYaml(block.content),
+    };
+  } catch (error) {
+    const format = FORMAT_LABELS[block.language];
     return {
       ok: false,
       error: `contract_malformed_${format.toLowerCase()}`,
-      message: `Invalid ${format} in ${block.format} block: ${e.message}`,
+      message: `Invalid ${format} in ${block.language} block: ${error.message}`,
     };
   }
 }
 
 export function extractContract(markdown) {
-  if (!markdown || typeof markdown !== "string") {
-    return { ok: false, error: "contract_not_found", message: "No markdown text provided" };
-  }
-
-  const blocks = [];
-  let match;
-  while ((match = FENCE_RE.exec(markdown)) !== null) {
-    blocks.push({ format: match[1], content: match[2] });
-  }
-
-  if (blocks.length === 0) {
-    return { ok: false, error: "contract_not_found", message: "No repo-guard-json or repo-guard-yaml block found in markdown" };
-  }
-
-  if (blocks.length > 1) {
-    return { ok: false, error: "multiple_contracts", message: `Found ${blocks.length} repo-guard contract blocks; expected exactly one` };
-  }
-
+  if (!markdown || typeof markdown !== "string") return { ok: false, error: "contract_not_found", message: "No markdown text provided" };
+  const parsed = parseMarkdown(markdown);
+  const blocks = parsed.codeBlocks.filter((block) => FORMAT_LABELS[block.language]);
+  if (blocks.length === 0) return { ok: false, error: "contract_not_found", message: "No repo-guard-json or repo-guard-yaml block found in markdown" };
+  if (blocks.length > 1) return { ok: false, error: "multiple_contracts", message: `Found ${blocks.length} repo-guard contract blocks; expected exactly one` };
   return parseContractBlock(blocks[0]);
 }
 
 const ISSUE_LINK_RE = /(?:Fixes|Closes|Resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
-
 export function extractLinkedIssueNumbers(text) {
   if (!text || typeof text !== "string") return [];
-  const numbers = [];
-  let match;
-  while ((match = ISSUE_LINK_RE.exec(text)) !== null) {
-    numbers.push(parseInt(match[1], 10));
-  }
-  return [...new Set(numbers)];
+  return [...new Set([...text.matchAll(ISSUE_LINK_RE)].map((match) => parseInt(match[1], 10)))];
 }
 
 export function resolveContract(prBody, issueBody) {
   const prResult = extractContract(prBody);
-  if (prResult.ok) return prResult;
-
-  if (prResult.error !== "contract_not_found") return prResult;
-
-  if (!issueBody) {
-    return { ok: false, error: "contract_not_found", message: "No contract in PR body and no linked issue body available" };
-  }
-
+  if (prResult.ok || prResult.error !== "contract_not_found") return prResult;
+  if (!issueBody) return { ok: false, error: "contract_not_found", message: "No contract in PR body and no linked issue body available" };
   const issueResult = extractContract(issueBody);
   if (issueResult.ok) return issueResult;
-
-  if (issueResult.error === "contract_not_found") {
-    return { ok: false, error: "fallback_missing", message: "No contract found in PR body or linked issue body" };
-  }
-
-  return issueResult;
+  return issueResult.error === "contract_not_found"
+    ? { ok: false, error: "fallback_missing", message: "No contract found in PR body or linked issue body" }
+    : issueResult;
 }
 
-const PRIVILEGED_AUTHORIZATION_FIELDS = [
-  "authorized_governance_paths",
-  "allow_policy_relaxation",
-];
-
-const SCHEMA_UNKNOWN_PRIVILEGED_FIELDS = [
-  "allow_policy_relaxation",
-];
+const PRIVILEGED_AUTHORIZATION_FIELDS = ["authorized_governance_paths", "allow_policy_relaxation"];
+const SCHEMA_UNKNOWN_PRIVILEGED_FIELDS = ["allow_policy_relaxation"];
 
 export function extractIssueAuthorization(issueBody) {
   if (!issueBody) return null;
   const result = extractContract(issueBody);
   if (!result.ok) return null;
   const authorization = {};
-  let hasAny = false;
   for (const field of PRIVILEGED_AUTHORIZATION_FIELDS) {
-    if (Object.hasOwn(result.contract, field)) {
-      authorization[field] = result.contract[field];
-      hasAny = true;
-    }
+    if (Object.hasOwn(result.contract, field)) authorization[field] = result.contract[field];
   }
-  return hasAny ? authorization : null;
+  return Object.keys(authorization).length ? authorization : null;
 }
 
 export function stripPrivilegedSchemaUnknownFields(contract) {
   if (!contract || typeof contract !== "object") return contract;
   let copy = null;
   for (const field of SCHEMA_UNKNOWN_PRIVILEGED_FIELDS) {
-    if (Object.hasOwn(contract, field)) {
-      if (copy === null) copy = { ...contract };
-      delete copy[field];
-    }
+    if (!Object.hasOwn(contract, field)) continue;
+    copy ||= { ...contract };
+    delete copy[field];
   }
-  return copy === null ? contract : copy;
+  return copy || contract;
 }

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -1,6 +1,7 @@
 import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
 import { compileConstraintIR, evaluateConstraintIR } from "../src/checks/rules/constraints.mjs";
 import { checkSizeRules } from "../src/checks/rules/size-rules.mjs";
+import { parseMarkdown } from "../src/document-facts.mjs";
 import { classifyPathSets, selectPaths } from "../src/diff/classification.mjs";
 
 let failures = 0;
@@ -12,6 +13,11 @@ function expect(label, actual, expected) {
     console.error(`  expected: ${expected}, got: ${actual}`);
   }
 }
+
+const markdown = parseMarkdown("# Заголовок\nТекст [ссылка](docs/a.md)\n```js\ncode()\n```\nПосле\n");
+expect("document facts parse headings once", markdown.headings[0].text, "Заголовок");
+expect("document facts expose links", markdown.links[0].target, "docs/a.md");
+expect("document facts exclude fenced code from prose", markdown.proseLines.some((line) => line.text.includes("code()")), false);
 
 const selectorFiles = [
   { path: "src/a.mjs", status: "modified", addedLines: ["x"], deletedLines: [] },


### PR DESCRIPTION
Fixes #113
Parent: #107

Сводит разросшиеся parser paths к одному документному слою:

- новый `document-facts.mjs` является каноническим parser/cache для Markdown, JSON и YAML;
- `RepositoryFacts` передаёт один parsed-document cache всем extractors/rules;
- contracts используют те же fenced-block facts, что integration templates;
- integration удаляет собственные Markdown/YAML parsers и локальный content cache;
- registry rules используют общие headings/links через `markdownSection`;
- `markdown_language` использует общие prose lines и больше не реализует свой fence state machine;
- JSON anchor fields используют общий JSON parser;
- fenced content dedent-ится, поэтому сохраняется поддержка контрактов внутри GitHub issue-form YAML.

Результат — одна реализация Markdown fence/heading/link semantics вместо четырёх. Structural diff существенно отрицательный: удалено несколько сотен строк parser-specific кода при добавлении компактного canonical слоя.

```repo-guard-yaml
change_type: refactor
scope:
  - src/document-facts.mjs
  - src/facts/**
  - src/extractors/**
  - src/checks/rules/content-rules.mjs
  - src/checks/rules/registry-rules.mjs
  - src/markdown-contract.mjs
  - tests/test-compression-rules.mjs
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/document-facts.mjs
must_not_touch:
  - schemas/**
  - repo-policy.json
  - .github/**
expected_effects:
  - Markdown JSON YAML и text facts имеют один parser/cache layer
  - contracts registry integration language checks и anchors больше не поддерживают независимые document parsers
  - parser-specific source surface значительно уменьшается
```