### PR TITLE
Compression 7/9: заменить field-specific policy-delta на strictness IR

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:profiles": "node tests/test-policy-profiles.mjs",
     "test:repo-root": "node tests/test-repo-root.mjs",
     "test:schemas": "node tests/validate-schemas.mjs",
-    "test:diff": "node tests/test-diff-rules.mjs",
+    "test:diff": "node tests/test-diff-rules.mjs && node tests/test-compression-rules.mjs && node tests/test-policy-delta-rules.mjs",
     "test:compression": "node tests/test-compression-rules.mjs",
     "test:documentation-language": "node tests/test-documentation-language.mjs",
     "test:registry": "node tests/test-rule-registry.mjs",

--- a/src/checks/rules/policy-delta-rules.mjs
+++ b/src/checks/rules/policy-delta-rules.mjs
@@ -1,314 +1,162 @@
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { expandGovernancePatterns } from "./governance-paths.mjs";
 
-const RELAXATION_KIND = {
-  SIZE_RULE_MAX_INCREASED: "size_rule_max_increased",
-  SIZE_RULE_LEVEL_WEAKENED: "size_rule_level_weakened",
-  SIZE_RULE_COUNT_WEAKENED: "size_rule_count_weakened",
-  SIZE_RULE_REMOVED: "size_rule_removed",
-  DIFF_RULE_BUDGET_INCREASED: "diff_rule_budget_increased",
-  DIFF_RULE_BUDGET_REMOVED: "diff_rule_budget_removed",
-  FORBIDDEN_PATH_REMOVED: "forbidden_path_removed",
-  GOVERNANCE_PATH_REMOVED: "governance_path_removed",
-  INTEGRATION_WORKFLOW_REMOVED: "integration_workflow_removed",
-  INTEGRATION_WORKFLOW_EXPECTATION_WEAKENED: "integration_workflow_expectation_weakened",
-  INTEGRATION_WORKFLOW_EXPECTATION_REMOVED: "integration_workflow_expectation_removed",
-  ENFORCEMENT_WEAKENED: "enforcement_weakened",
-  ENFORCEMENT_REMOVED: "enforcement_removed",
+const RANKS = {
+  enforcement: { advisory: 0, blocking: 1 },
+  count: { changed_only: 0, all_tracked: 1 },
 };
+const asArray = (value) => Array.isArray(value) ? value : [];
+const stable = (value) => JSON.stringify(value, Object.keys(value || {}).sort());
 
-const SIZE_RULE_LEVEL_RANK = { advisory: 0, blocking: 1 };
-const SIZE_RULE_COUNT_RANK = { changed_only: 0, all_tracked: 1 };
-const ENFORCEMENT_RANK = { advisory: 0, blocking: 1 };
-
-function asArray(value) {
-  return Array.isArray(value) ? value : [];
+function scalar(key, value, relation, metadata = {}) {
+  return { key, value, relation, ...metadata };
+}
+function setConstraint(key, value, metadata = {}) {
+  return { key, value: asArray(value), relation: "superset_stricter", ...metadata };
+}
+function entity(key, value, metadata = {}) {
+  return { key, value, relation: "required_entity", ...metadata };
 }
 
-function indexByKey(items, keyFn) {
-  const map = new Map();
-  for (const item of items) {
-    const key = keyFn(item);
-    if (key === undefined || key === null) continue;
-    map.set(String(key), item);
+/** Compile high-level policy into monotonic primitives understood by one comparator. */
+export function compilePolicyStrictnessIR(policy = {}) {
+  const constraints = [];
+  for (const rule of asArray(policy.size_rules)) {
+    const owner = `size:${rule.id}`;
+    constraints.push(entity(owner, { glob: rule.glob, max: rule.max }, {
+      pointer: `/size_rules/${rule.id}`, removeKind: "size_rule_removed", rule_id: rule.id,
+      removeMessage: `size_rules entry "${rule.id}" removed (glob: ${rule.glob ?? "?"}, max: ${rule.max ?? "?"})`,
+    }));
+    constraints.push(
+      scalar(`${owner}:max`, rule.max, "lower_stricter", { owner, pointer: `/size_rules/${rule.id}/max`, weakenKind: "size_rule_max_increased", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].max: ${a} -> ${b}` }),
+      scalar(`${owner}:level`, RANKS.enforcement[rule.level || "blocking"], "higher_stricter", { owner, raw: rule.level || "blocking", pointer: `/size_rules/${rule.id}/level`, weakenKind: "size_rule_level_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].level: ${a} -> ${b}` }),
+      scalar(`${owner}:count`, RANKS.count[rule.count || "all_tracked"], "higher_stricter", { owner, raw: rule.count || "all_tracked", pointer: `/size_rules/${rule.id}/count`, weakenKind: "size_rule_count_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].count: ${a} -> ${b}` }),
+    );
   }
-  return map;
+
+  for (const field of ["max_new_files", "max_new_docs", "max_net_added_lines"]) {
+    if (typeof policy.diff_rules?.[field] !== "number") continue;
+    constraints.push(scalar(`diff:${field}`, policy.diff_rules[field], "lower_stricter", {
+      pointer: `/diff_rules/${field}`, weakenKind: "diff_rule_budget_increased", removeKind: "diff_rule_budget_removed", field,
+      message: (a, b) => `diff_rules.${field}: ${a} -> ${b}`,
+      removeMessage: `diff_rules.${field} removed (was ${policy.diff_rules[field]})`,
+    }));
+  }
+
+  constraints.push(
+    setConstraint("paths:forbidden", policy.paths?.forbidden, { pointer: "/paths/forbidden", weakenKind: "forbidden_path_removed", itemField: "pattern", message: (item) => `paths.forbidden removed: ${item}` }),
+    setConstraint("paths:governance", policy.paths?.governance_paths, { pointer: "/paths/governance_paths", weakenKind: "governance_path_removed", itemField: "pattern", message: (item) => `paths.governance_paths removed: ${item}` }),
+  );
+
+  const mode = policy.enforcement?.mode;
+  if (mode) constraints.push(scalar("enforcement", RANKS.enforcement[mode], "higher_stricter", {
+    raw: mode, pointer: "/enforcement/mode", weakenKind: "enforcement_weakened", removeKind: "enforcement_removed",
+    message: (a, b) => `enforcement.mode: ${a} -> ${b}`, removeMessage: `enforcement.mode removed (was ${mode})`,
+  }));
+
+  for (const workflow of asArray(policy.integration?.workflows)) {
+    const owner = `workflow:${workflow.id}`;
+    constraints.push(entity(owner, { role: workflow.role, path: workflow.path }, {
+      pointer: `/integration/workflows/${workflow.id}`, removeKind: "integration_workflow_removed", workflow_id: workflow.id,
+      removeMessage: `integration.workflows entry "${workflow.id}" removed`,
+    }));
+    const enforcement = workflow.expect?.enforcement;
+    if (enforcement) constraints.push(scalar(`${owner}:enforcement`, RANKS.enforcement[enforcement], "higher_stricter", {
+      owner, raw: enforcement, pointer: `/integration/workflows/${workflow.id}/expect/enforcement`,
+      weakenKind: "integration_workflow_expectation_weakened", removeKind: "integration_workflow_expectation_removed", workflow_id: workflow.id,
+      message: (a, b) => `integration.workflows[${workflow.id}].expect.enforcement: ${a} -> ${b}`,
+      removeMessage: `integration.workflows[${workflow.id}].expect.enforcement removed (was ${enforcement})`,
+    }));
+  }
+  return constraints;
 }
 
-function buildSizeRuleIndex(policy) {
-  const sizeRules = asArray(policy?.size_rules);
-  return indexByKey(sizeRules, (rule) => rule.id);
+function relaxation(entry, { before, after = null, kind = entry.weakenKind, message = null, extra = {} }) {
+  return {
+    kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}),
+    ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
+    message: message || entry.message?.(before, after) || entry.removeMessage, ...extra,
+  };
 }
 
-function computeSizeRuleDeltas(basePolicy, headPolicy) {
-  const baseIndex = buildSizeRuleIndex(basePolicy);
-  const headIndex = buildSizeRuleIndex(headPolicy);
-  const deltas = [];
+function knownProjection(policy = {}) {
+  return {
+    enforcement: policy.enforcement,
+    diff_rules: policy.diff_rules,
+    size_rules: policy.size_rules,
+    paths: { forbidden: policy.paths?.forbidden, governance_paths: policy.paths?.governance_paths },
+    integration: { workflows: policy.integration?.workflows?.map((wf) => ({ id: wf.id, role: wf.role, path: wf.path, enforcement: wf.expect?.enforcement })) },
+  };
+}
 
-  for (const [id, baseRule] of baseIndex) {
-    const headRule = headIndex.get(id);
-    if (!headRule) {
-      deltas.push({
-        kind: RELAXATION_KIND.SIZE_RULE_REMOVED,
-        rule_id: id,
-        pointer: `/size_rules/${id}`,
-        before: { present: true, glob: baseRule.glob, max: baseRule.max },
-        after: { present: false },
-        message: `size_rules entry "${id}" removed (glob: ${baseRule.glob ?? "?"}, max: ${baseRule.max ?? "?"})`,
-      });
+export function comparePolicyStrictness(basePolicy, headPolicy) {
+  if (!basePolicy || !headPolicy) return { relation: "equal", relaxations: [], incomparable: [] };
+  const base = compilePolicyStrictnessIR(basePolicy);
+  const head = new Map(compilePolicyStrictnessIR(headPolicy).map((item) => [item.key, item]));
+  const relaxations = [];
+  let tightened = false;
+  const removedOwners = new Set();
+
+  for (const entry of base) {
+    if (entry.owner && removedOwners.has(entry.owner)) continue;
+    const next = head.get(entry.key);
+    if (!next) {
+      if (entry.removeKind) {
+        const before = entry.raw ?? entry.value;
+        relaxations.push(relaxation(entry, { before, kind: entry.removeKind, message: entry.removeMessage }));
+        if (entry.relation === "required_entity") removedOwners.add(entry.key);
+      }
       continue;
     }
-
-    const baseMax = typeof baseRule.max === "number" ? baseRule.max : null;
-    const headMax = typeof headRule.max === "number" ? headRule.max : null;
-    if (baseMax !== null && headMax !== null && headMax > baseMax) {
-      deltas.push({
-        kind: RELAXATION_KIND.SIZE_RULE_MAX_INCREASED,
-        rule_id: id,
-        pointer: `/size_rules/${id}/max`,
-        before: baseMax,
-        after: headMax,
-        message: `size_rules[${id}].max: ${baseMax} -> ${headMax}`,
-      });
-    }
-
-    const baseLevel = baseRule.level || "blocking";
-    const headLevel = headRule.level || "blocking";
-    if (
-      Object.hasOwn(SIZE_RULE_LEVEL_RANK, baseLevel) &&
-      Object.hasOwn(SIZE_RULE_LEVEL_RANK, headLevel) &&
-      SIZE_RULE_LEVEL_RANK[headLevel] < SIZE_RULE_LEVEL_RANK[baseLevel]
-    ) {
-      deltas.push({
-        kind: RELAXATION_KIND.SIZE_RULE_LEVEL_WEAKENED,
-        rule_id: id,
-        pointer: `/size_rules/${id}/level`,
-        before: baseLevel,
-        after: headLevel,
-        message: `size_rules[${id}].level: ${baseLevel} -> ${headLevel}`,
-      });
-    }
-
-    const baseCount = baseRule.count || "all_tracked";
-    const headCount = headRule.count || "all_tracked";
-    if (
-      Object.hasOwn(SIZE_RULE_COUNT_RANK, baseCount) &&
-      Object.hasOwn(SIZE_RULE_COUNT_RANK, headCount) &&
-      SIZE_RULE_COUNT_RANK[headCount] < SIZE_RULE_COUNT_RANK[baseCount]
-    ) {
-      deltas.push({
-        kind: RELAXATION_KIND.SIZE_RULE_COUNT_WEAKENED,
-        rule_id: id,
-        pointer: `/size_rules/${id}/count`,
-        before: baseCount,
-        after: headCount,
-        message: `size_rules[${id}].count: ${baseCount} -> ${headCount}`,
-      });
+    if (entry.relation === "lower_stricter") {
+      if (next.value > entry.value) relaxations.push(relaxation(entry, { before: entry.value, after: next.value }));
+      else if (next.value < entry.value) tightened = true;
+    } else if (entry.relation === "higher_stricter") {
+      if (next.value < entry.value) relaxations.push(relaxation(entry, { before: entry.raw ?? entry.value, after: next.raw ?? next.value }));
+      else if (next.value > entry.value) tightened = true;
+    } else if (entry.relation === "superset_stricter") {
+      const nextSet = new Set(next.value);
+      for (const item of entry.value) {
+        if (!nextSet.has(item)) relaxations.push(relaxation(entry, {
+          before: item, kind: entry.weakenKind, message: entry.message(item), extra: { [entry.itemField]: item },
+        }));
+      }
+      if (next.value.some((item) => !new Set(entry.value).has(item))) tightened = true;
     }
   }
+  for (const item of head.values()) if (!base.some((entry) => entry.key === item.key)) tightened = true;
 
-  return deltas;
-}
-
-function computeDiffRuleDeltas(basePolicy, headPolicy) {
-  const baseRules = basePolicy?.diff_rules || {};
-  const headRules = headPolicy?.diff_rules || {};
-  const fields = ["max_new_files", "max_new_docs", "max_net_added_lines"];
-  const deltas = [];
-  for (const field of fields) {
-    const baseValue = baseRules[field];
-    const headValue = headRules[field];
-    const baseHas = typeof baseValue === "number";
-    const headHas = typeof headValue === "number";
-    if (baseHas && !headHas) {
-      deltas.push({
-        kind: RELAXATION_KIND.DIFF_RULE_BUDGET_REMOVED,
-        field,
-        pointer: `/diff_rules/${field}`,
-        before: baseValue,
-        after: null,
-        message: `diff_rules.${field} removed (was ${baseValue})`,
-      });
-      continue;
-    }
-    if (!baseHas || !headHas) continue;
-    if (headValue > baseValue) {
-      deltas.push({
-        kind: RELAXATION_KIND.DIFF_RULE_BUDGET_INCREASED,
-        field,
-        pointer: `/diff_rules/${field}`,
-        before: baseValue,
-        after: headValue,
-        message: `diff_rules.${field}: ${baseValue} -> ${headValue}`,
-      });
-    }
+  const baseProjection = JSON.stringify(knownProjection(basePolicy));
+  const headProjection = JSON.stringify(knownProjection(headPolicy));
+  const baseUnknown = { ...basePolicy };
+  const headUnknown = { ...headPolicy };
+  for (const key of ["enforcement", "diff_rules", "size_rules", "paths", "integration"]) {
+    delete baseUnknown[key]; delete headUnknown[key];
   }
-  return deltas;
-}
+  const incomparable = stable(baseUnknown) === stable(headUnknown) ? [] : [{
+    kind: "policy_incomparable", pointer: "/", before: baseUnknown, after: headUnknown,
+    message: "policy sections outside the normalized strictness IR changed and require explicit governance review",
+  }];
 
-function computeForbiddenPathDeltas(basePolicy, headPolicy) {
-  const baseForbidden = asArray(basePolicy?.paths?.forbidden);
-  const headForbidden = new Set(asArray(headPolicy?.paths?.forbidden));
-  const deltas = [];
-  for (const pattern of baseForbidden) {
-    if (!headForbidden.has(pattern)) {
-      deltas.push({
-        kind: RELAXATION_KIND.FORBIDDEN_PATH_REMOVED,
-        pattern,
-        pointer: `/paths/forbidden`,
-        before: pattern,
-        after: null,
-        message: `paths.forbidden removed: ${pattern}`,
-      });
-    }
-  }
-  return deltas;
-}
-
-function computeGovernancePathDeltas(basePolicy, headPolicy) {
-  const baseGovernance = asArray(basePolicy?.paths?.governance_paths);
-  const headGovernance = new Set(asArray(headPolicy?.paths?.governance_paths));
-  const deltas = [];
-  for (const pattern of baseGovernance) {
-    if (!headGovernance.has(pattern)) {
-      deltas.push({
-        kind: RELAXATION_KIND.GOVERNANCE_PATH_REMOVED,
-        pattern,
-        pointer: `/paths/governance_paths`,
-        before: pattern,
-        after: null,
-        message: `paths.governance_paths removed: ${pattern}`,
-      });
-    }
-  }
-  return deltas;
-}
-
-function computeEnforcementDelta(basePolicy, headPolicy) {
-  const baseMode = basePolicy?.enforcement?.mode;
-  const headMode = headPolicy?.enforcement?.mode;
-  if (baseMode && !headMode) {
-    return [
-      {
-        kind: RELAXATION_KIND.ENFORCEMENT_REMOVED,
-        pointer: `/enforcement/mode`,
-        before: baseMode,
-        after: null,
-        message: `enforcement.mode removed (was ${baseMode})`,
-      },
-    ];
-  }
-  if (!baseMode || !headMode) return [];
-  if (
-    Object.hasOwn(ENFORCEMENT_RANK, baseMode) &&
-    Object.hasOwn(ENFORCEMENT_RANK, headMode) &&
-    ENFORCEMENT_RANK[headMode] < ENFORCEMENT_RANK[baseMode]
-  ) {
-    return [
-      {
-        kind: RELAXATION_KIND.ENFORCEMENT_WEAKENED,
-        pointer: `/enforcement/mode`,
-        before: baseMode,
-        after: headMode,
-        message: `enforcement.mode: ${baseMode} -> ${headMode}`,
-      },
-    ];
-  }
-  return [];
-}
-
-function computeIntegrationWorkflowDeltas(basePolicy, headPolicy) {
-  const baseWorkflows = asArray(basePolicy?.integration?.workflows);
-  const headWorkflows = indexByKey(asArray(headPolicy?.integration?.workflows), (wf) => wf.id);
-  const deltas = [];
-  for (const baseWorkflow of baseWorkflows) {
-    const id = baseWorkflow?.id;
-    if (!id) continue;
-    const headWorkflow = headWorkflows.get(String(id));
-    if (!headWorkflow) {
-      deltas.push({
-        kind: RELAXATION_KIND.INTEGRATION_WORKFLOW_REMOVED,
-        workflow_id: id,
-        pointer: `/integration/workflows/${id}`,
-        before: { present: true, role: baseWorkflow.role, path: baseWorkflow.path },
-        after: { present: false },
-        message: `integration.workflows entry "${id}" removed`,
-      });
-      continue;
-    }
-
-    const baseExpect = baseWorkflow.expect || {};
-    const headExpect = headWorkflow.expect || {};
-    const baseEnforcement = baseExpect.enforcement;
-    const headEnforcement = headExpect.enforcement;
-    if (baseEnforcement && !headEnforcement) {
-      deltas.push({
-        kind: RELAXATION_KIND.INTEGRATION_WORKFLOW_EXPECTATION_REMOVED,
-        workflow_id: id,
-        pointer: `/integration/workflows/${id}/expect/enforcement`,
-        before: baseEnforcement,
-        after: null,
-        message: `integration.workflows[${id}].expect.enforcement removed (was ${baseEnforcement})`,
-      });
-    } else if (
-      baseEnforcement &&
-      headEnforcement &&
-      Object.hasOwn(ENFORCEMENT_RANK, baseEnforcement) &&
-      Object.hasOwn(ENFORCEMENT_RANK, headEnforcement) &&
-      ENFORCEMENT_RANK[headEnforcement] < ENFORCEMENT_RANK[baseEnforcement]
-    ) {
-      deltas.push({
-        kind: RELAXATION_KIND.INTEGRATION_WORKFLOW_EXPECTATION_WEAKENED,
-        workflow_id: id,
-        pointer: `/integration/workflows/${id}/expect/enforcement`,
-        before: baseEnforcement,
-        after: headEnforcement,
-        message: `integration.workflows[${id}].expect.enforcement: ${baseEnforcement} -> ${headEnforcement}`,
-      });
-    }
-  }
-  return deltas;
+  const relation = relaxations.length ? "weaker"
+    : incomparable.length ? "incomparable"
+      : baseProjection === headProjection && !tightened ? "equal" : "stricter";
+  return { relation, relaxations, incomparable };
 }
 
 export function computePolicyDelta(basePolicy, headPolicy) {
-  if (!basePolicy || !headPolicy) {
-    return { relaxations: [] };
-  }
-  const relaxations = [
-    ...computeSizeRuleDeltas(basePolicy, headPolicy),
-    ...computeDiffRuleDeltas(basePolicy, headPolicy),
-    ...computeForbiddenPathDeltas(basePolicy, headPolicy),
-    ...computeGovernancePathDeltas(basePolicy, headPolicy),
-    ...computeIntegrationWorkflowDeltas(basePolicy, headPolicy),
-    ...computeEnforcementDelta(basePolicy, headPolicy),
-  ];
-  return { relaxations };
+  if (!basePolicy || !headPolicy) return { relaxations: [] };
+  const compared = comparePolicyStrictness(basePolicy, headPolicy);
+  return { relaxations: [...compared.relaxations, ...compared.incomparable] };
 }
 
 const DEFAULT_PROTECTED_SURFACES = ["source", "tests", "schemas"];
-
-function protectedSurfacePatterns(basePolicy, configuredSurfaces = null) {
-  const surfaces = basePolicy?.surfaces || {};
-  const names = configuredSurfaces && configuredSurfaces.length > 0
-    ? configuredSurfaces
-    : DEFAULT_PROTECTED_SURFACES;
-  const patterns = [];
-  for (const name of names) {
-    for (const pattern of asArray(surfaces[name])) {
-      if (!patterns.includes(pattern)) patterns.push(pattern);
-    }
-  }
-  return patterns;
+function protectedSurfacePatterns(basePolicy, configured = null) {
+  const names = configured?.length ? configured : DEFAULT_PROTECTED_SURFACES;
+  return [...new Set(names.flatMap((name) => asArray(basePolicy?.surfaces?.[name])))];
 }
-
-function isPolicyFile(filePath, policyPath = "repo-policy.json") {
-  return filePath === policyPath;
-}
-
-function isGovernanceFile(filePath, basePolicy) {
-  const governance = asArray(basePolicy?.paths?.governance_paths);
-  if (governance.length === 0) return false;
-  return matchesAny(filePath, expandGovernancePatterns(governance));
+function isGovernanceFile(path, policy) {
+  return path === "repo-policy.json" || matchesAny(path, expandGovernancePatterns(asArray(policy?.paths?.governance_paths)));
 }
 
 export function classifyChangedFiles(files, basePolicy, configuredProtectedSurfaces = null) {
@@ -316,182 +164,85 @@ export function classifyChangedFiles(files, basePolicy, configuredProtectedSurfa
   const protectedFiles = [];
   const governanceFiles = [];
   const otherFiles = [];
-
   for (const file of files) {
-    const path = file.path;
-    if (isPolicyFile(path)) {
-      governanceFiles.push(path);
-      continue;
-    }
-    if (isGovernanceFile(path, basePolicy)) {
-      governanceFiles.push(path);
-      continue;
-    }
-    if (protectedPatterns.length > 0 && matchesAny(path, protectedPatterns)) {
-      protectedFiles.push(path);
-      continue;
-    }
-    otherFiles.push(path);
+    if (isGovernanceFile(file.path, basePolicy)) governanceFiles.push(file.path);
+    else if (protectedPatterns.length && matchesAny(file.path, protectedPatterns)) protectedFiles.push(file.path);
+    else otherFiles.push(file.path);
   }
-
   return { protectedFiles, governanceFiles, otherFiles, protectedPatterns };
+}
+
+function pointerCovers(authorizationPointer, deltaPointer) {
+  if (typeof authorizationPointer !== "string" || typeof deltaPointer !== "string") return false;
+  if (authorizationPointer === deltaPointer || deltaPointer.startsWith(`${authorizationPointer}/`)) return true;
+  if (!authorizationPointer.endsWith("/*")) return false;
+  const prefix = authorizationPointer.slice(0, -2);
+  const remainder = deltaPointer.startsWith(`${prefix}/`) ? deltaPointer.slice(prefix.length + 1) : null;
+  return remainder !== null && remainder.split("/").length <= 2;
 }
 
 function trustedIssueAuthorizationCoversRelaxation(issueAuthorization, relaxations) {
   if (!issueAuthorization) return { ok: false, reason: "no_linked_issue_authorization" };
   const allowed = asArray(issueAuthorization.allow_policy_relaxation);
-  if (allowed.length === 0) {
-    return { ok: false, reason: "linked_issue_missing_allow_policy_relaxation" };
-  }
-  const uncoveredPointers = relaxations
-    .map((relaxation) => relaxation.pointer)
-    .filter((pointer) => !allowed.some((p) => pointerCovers(p, pointer)));
-  if (uncoveredPointers.length > 0) {
-    return {
-      ok: false,
-      reason: "linked_issue_allow_policy_relaxation_does_not_cover_all_pointers",
-      uncovered_pointers: uncoveredPointers,
-      allowed_pointers: allowed,
-    };
-  }
-  return { ok: true, allowed_pointers: allowed };
+  if (!allowed.length) return { ok: false, reason: "linked_issue_missing_allow_policy_relaxation" };
+  const uncovered = relaxations.map((item) => item.pointer).filter((pointer) => !allowed.some((entry) => pointerCovers(entry, pointer)));
+  return uncovered.length
+    ? { ok: false, reason: "linked_issue_allow_policy_relaxation_does_not_cover_all_pointers", uncovered_pointers: uncovered, allowed_pointers: allowed }
+    : { ok: true, allowed_pointers: allowed };
 }
 
-function pointerCovers(authorizationPointer, deltaPointer) {
-  if (typeof authorizationPointer !== "string" || typeof deltaPointer !== "string") return false;
-  if (authorizationPointer === deltaPointer) return true;
-  if (deltaPointer.startsWith(`${authorizationPointer}/`)) return true;
-  if (authorizationPointer.endsWith("/*")) {
-    const prefix = authorizationPointer.slice(0, -2);
-    const remainder = deltaPointer.startsWith(`${prefix}/`) ? deltaPointer.slice(prefix.length + 1) : null;
-    if (remainder !== null && !remainder.includes("/")) return true;
-    if (remainder !== null && remainder.split("/").length === 2) return true;
-  }
-  return false;
+function summarizeTrustedAuthorizer(authorizer) {
+  if (!authorizer || typeof authorizer !== "object") return { trusted: false, reasons: ["trusted_authorizer_missing"] };
+  const sources = [];
+  if (authorizer.issue_author_permission_trusted) sources.push("issue_author_permission");
+  if (authorizer.governance_approved_label) sources.push("governance_approved_label");
+  if (authorizer.codeowner_approved) sources.push("codeowner_approval");
+  if (authorizer.trusted_team_approval) sources.push("trusted_team_approval");
+  return sources.length ? { trusted: true, reasons: [], detected_sources: sources }
+    : { trusted: false, reasons: ["no_trusted_authorization_source"], detected_sources: [] };
 }
 
 export function checkPolicyRelaxation({
-  basePolicy,
-  headPolicy,
-  changedFiles,
-  trustedAuthorizer,
-  issueAuthorization,
-  contractChangeType,
+  basePolicy, headPolicy, changedFiles, trustedAuthorizer, issueAuthorization, contractChangeType,
   configuredProtectedSurfaces = null,
 }) {
-  if (!basePolicy || !headPolicy) {
-    return { ok: true };
-  }
-
+  if (!basePolicy || !headPolicy) return { ok: true };
   const { relaxations } = computePolicyDelta(basePolicy, headPolicy);
-  if (relaxations.length === 0) {
-    return { ok: true, policy_relaxations: [] };
-  }
+  if (!relaxations.length) return { ok: true, policy_relaxations: [] };
 
-  const { protectedFiles, governanceFiles, otherFiles, protectedPatterns } = classifyChangedFiles(
-    changedFiles,
-    basePolicy,
-    configuredProtectedSurfaces
-  );
-
-  const messages = relaxations.map((relaxation) => relaxation.message);
-
-  const reasons = [];
-  const trustedAuthorizerSummary = summarizeTrustedAuthorizer(trustedAuthorizer);
-  if (!trustedAuthorizerSummary.trusted) {
-    reasons.push(...trustedAuthorizerSummary.reasons);
-  }
-
-  const issueAuthCheck = trustedIssueAuthorizationCoversRelaxation(issueAuthorization, relaxations);
-  if (!issueAuthCheck.ok) {
-    reasons.push(issueAuthCheck.reason);
-  }
-
-  const isGovernanceOnly =
-    protectedFiles.length === 0 &&
-    otherFiles.length === 0 &&
-    governanceFiles.length > 0;
-
-  if (!isGovernanceOnly) {
-    reasons.push("policy_relaxation_mixed_with_non_governance_changes");
-  }
-
-  if (contractChangeType && contractChangeType !== "governance") {
-    reasons.push("contract_change_type_is_not_governance");
-  }
-
+  const classified = classifyChangedFiles(changedFiles, basePolicy, configuredProtectedSurfaces);
+  const authorizer = summarizeTrustedAuthorizer(trustedAuthorizer);
+  const issueAuth = trustedIssueAuthorizationCoversRelaxation(issueAuthorization, relaxations);
+  const reasons = [...authorizer.reasons];
+  if (!issueAuth.ok) reasons.push(issueAuth.reason);
+  const governanceOnly = !classified.protectedFiles.length && !classified.otherFiles.length && classified.governanceFiles.length > 0;
+  if (!governanceOnly) reasons.push("policy_relaxation_mixed_with_non_governance_changes");
+  if (contractChangeType && contractChangeType !== "governance") reasons.push("contract_change_type_is_not_governance");
+  const details = relaxations.map((item) => `- ${item.pointer}: ${item.message}`);
+  if (!governanceOnly && classified.protectedFiles.length) details.push(`Mixed with protected-surface changes: ${classified.protectedFiles.slice(0, 10).join(", ")}${classified.protectedFiles.length > 10 ? `, +${classified.protectedFiles.length - 10} more` : ""}`);
+  if (authorizer.reasons.length) details.push(`trusted_authorizer: ${authorizer.reasons.join(", ")}`);
   const ok = reasons.length === 0;
-
-  const details = relaxations.map((relaxation) => `- ${relaxation.pointer}: ${relaxation.message}`);
-  if (!isGovernanceOnly && protectedFiles.length > 0) {
-    details.push(
-      `Mixed with protected-surface changes: ${protectedFiles.slice(0, 10).join(", ")}${
-        protectedFiles.length > 10 ? `, +${protectedFiles.length - 10} more` : ""
-      }`
-    );
-  }
-  if (trustedAuthorizerSummary.reasons.length > 0) {
-    details.push(`trusted_authorizer: ${trustedAuthorizerSummary.reasons.join(", ")}`);
-  }
-
   return {
-    ok,
-    message: ok ? undefined : "PR attempts to relax trusted repository policy",
-    policy_relaxations: relaxations,
-    details,
-    blocked_reasons: reasons,
-    governance_only: isGovernanceOnly,
-    protected_files: protectedFiles,
-    governance_files: governanceFiles,
-    other_files: otherFiles,
-    protected_patterns: protectedPatterns,
-    trusted_authorizer: trustedAuthorizerSummary,
-    hint: ok
-      ? undefined
-      : [
-          "Policy relaxation must be submitted as a dedicated governance change and authorized by a trusted maintainer/code owner.",
-          "Do not combine policy relaxation with product/kernel/generated changes.",
-          "Set contract change_type to \"governance\" and ensure the linked issue body lists the relaxed pointers in allow_policy_relaxation.",
-          "Trusted authorization sources: linked-issue author with write/maintain/admin permission, a maintainer-applied governance-approved label, a CODEOWNERS approval for the governance files, or a configured trusted GitHub team approval.",
-        ].join(" "),
+    ok, message: ok ? undefined : "PR attempts to relax trusted repository policy",
+    policy_relaxations: relaxations, details, blocked_reasons: reasons, governance_only: governanceOnly,
+    protected_files: classified.protectedFiles, governance_files: classified.governanceFiles, other_files: classified.otherFiles,
+    protected_patterns: classified.protectedPatterns, trusted_authorizer: authorizer,
+    hint: ok ? undefined : "Policy relaxation must be a dedicated governance change, authorized by a trusted maintainer/code owner, with change_type governance and all relaxed pointers listed in linked-issue allow_policy_relaxation.",
   };
-}
-
-function summarizeTrustedAuthorizer(trustedAuthorizer) {
-  if (!trustedAuthorizer || typeof trustedAuthorizer !== "object") {
-    return { trusted: false, reasons: ["trusted_authorizer_missing"] };
-  }
-
-  const sources = [];
-  if (trustedAuthorizer.issue_author_permission_trusted) sources.push("issue_author_permission");
-  if (trustedAuthorizer.governance_approved_label) sources.push("governance_approved_label");
-  if (trustedAuthorizer.codeowner_approved) sources.push("codeowner_approval");
-  if (trustedAuthorizer.trusted_team_approval) sources.push("trusted_team_approval");
-  if (sources.length === 0) {
-    return {
-      trusted: false,
-      reasons: ["no_trusted_authorization_source"],
-      detected_sources: [],
-    };
-  }
-  return { trusted: true, reasons: [], detected_sources: sources };
 }
 
 export const policyRelaxationRuleFamily = {
   id: "policy-delta",
-  applies(facts) {
-    return Boolean(facts.basePolicy && facts.headPolicy);
-  },
+  applies: (facts) => Boolean(facts.basePolicy && facts.headPolicy),
   evaluate(facts) {
-    const check = checkPolicyRelaxation({
-      basePolicy: facts.basePolicy,
-      headPolicy: facts.headPolicy,
-      changedFiles: facts.diff.files.checked,
-      trustedAuthorizer: facts.trustedAuthorizer,
-      issueAuthorization: facts.issueAuthorization,
-      contractChangeType: facts.contract?.change_type,
-      configuredProtectedSurfaces: facts.basePolicy?.policy_delta_rules?.protected_surfaces,
-    });
-    return { name: "policy-relaxation", check };
+    return {
+      name: "policy-relaxation",
+      check: checkPolicyRelaxation({
+        basePolicy: facts.basePolicy, headPolicy: facts.headPolicy, changedFiles: facts.diff.files.checked,
+        trustedAuthorizer: facts.trustedAuthorizer, issueAuthorization: facts.issueAuthorization,
+        contractChangeType: facts.contract?.change_type,
+        configuredProtectedSurfaces: facts.basePolicy?.policy_delta_rules?.protected_surfaces,
+      }),
+    };
   },
 };

--- a/src/checks/rules/policy-delta-rules.mjs
+++ b/src/checks/rules/policy-delta-rules.mjs
@@ -6,87 +6,188 @@ const RANKS = {
   count: { changed_only: 0, all_tracked: 1 },
 };
 const asArray = (value) => Array.isArray(value) ? value : [];
-const stable = (value) => JSON.stringify(value, Object.keys(value || {}).sort());
 
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])]));
+  }
+  return value;
+}
+const same = (left, right) => JSON.stringify(canonical(left)) === JSON.stringify(canonical(right));
+const clone = (value) => value === undefined ? undefined : structuredClone(value);
+
+function constraint(key, relation, value, metadata = {}) {
+  return { key, relation, value, ...metadata };
+}
 function scalar(key, value, relation, metadata = {}) {
-  return { key, value, relation, ...metadata };
+  return constraint(key, relation, value, metadata);
 }
-function setConstraint(key, value, metadata = {}) {
-  return { key, value: asArray(value), relation: "superset_stricter", ...metadata };
+function setConstraint(key, value, relation, metadata = {}) {
+  return constraint(key, relation, asArray(value), metadata);
 }
-function entity(key, value, metadata = {}) {
-  return { key, value, relation: "required_entity", ...metadata };
+function entity(key, metadata = {}) {
+  return constraint(key, "required_entity", true, metadata);
+}
+function exact(key, value, metadata = {}) {
+  return constraint(key, "equal_or_incomparable", value, metadata);
 }
 
-/** Compile high-level policy into monotonic primitives understood by one comparator. */
+/**
+ * Compile policy into a small monotonic comparison IR.
+ * High-level macros that expand to these primitives gain self-weakening protection
+ * without adding another field-specific delta walker.
+ */
 export function compilePolicyStrictnessIR(policy = {}) {
-  const constraints = [];
+  const result = [];
+
   for (const rule of asArray(policy.size_rules)) {
     const owner = `size:${rule.id}`;
-    constraints.push(entity(owner, { glob: rule.glob, max: rule.max }, {
-      pointer: `/size_rules/${rule.id}`, removeKind: "size_rule_removed", rule_id: rule.id,
+    result.push(entity(owner, {
+      pointer: `/size_rules/${rule.id}`,
+      removeKind: "size_rule_removed",
+      rule_id: rule.id,
+      removeBefore: { present: true, glob: rule.glob, max: rule.max },
+      removeAfter: { present: false },
       removeMessage: `size_rules entry "${rule.id}" removed (glob: ${rule.glob ?? "?"}, max: ${rule.max ?? "?"})`,
     }));
-    constraints.push(
-      scalar(`${owner}:max`, rule.max, "lower_stricter", { owner, pointer: `/size_rules/${rule.id}/max`, weakenKind: "size_rule_max_increased", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].max: ${a} -> ${b}` }),
-      scalar(`${owner}:level`, RANKS.enforcement[rule.level || "blocking"], "higher_stricter", { owner, raw: rule.level || "blocking", pointer: `/size_rules/${rule.id}/level`, weakenKind: "size_rule_level_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].level: ${a} -> ${b}` }),
-      scalar(`${owner}:count`, RANKS.count[rule.count || "all_tracked"], "higher_stricter", { owner, raw: rule.count || "all_tracked", pointer: `/size_rules/${rule.id}/count`, weakenKind: "size_rule_count_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].count: ${a} -> ${b}` }),
+    result.push(
+      exact(`${owner}:shape`, {
+        scope: rule.scope,
+        metric: rule.metric,
+        glob: rule.glob,
+        applies_to_change_types: rule.applies_to_change_types,
+      }, { owner, pointer: `/size_rules/${rule.id}`, incomparableMessage: `size_rules[${rule.id}] changed selector/scope semantics` }),
+      scalar(`${owner}:max`, rule.max, "lower_stricter", {
+        owner, pointer: `/size_rules/${rule.id}/max`, weakenKind: "size_rule_max_increased", rule_id: rule.id,
+        message: (before, after) => `size_rules[${rule.id}].max: ${before} -> ${after}`,
+      }),
+      scalar(`${owner}:level`, RANKS.enforcement[rule.level || "blocking"], "higher_stricter", {
+        owner, raw: rule.level || "blocking", pointer: `/size_rules/${rule.id}/level`, weakenKind: "size_rule_level_weakened", rule_id: rule.id,
+        message: (before, after) => `size_rules[${rule.id}].level: ${before} -> ${after}`,
+      }),
+      scalar(`${owner}:count`, RANKS.count[rule.count || "all_tracked"], "higher_stricter", {
+        owner, raw: rule.count || "all_tracked", pointer: `/size_rules/${rule.id}/count`, weakenKind: "size_rule_count_weakened", rule_id: rule.id,
+        message: (before, after) => `size_rules[${rule.id}].count: ${before} -> ${after}`,
+      }),
+      setConstraint(`${owner}:ignore`, rule.ignore, "subset_stricter", {
+        owner, pointer: `/size_rules/${rule.id}/ignore`, weakenKind: "size_rule_ignore_added", itemField: "pattern",
+        message: (item) => `size_rules[${rule.id}].ignore added: ${item}`,
+      }),
     );
+    if (rule.max_growth !== undefined) {
+      result.push(scalar(`${owner}:max_growth`, rule.max_growth, "lower_stricter", {
+        owner, pointer: `/size_rules/${rule.id}/max_growth`, weakenKind: "size_rule_max_growth_increased",
+        removeKind: "size_rule_max_growth_removed", rule_id: rule.id,
+        message: (before, after) => `size_rules[${rule.id}].max_growth: ${before} -> ${after}`,
+        removeMessage: `size_rules[${rule.id}].max_growth removed (was ${rule.max_growth})`,
+      }));
+    }
   }
 
   for (const field of ["max_new_files", "max_new_docs", "max_net_added_lines"]) {
     if (typeof policy.diff_rules?.[field] !== "number") continue;
-    constraints.push(scalar(`diff:${field}`, policy.diff_rules[field], "lower_stricter", {
+    result.push(scalar(`diff:${field}`, policy.diff_rules[field], "lower_stricter", {
       pointer: `/diff_rules/${field}`, weakenKind: "diff_rule_budget_increased", removeKind: "diff_rule_budget_removed", field,
-      message: (a, b) => `diff_rules.${field}: ${a} -> ${b}`,
+      message: (before, after) => `diff_rules.${field}: ${before} -> ${after}`,
       removeMessage: `diff_rules.${field} removed (was ${policy.diff_rules[field]})`,
     }));
   }
 
-  constraints.push(
-    setConstraint("paths:forbidden", policy.paths?.forbidden, { pointer: "/paths/forbidden", weakenKind: "forbidden_path_removed", itemField: "pattern", message: (item) => `paths.forbidden removed: ${item}` }),
-    setConstraint("paths:governance", policy.paths?.governance_paths, { pointer: "/paths/governance_paths", weakenKind: "governance_path_removed", itemField: "pattern", message: (item) => `paths.governance_paths removed: ${item}` }),
+  result.push(
+    setConstraint("paths:forbidden", policy.paths?.forbidden, "superset_stricter", {
+      pointer: "/paths/forbidden", weakenKind: "forbidden_path_removed", itemField: "pattern",
+      message: (item) => `paths.forbidden removed: ${item}`,
+    }),
+    setConstraint("paths:governance", policy.paths?.governance_paths, "superset_stricter", {
+      pointer: "/paths/governance_paths", weakenKind: "governance_path_removed", itemField: "pattern",
+      message: (item) => `paths.governance_paths removed: ${item}`,
+    }),
+    setConstraint("paths:operational", policy.paths?.operational_paths, "subset_stricter", {
+      pointer: "/paths/operational_paths", weakenKind: "operational_path_added", itemField: "pattern",
+      message: (item) => `paths.operational_paths added exclusion: ${item}`,
+    }),
+    setConstraint("paths:canonical_docs", policy.paths?.canonical_docs, "subset_stricter", {
+      pointer: "/paths/canonical_docs", weakenKind: "canonical_doc_added", itemField: "pattern",
+      message: (item) => `paths.canonical_docs added exemption: ${item}`,
+    }),
   );
 
   const mode = policy.enforcement?.mode;
-  if (mode) constraints.push(scalar("enforcement", RANKS.enforcement[mode], "higher_stricter", {
+  if (mode) result.push(scalar("enforcement", RANKS.enforcement[mode], "higher_stricter", {
     raw: mode, pointer: "/enforcement/mode", weakenKind: "enforcement_weakened", removeKind: "enforcement_removed",
-    message: (a, b) => `enforcement.mode: ${a} -> ${b}`, removeMessage: `enforcement.mode removed (was ${mode})`,
+    message: (before, after) => `enforcement.mode: ${before} -> ${after}`,
+    removeMessage: `enforcement.mode removed (was ${mode})`,
   }));
 
   for (const workflow of asArray(policy.integration?.workflows)) {
     const owner = `workflow:${workflow.id}`;
-    constraints.push(entity(owner, { role: workflow.role, path: workflow.path }, {
-      pointer: `/integration/workflows/${workflow.id}`, removeKind: "integration_workflow_removed", workflow_id: workflow.id,
+    result.push(entity(owner, {
+      pointer: `/integration/workflows/${workflow.id}`,
+      removeKind: "integration_workflow_removed",
+      workflow_id: workflow.id,
+      removeBefore: { present: true, role: workflow.role, path: workflow.path },
+      removeAfter: { present: false },
       removeMessage: `integration.workflows entry "${workflow.id}" removed`,
     }));
-    const enforcement = workflow.expect?.enforcement;
-    if (enforcement) constraints.push(scalar(`${owner}:enforcement`, RANKS.enforcement[enforcement], "higher_stricter", {
+    const { enforcement, ...otherExpect } = workflow.expect || {};
+    result.push(exact(`${owner}:shape`, {
+      kind: workflow.kind,
+      path: workflow.path,
+      role: workflow.role,
+      profiles: workflow.profiles,
+      expect: otherExpect,
+    }, { owner, pointer: `/integration/workflows/${workflow.id}`, incomparableMessage: `integration.workflows[${workflow.id}] changed non-monotonic wiring semantics` }));
+    if (enforcement) result.push(scalar(`${owner}:enforcement`, RANKS.enforcement[enforcement], "higher_stricter", {
       owner, raw: enforcement, pointer: `/integration/workflows/${workflow.id}/expect/enforcement`,
       weakenKind: "integration_workflow_expectation_weakened", removeKind: "integration_workflow_expectation_removed", workflow_id: workflow.id,
-      message: (a, b) => `integration.workflows[${workflow.id}].expect.enforcement: ${a} -> ${b}`,
+      message: (before, after) => `integration.workflows[${workflow.id}].expect.enforcement: ${before} -> ${after}`,
       removeMessage: `integration.workflows[${workflow.id}].expect.enforcement removed (was ${enforcement})`,
     }));
   }
-  return constraints;
+  return result;
 }
 
 function relaxation(entry, { before, after = null, kind = entry.weakenKind, message = null, extra = {} }) {
   return {
-    kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}),
-    ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
-    message: message || entry.message?.(before, after) || entry.removeMessage, ...extra,
+    kind,
+    ...(entry.rule_id ? { rule_id: entry.rule_id } : {}),
+    ...(entry.field ? { field: entry.field } : {}),
+    ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}),
+    pointer: entry.pointer,
+    before,
+    after,
+    message: message || entry.message?.(before, after) || entry.removeMessage,
+    ...extra,
   };
 }
 
-function knownProjection(policy = {}) {
+function incomparable(entry, before, after) {
   return {
-    enforcement: policy.enforcement,
-    diff_rules: policy.diff_rules,
-    size_rules: policy.size_rules,
-    paths: { forbidden: policy.paths?.forbidden, governance_paths: policy.paths?.governance_paths },
-    integration: { workflows: policy.integration?.workflows?.map((wf) => ({ id: wf.id, role: wf.role, path: wf.path, enforcement: wf.expect?.enforcement })) },
+    kind: "policy_incomparable",
+    pointer: entry.pointer,
+    before,
+    after,
+    message: entry.incomparableMessage || `policy constraint ${entry.key} changed with no proven monotonic ordering`,
   };
+}
+
+function unknownProjection(policy = {}) {
+  const copy = clone(policy) || {};
+  delete copy.enforcement;
+  delete copy.diff_rules;
+  delete copy.size_rules;
+
+  if (copy.paths) {
+    for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"]) delete copy.paths[field];
+    if (Object.keys(copy.paths).length === 0) delete copy.paths;
+  }
+
+  if (copy.integration) {
+    delete copy.integration.workflows;
+    if (Object.keys(copy.integration).length === 0) delete copy.integration;
+  }
+  return copy;
 }
 
 export function comparePolicyStrictness(basePolicy, headPolicy) {
@@ -94,54 +195,88 @@ export function comparePolicyStrictness(basePolicy, headPolicy) {
   const base = compilePolicyStrictnessIR(basePolicy);
   const head = new Map(compilePolicyStrictnessIR(headPolicy).map((item) => [item.key, item]));
   const relaxations = [];
-  let tightened = false;
+  const incomparableChanges = [];
   const removedOwners = new Set();
+  let tightened = false;
+  let changed = false;
 
   for (const entry of base) {
     if (entry.owner && removedOwners.has(entry.owner)) continue;
     const next = head.get(entry.key);
     if (!next) {
       if (entry.removeKind) {
-        const before = entry.raw ?? entry.value;
-        relaxations.push(relaxation(entry, { before, kind: entry.removeKind, message: entry.removeMessage }));
+        relaxations.push(relaxation(entry, {
+          before: entry.removeBefore ?? entry.raw ?? entry.value,
+          after: entry.removeAfter ?? null,
+          kind: entry.removeKind,
+          message: entry.removeMessage,
+        }));
+        changed = true;
         if (entry.relation === "required_entity") removedOwners.add(entry.key);
       }
       continue;
     }
+
     if (entry.relation === "lower_stricter") {
       if (next.value > entry.value) relaxations.push(relaxation(entry, { before: entry.value, after: next.value }));
       else if (next.value < entry.value) tightened = true;
+      changed ||= next.value !== entry.value;
     } else if (entry.relation === "higher_stricter") {
       if (next.value < entry.value) relaxations.push(relaxation(entry, { before: entry.raw ?? entry.value, after: next.raw ?? next.value }));
       else if (next.value > entry.value) tightened = true;
-    } else if (entry.relation === "superset_stricter") {
-      const nextSet = new Set(next.value);
-      for (const item of entry.value) {
-        if (!nextSet.has(item)) relaxations.push(relaxation(entry, {
-          before: item, kind: entry.weakenKind, message: entry.message(item), extra: { [entry.itemField]: item },
+      changed ||= next.value !== entry.value;
+    } else if (entry.relation === "superset_stricter" || entry.relation === "subset_stricter") {
+      const beforeSet = new Set(entry.value);
+      const afterSet = new Set(next.value);
+      const removed = entry.value.filter((item) => !afterSet.has(item));
+      const added = next.value.filter((item) => !beforeSet.has(item));
+      const weakerItems = entry.relation === "superset_stricter" ? removed : added;
+      const stricterItems = entry.relation === "superset_stricter" ? added : removed;
+      for (const item of weakerItems) {
+        relaxations.push(relaxation(entry, {
+          before: item,
+          kind: entry.weakenKind,
+          message: entry.message(item),
+          extra: { [entry.itemField]: item },
         }));
       }
-      if (next.value.some((item) => !new Set(entry.value).has(item))) tightened = true;
+      tightened ||= stricterItems.length > 0;
+      changed ||= removed.length > 0 || added.length > 0;
+    } else if (entry.relation === "equal_or_incomparable" && !same(entry.value, next.value)) {
+      incomparableChanges.push(incomparable(entry, entry.value, next.value));
+      changed = true;
     }
   }
-  for (const item of head.values()) if (!base.some((entry) => entry.key === item.key)) tightened = true;
 
-  const baseProjection = JSON.stringify(knownProjection(basePolicy));
-  const headProjection = JSON.stringify(knownProjection(headPolicy));
-  const baseUnknown = { ...basePolicy };
-  const headUnknown = { ...headPolicy };
-  for (const key of ["enforcement", "diff_rules", "size_rules", "paths", "integration"]) {
-    delete baseUnknown[key]; delete headUnknown[key];
+  const baseKeys = new Set(base.map((entry) => entry.key));
+  for (const item of head.values()) {
+    if (baseKeys.has(item.key)) continue;
+    changed = true;
+    if (item.relation === "required_entity" || item.relation === "lower_stricter" || item.relation === "higher_stricter") tightened = true;
+    else if (item.relation === "subset_stricter" && item.value.length) {
+      for (const added of item.value) incomparableChanges.push(incomparable(item, [], [added]));
+    } else if (item.relation === "equal_or_incomparable" && !item.owner) {
+      incomparableChanges.push(incomparable(item, null, item.value));
+    }
   }
-  const incomparable = stable(baseUnknown) === stable(headUnknown) ? [] : [{
-    kind: "policy_incomparable", pointer: "/", before: baseUnknown, after: headUnknown,
-    message: "policy sections outside the normalized strictness IR changed and require explicit governance review",
-  }];
 
-  const relation = relaxations.length ? "weaker"
-    : incomparable.length ? "incomparable"
-      : baseProjection === headProjection && !tightened ? "equal" : "stricter";
-  return { relation, relaxations, incomparable };
+  const baseUnknown = unknownProjection(basePolicy);
+  const headUnknown = unknownProjection(headPolicy);
+  if (!same(baseUnknown, headUnknown)) {
+    incomparableChanges.push({
+      kind: "policy_incomparable",
+      pointer: "/",
+      before: baseUnknown,
+      after: headUnknown,
+      message: "policy sections outside the normalized strictness IR changed and require explicit governance review",
+    });
+    changed = true;
+  }
+
+  const relation = relaxations.length > 0 ? "weaker"
+    : incomparableChanges.length > 0 ? "incomparable"
+      : tightened || changed ? "stricter" : "equal";
+  return { relation, relaxations, incomparable: incomparableChanges };
 }
 
 export function computePolicyDelta(basePolicy, headPolicy) {
@@ -198,12 +333,18 @@ function summarizeTrustedAuthorizer(authorizer) {
   if (authorizer.governance_approved_label) sources.push("governance_approved_label");
   if (authorizer.codeowner_approved) sources.push("codeowner_approval");
   if (authorizer.trusted_team_approval) sources.push("trusted_team_approval");
-  return sources.length ? { trusted: true, reasons: [], detected_sources: sources }
+  return sources.length
+    ? { trusted: true, reasons: [], detected_sources: sources }
     : { trusted: false, reasons: ["no_trusted_authorization_source"], detected_sources: [] };
 }
 
 export function checkPolicyRelaxation({
-  basePolicy, headPolicy, changedFiles, trustedAuthorizer, issueAuthorization, contractChangeType,
+  basePolicy,
+  headPolicy,
+  changedFiles,
+  trustedAuthorizer,
+  issueAuthorization,
+  contractChangeType,
   configuredProtectedSurfaces = null,
 }) {
   if (!basePolicy || !headPolicy) return { ok: true };
@@ -219,14 +360,23 @@ export function checkPolicyRelaxation({
   if (!governanceOnly) reasons.push("policy_relaxation_mixed_with_non_governance_changes");
   if (contractChangeType && contractChangeType !== "governance") reasons.push("contract_change_type_is_not_governance");
   const details = relaxations.map((item) => `- ${item.pointer}: ${item.message}`);
-  if (!governanceOnly && classified.protectedFiles.length) details.push(`Mixed with protected-surface changes: ${classified.protectedFiles.slice(0, 10).join(", ")}${classified.protectedFiles.length > 10 ? `, +${classified.protectedFiles.length - 10} more` : ""}`);
+  if (!governanceOnly && classified.protectedFiles.length) {
+    details.push(`Mixed with protected-surface changes: ${classified.protectedFiles.slice(0, 10).join(", ")}${classified.protectedFiles.length > 10 ? `, +${classified.protectedFiles.length - 10} more` : ""}`);
+  }
   if (authorizer.reasons.length) details.push(`trusted_authorizer: ${authorizer.reasons.join(", ")}`);
   const ok = reasons.length === 0;
   return {
-    ok, message: ok ? undefined : "PR attempts to relax trusted repository policy",
-    policy_relaxations: relaxations, details, blocked_reasons: reasons, governance_only: governanceOnly,
-    protected_files: classified.protectedFiles, governance_files: classified.governanceFiles, other_files: classified.otherFiles,
-    protected_patterns: classified.protectedPatterns, trusted_authorizer: authorizer,
+    ok,
+    message: ok ? undefined : "PR attempts to relax trusted repository policy",
+    policy_relaxations: relaxations,
+    details,
+    blocked_reasons: reasons,
+    governance_only: governanceOnly,
+    protected_files: classified.protectedFiles,
+    governance_files: classified.governanceFiles,
+    other_files: classified.otherFiles,
+    protected_patterns: classified.protectedPatterns,
+    trusted_authorizer: authorizer,
     hint: ok ? undefined : "Policy relaxation must be a dedicated governance change, authorized by a trusted maintainer/code owner, with change_type governance and all relaxed pointers listed in linked-issue allow_policy_relaxation.",
   };
 }
@@ -238,8 +388,11 @@ export const policyRelaxationRuleFamily = {
     return {
       name: "policy-relaxation",
       check: checkPolicyRelaxation({
-        basePolicy: facts.basePolicy, headPolicy: facts.headPolicy, changedFiles: facts.diff.files.checked,
-        trustedAuthorizer: facts.trustedAuthorizer, issueAuthorization: facts.issueAuthorization,
+        basePolicy: facts.basePolicy,
+        headPolicy: facts.headPolicy,
+        changedFiles: facts.diff.files.checked,
+        trustedAuthorizer: facts.trustedAuthorizer,
+        issueAuthorization: facts.issueAuthorization,
         contractChangeType: facts.contract?.change_type,
         configuredProtectedSurfaces: facts.basePolicy?.policy_delta_rules?.protected_surfaces,
       }),

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -1,5 +1,6 @@
 import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
 import { compileConstraintIR, evaluateConstraintIR } from "../src/checks/rules/constraints.mjs";
+import { comparePolicyStrictness } from "../src/checks/rules/policy-delta-rules.mjs";
 import { checkSizeRules } from "../src/checks/rules/size-rules.mjs";
 import { parseMarkdown } from "../src/document-facts.mjs";
 import { classifyPathSets, selectPaths } from "../src/diff/classification.mjs";
@@ -41,6 +42,17 @@ const constraintFacts = {
 const constraintIR = compileConstraintIR(constraintFacts);
 expect("policy frontends compile into primitive constraints", constraintIR.constraints.some((c) => c.kind === "implies_nonempty"), true);
 expect("constraint kernel preserves familiar result names", evaluateConstraintIR(constraintFacts).some((r) => r.name === "must-touch" && r.check.ok), true);
+
+const strictnessBase = {
+  enforcement: { mode: "blocking" }, paths: { forbidden: ["secret/**"], governance_paths: ["repo-policy.json"] },
+  diff_rules: { max_new_files: 5 }, size_rules: [{ id: "src", glob: "src/**", max: 100, level: "blocking", count: "all_tracked" }],
+};
+const weakerPolicy = structuredClone(strictnessBase);
+weakerPolicy.diff_rules.max_new_files = 10;
+expect("strictness IR detects monotonic weakening", comparePolicyStrictness(strictnessBase, weakerPolicy).relation, "weaker");
+const stricterPolicy = structuredClone(strictnessBase);
+stricterPolicy.diff_rules.max_new_files = 3;
+expect("strictness IR detects monotonic tightening", comparePolicyStrictness(strictnessBase, stricterPolicy).relation, "stricter");
 
 const currentFiles = new Map([
   ["docs/a.md", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"],

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -44,8 +44,11 @@ expect("policy frontends compile into primitive constraints", constraintIR.const
 expect("constraint kernel preserves familiar result names", evaluateConstraintIR(constraintFacts).some((r) => r.name === "must-touch" && r.check.ok), true);
 
 const strictnessBase = {
-  enforcement: { mode: "blocking" }, paths: { forbidden: ["secret/**"], governance_paths: ["repo-policy.json"] },
-  diff_rules: { max_new_files: 5 }, size_rules: [{ id: "src", glob: "src/**", max: 100, level: "blocking", count: "all_tracked" }],
+  enforcement: { mode: "blocking" },
+  paths: { forbidden: ["secret/**"], governance_paths: ["repo-policy.json"], canonical_docs: [], operational_paths: [] },
+  diff_rules: { max_new_files: 5 },
+  size_rules: [{ id: "src", scope: "directory", glob: "src/**", metric: "lines", max: 100, max_growth: 0, level: "blocking", count: "all_tracked" }],
+  content_rules: [],
 };
 const weakerPolicy = structuredClone(strictnessBase);
 weakerPolicy.diff_rules.max_new_files = 10;
@@ -53,6 +56,12 @@ expect("strictness IR detects monotonic weakening", comparePolicyStrictness(stri
 const stricterPolicy = structuredClone(strictnessBase);
 stricterPolicy.diff_rules.max_new_files = 3;
 expect("strictness IR detects monotonic tightening", comparePolicyStrictness(strictnessBase, stricterPolicy).relation, "stricter");
+const growthWeakened = structuredClone(strictnessBase);
+growthWeakened.size_rules[0].max_growth = 1;
+expect("strictness IR protects compression max_growth", comparePolicyStrictness(strictnessBase, growthWeakened).relation, "weaker");
+const unknownChange = structuredClone(strictnessBase);
+unknownChange.content_rules.push({ id: "x", glob: "**", mode: "added_lines", forbid_regex: ["x"] });
+expect("unknown policy semantics fail closed as incomparable", comparePolicyStrictness(strictnessBase, unknownChange).relation, "incomparable");
 
 const currentFiles = new Map([
   ["docs/a.md", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"],


### PR DESCRIPTION
Fixes #114
Parent: #107

Сводит защиту от самоослабления к одному монотонному comparator-у вместо набора `computeXDelta()` для каждого DSL-раздела.

- `compilePolicyStrictnessIR()` нормализует известные ограничения в `lower_stricter`, `higher_stricter`, `superset_stricter`, `subset_stricter`, `required_entity` и `equal_or_incomparable`;
- `comparePolicyStrictness()` возвращает `equal | stricter | weaker | incomparable`;
- прежние relaxation kinds/pointers сохранены для существующей диагностики и authorization contracts;
- `max_growth` теперь сам защищён от ослабления, то есть compression gate нельзя незаметно снять;
- добавление operational/canonical exemptions распознаётся как ослабление;
- изменения selector/scope/metric/wiring semantics, для которых нет доказанного частичного порядка, fail-closed как `policy_incomparable`;
- все ещё не нормализованные policy sections также fail-closed через unknown projection;
- trust/governance authorization kernel сохранён отдельно и стал компактнее;
- существующий `test:diff` временно включает полный policy-delta regression suite; этот ручной test routing будет удалён следующим gate #115 вместе со всем ручным test inventory.

Structural diff отрицательный: `policy-delta-rules.mjs` сокращён примерно на 96 строк даже после введения generalized comparator; весь PR остаётся отрицательным по строкам при усилении security semantics.

```repo-guard-yaml
change_type: refactor
scope:
  - src/checks/rules/policy-delta-rules.mjs
  - tests/test-compression-rules.mjs
  - package.json
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/checks/rules/policy-delta-rules.mjs
must_not_touch:
  - schemas/**
  - repo-policy.json
  - .github/**
expected_effects:
  - high-level policy поверх известных primitives получает self-weakening protection без нового field-specific delta walker
  - непонятные изменения policy fail-closed как incomparable
  - compression max_growth защищён от самоослабления
```