### PR TITLE
Compression 2.0 1/8: enforce contract.scope

### DIFF
--- a/scripts/compression-metrics.mjs
+++ b/scripts/compression-metrics.mjs
@@ -3,94 +3,66 @@
 import { execFileSync } from "node:child_process";
 
 const args = process.argv.slice(2);
-function argValue(name, fallback = null) {
-  const index = args.indexOf(name);
-  return index >= 0 && args[index + 1] ? args[index + 1] : fallback;
-}
-const ref = argValue("--ref", "HEAD");
-const compareRef = argValue("--compare");
+const arg = (name, fallback = null) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : fallback;
+};
+const ref = arg("--ref", "HEAD");
+const compareRef = arg("--compare");
+const git = (argv) => execFileSync("git", argv, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+const pathsAt = (target, roots) => git(["ls-tree", "-r", "--name-only", target, "--", ...roots]).split(/\r?\n/).filter(Boolean).sort();
+const textAt = (target, path) => git(["show", `${target}:${path}`]);
+const jsonAt = (target, path) => JSON.parse(textAt(target, path));
+const lines = (text) => text ? (text.match(/\n/g) || []).length + (text.endsWith("\n") ? 0 : 1) : 0;
 
-function git(arguments_) {
-  return execFileSync("git", arguments_, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
-}
-function pathsAt(targetRef, roots) {
-  return git(["ls-tree", "-r", "--name-only", targetRef, "--", ...roots]).split(/\r?\n/).filter(Boolean).sort();
-}
-const textAt = (targetRef, path) => git(["show", `${targetRef}:${path}`]);
-function countLines(text) {
-  if (!text.length) return 0;
-  return (text.match(/\n/g) || []).length + (text.endsWith("\n") ? 0 : 1);
-}
-function physicalMetrics(targetRef, roots) {
-  const files = pathsAt(targetRef, roots);
-  let lines = 0;
-  let bytes = 0;
-  for (const path of files) {
-    const content = textAt(targetRef, path);
-    lines += countLines(content);
-    bytes += Buffer.byteLength(content);
-  }
-  return { files: files.length, lines, bytes };
-}
-const jsonAt = (targetRef, path) => JSON.parse(textAt(targetRef, path));
-
-function ruleFamilyCount(targetRef) {
-  const text = textAt(targetRef, "src/checks/default-rule-families.mjs");
-  const match = text.match(/defaultRuleFamilies\s*=\s*\[([\s\S]*?)\]/);
-  return match ? (match[1].match(/\b[A-Za-z][A-Za-z0-9]*RuleFamily\b/g) || []).length : 0;
+function physical(target, roots) {
+  const files = pathsAt(target, roots);
+  return files.reduce((out, path) => {
+    const content = textAt(target, path);
+    out.lines += lines(content);
+    out.bytes += Buffer.byteLength(content);
+    return out;
+  }, { files: files.length, lines: 0, bytes: 0 });
 }
 
-function markdownParserFiles(targetRef) {
-  const markers = [
-    "function parseMarkdown(",
-    "const FENCE_RE",
-    "function extractMarkdownSection(",
-    "let inFence = false",
-  ];
-  return pathsAt(targetRef, ["src"]).filter((path) => {
-    if (!/\.(?:mjs|js)$/.test(path)) return false;
-    const content = textAt(targetRef, path);
-    return markers.some((marker) => content.includes(marker));
-  });
+function sourceCorpus(target) {
+  return pathsAt(target, ["src"]).filter((path) => /\.(?:mjs|js)$/.test(path)).map((path) => textAt(target, path)).join("\n");
 }
 
-function architectureMetrics(targetRef) {
-  const policy = jsonAt(targetRef, "repo-policy.json");
-  const pkg = jsonAt(targetRef, "package.json");
-  const coverage = jsonAt(targetRef, "docs/self-hosting-coverage.json");
-  const parserFiles = markdownParserFiles(targetRef);
-  const testCommand = pkg.scripts?.test || "";
-  return {
-    ref: targetRef,
-    physical: {
-      src: physicalMetrics(targetRef, ["src"]),
-      schemas: physicalMetrics(targetRef, ["schemas"]),
-      tests: physicalMetrics(targetRef, ["tests"]),
-    },
-    architecture: {
-      rule_families: ruleFamilyCount(targetRef),
-      declared_surfaces: Object.keys(policy.surfaces || {}).length,
-      declared_new_file_classes: Object.keys(policy.new_file_classes || {}).length,
-      markdown_parser_files: parserFiles.length,
-      markdown_parser_paths: parserFiles,
-      manual_test_script_entries: (testCommand.match(/node\s+tests\/(?:test-|validate-schemas)/g) || []).length,
-      self_hosting_status_entries: (JSON.stringify(coverage).match(/"status":/g) || []).length,
-      self_hosting_exceptions: Object.keys(coverage.exceptions || {}).length,
-    },
+function architecture(target) {
+  const policy = jsonAt(target, "repo-policy.json");
+  const pkg = jsonAt(target, "package.json");
+  const coverage = jsonAt(target, "docs/self-hosting-coverage.json");
+  const defaults = textAt(target, "src/checks/default-rule-families.mjs");
+  const corpus = sourceCorpus(target);
+  const parserFiles = pathsAt(target, ["src"]).filter((path) => /\.(?:mjs|js)$/.test(path) && /function parseMarkdown\(|const FENCE_RE|function extractMarkdownSection\(|let inFence = false/.test(textAt(target, path)));
+  const metric = {
+    rule_families: (defaults.match(/\b[A-Za-z][A-Za-z0-9]*RuleFamily\b/g) || []).length,
+    declared_surfaces: Object.keys(policy.surfaces || {}).length,
+    declared_new_file_classes: Object.keys(policy.new_file_classes || {}).length,
+    markdown_parser_files: parserFiles.length,
+    manual_test_script_entries: ((pkg.scripts?.test || "").match(/node\s+tests\/(?:test-|validate-schemas)/g) || []).length,
+    self_hosting_status_entries: (JSON.stringify(coverage).match(/"status":/g) || []).length,
+    self_hosting_exceptions: Object.keys(coverage.exceptions || {}).length,
+    runtime_ir_compilers: (corpus.match(/function compileConstraintIR\b/g) || []).length,
+    strictness_ir_compilers: (corpus.match(/function compilePolicyStrictnessIR\b/g) || []).length,
+    command_dispatch_branches: (corpus.match(/command ===/g) || []).length,
+    bespoke_integration_validator: pathsAt(target, ["src/integration-validator.mjs"]).length,
+    privileged_field_workarounds: (corpus.match(/stripPrivilegedSchemaUnknownFields|SCHEMA_UNKNOWN_PRIVILEGED_FIELDS/g) || []).length,
   };
+  metric.semantic_edit_sites = metric.rule_families + metric.runtime_ir_compilers + metric.strictness_ir_compilers + metric.bespoke_integration_validator + metric.command_dispatch_branches;
+  return { ref: target, physical: { src: physical(target, ["src"]), schemas: physical(target, ["schemas"]), tests: physical(target, ["tests"]) }, architecture: metric };
 }
 
 function subtract(after, before) {
   if (typeof after === "number" && typeof before === "number") return after - before;
-  if (after && before && typeof after === "object" && typeof before === "object" && !Array.isArray(after) && !Array.isArray(before)) {
-    return Object.fromEntries(Object.keys(after).filter((key) => Object.hasOwn(before, key)).map((key) => [key, subtract(after[key], before[key])]));
-  }
-  return undefined;
+  if (!after || !before || typeof after !== "object" || typeof before !== "object" || Array.isArray(after) || Array.isArray(before)) return undefined;
+  return Object.fromEntries(Object.keys(after).filter((key) => Object.hasOwn(before, key)).map((key) => [key, subtract(after[key], before[key])]));
 }
 
-const current = architectureMetrics(ref);
+const current = architecture(ref);
 if (!compareRef) console.log(JSON.stringify(current, null, 2));
 else {
-  const baseline = architectureMetrics(compareRef);
+  const baseline = architecture(compareRef);
   console.log(JSON.stringify({ baseline, current, delta: subtract(current, baseline) }, null, 2));
 }

--- a/src/checks/rules/constraints.mjs
+++ b/src/checks/rules/constraints.mjs
@@ -1,16 +1,18 @@
 import { calculateDiffGrowth } from "../../diff/growth.mjs";
 import { selectPaths } from "../../diff/classification.mjs";
+import { matchesAny } from "../../utils/path-patterns.mjs";
 
-export function checkCanonicalDocsBudget(files, canonicalDocs = [], max) {
+function budget(selected, max) {
   if (max === undefined) return { ok: true };
-  const selected = files.filter((file) => file.status === "added" && /\.md$/i.test(file.path) && !canonicalDocs.includes(file.path));
   return { ok: selected.length <= max, actual: selected.length, limit: max, files: selected.map((file) => file.path) };
 }
 
+export function checkCanonicalDocsBudget(files, canonicalDocs = [], max) {
+  return budget(files.filter((file) => file.status === "added" && /\.md$/i.test(file.path) && !canonicalDocs.includes(file.path)), max);
+}
+
 export function checkNewFilesBudget(files, max) {
-  if (max === undefined) return { ok: true };
-  const selected = files.filter((file) => file.status === "added");
-  return { ok: selected.length <= max, actual: selected.length, limit: max, files: selected.map((file) => file.path) };
+  return budget(files.filter((file) => file.status === "added"), max);
 }
 
 export function checkNetAddedLinesBudget(files, max) {
@@ -22,10 +24,7 @@ export function checkNetAddedLinesBudget(files, max) {
 export function checkSurfaceDebt(files, debt) {
   const growth = calculateDiffGrowth(files);
   if (growth.new_files <= 0 && growth.net_added_lines <= 0) return { ok: true, status: "not_needed", growth };
-  if (!debt) return {
-    ok: true, status: "undeclared", growth,
-    details: [`new files: ${growth.new_files}`, `net added lines: ${growth.net_added_lines}`],
-  };
+  if (!debt) return { ok: true, status: "undeclared", growth, details: [`new files: ${growth.new_files}`, `net added lines: ${growth.net_added_lines}`] };
   if (!debt.repayment_issue) return {
     ok: false, status: "missing_repayment_target", message: "declared surface debt is missing repayment target: repayment_issue",
     growth, surface_debt: debt, details: ["missing repayment_issue"],
@@ -33,23 +32,26 @@ export function checkSurfaceDebt(files, debt) {
   };
   const expected = debt.expected_delta || {};
   const exceeded = [];
-  if (expected.max_new_files !== undefined && growth.new_files > expected.max_new_files) {
-    exceeded.push(`new files ${growth.new_files} exceeds declared debt ${expected.max_new_files}`);
-  }
-  if (expected.max_net_added_lines !== undefined && growth.net_added_lines > expected.max_net_added_lines) {
-    exceeded.push(`net added lines ${growth.net_added_lines} exceeds declared debt ${expected.max_net_added_lines}`);
-  }
+  if (expected.max_new_files !== undefined && growth.new_files > expected.max_new_files) exceeded.push(`new files ${growth.new_files} exceeds declared debt ${expected.max_new_files}`);
+  if (expected.max_net_added_lines !== undefined && growth.net_added_lines > expected.max_net_added_lines) exceeded.push(`net added lines ${growth.net_added_lines} exceeds declared debt ${expected.max_net_added_lines}`);
   return {
-    ok: exceeded.length === 0,
-    status: exceeded.length ? "declared_debt_exceeded" : "declared",
+    ok: exceeded.length === 0, status: exceeded.length ? "declared_debt_exceeded" : "declared",
     message: exceeded.length ? "declared surface debt is smaller than actual diff growth" : undefined,
     growth, surface_debt: debt, details: exceeded,
     hint: exceeded.length ? "Update expected_delta to match intentional temporary growth or reduce the diff." : undefined,
   };
 }
 
-export function checkForbiddenPaths(files, patterns) {
-  return selectPaths(files, patterns, { excludeStatuses: ["deleted"] });
+export const checkForbiddenPaths = (files, patterns) => selectPaths(files, patterns, { excludeStatuses: ["deleted"] });
+
+export function checkScope(files, patterns) {
+  if (!patterns?.length) return { ok: true };
+  const out = files.filter((file) => !matchesAny(file.path, patterns)).map((file) => file.path).sort();
+  return {
+    ok: out.length === 0, declared_scope: patterns, out_of_scope_paths: out,
+    message: out.length ? "changed files fall outside declared contract scope" : undefined,
+    details: out.map((path) => `out of scope: ${path}`),
+  };
 }
 
 export function checkMustTouch(files, patterns) {
@@ -68,14 +70,11 @@ export function checkMustNotTouch(files, patterns) {
 }
 
 export function checkCochangeRules(files, rules = []) {
-  return rules.flatMap((rule) =>
-    selectPaths(files, rule.if_changed).length && !selectPaths(files, rule.must_change_any).length
-      ? [{ if_changed: rule.if_changed, must_change_any: rule.must_change_any }]
-      : []);
+  return rules.flatMap((rule) => selectPaths(files, rule.if_changed).length && !selectPaths(files, rule.must_change_any).length
+    ? [{ if_changed: rule.if_changed, must_change_any: rule.must_change_any }] : []);
 }
 
 export function compileConstraintIR(facts) {
-  const files = facts.diff.files.checked;
   const diff = facts.policy.diff_rules || {};
   const budgets = facts.contract?.budgets || {};
   const constraints = [
@@ -86,13 +85,12 @@ export function compileConstraintIR(facts) {
     { kind: "surface_debt", name: "surface-debt", debt: facts.contract?.surface_debt },
     ...facts.policy.cochange_rules.map((rule) => ({ kind: "implies_nonempty", name: "cochange", ...rule })),
   ];
-  if (facts.contract) {
-    constraints.push(
-      { kind: "require_paths", name: "must-touch", patterns: facts.contract.must_touch },
-      { kind: "forbid_paths", name: "must-not-touch", patterns: facts.contract.must_not_touch, contract: true },
-    );
-  }
-  return { files, constraints };
+  if (facts.contract) constraints.push(
+    { kind: "scope_paths", name: "contract-scope", patterns: facts.contract.scope },
+    { kind: "require_paths", name: "must-touch", patterns: facts.contract.must_touch },
+    { kind: "forbid_paths", name: "must-not-touch", patterns: facts.contract.must_not_touch, contract: true },
+  );
+  return { files: facts.diff.files.checked, constraints };
 }
 
 function evaluateMetric(files, constraint, policy) {
@@ -103,34 +101,29 @@ function evaluateMetric(files, constraint, policy) {
 
 export function evaluateConstraintIR(facts) {
   const { files, constraints } = compileConstraintIR(facts);
-  const results = [];
-  const cochangeViolations = [];
+  const results = [], cochange = [];
   for (const constraint of constraints) {
-    if (constraint.kind === "max_metric") {
-      results.push({ name: constraint.name, check: evaluateMetric(files, constraint, facts.policy) });
-    } else if (constraint.kind === "surface_debt") {
-      results.push({ name: constraint.name, check: checkSurfaceDebt(files, constraint.debt) });
-    } else if (constraint.kind === "require_paths") {
-      results.push({ name: constraint.name, check: checkMustTouch(files, constraint.patterns) });
-    } else if (constraint.kind === "forbid_paths") {
-      if (constraint.contract) results.push({ name: constraint.name, check: checkMustNotTouch(files, constraint.patterns) });
+    let check;
+    if (constraint.kind === "max_metric") check = evaluateMetric(files, constraint, facts.policy);
+    else if (constraint.kind === "surface_debt") check = checkSurfaceDebt(files, constraint.debt);
+    else if (constraint.kind === "scope_paths") check = checkScope(files, constraint.patterns);
+    else if (constraint.kind === "require_paths") check = checkMustTouch(files, constraint.patterns);
+    else if (constraint.kind === "forbid_paths") {
+      if (constraint.contract) check = checkMustNotTouch(files, constraint.patterns);
       else {
         const found = checkForbiddenPaths(files, constraint.patterns);
-        results.push({ name: constraint.name, check: { ok: found.length === 0, files: found } });
+        check = { ok: found.length === 0, files: found };
       }
     } else if (constraint.kind === "implies_nonempty") {
-      if (selectPaths(files, constraint.if_changed).length && !selectPaths(files, constraint.must_change_any).length) {
-        cochangeViolations.push({ if_changed: constraint.if_changed, must_change_any: constraint.must_change_any });
-      }
+      if (selectPaths(files, constraint.if_changed).length && !selectPaths(files, constraint.must_change_any).length) cochange.push(constraint);
+      continue;
     }
+    results.push({ name: constraint.name, check });
   }
-  results.push(...(cochangeViolations.length
-    ? cochangeViolations.map((v) => ({ name: `cochange: ${v.if_changed.join(",")} -> ${v.must_change_any.join(",")}`, check: { ok: false, must_touch: v.must_change_any } }))
+  results.push(...(cochange.length
+    ? cochange.map((item) => ({ name: `cochange: ${item.if_changed.join(",")} -> ${item.must_change_any.join(",")}`, check: { ok: false, must_touch: item.must_change_any } }))
     : [{ name: "cochange-rules", check: { ok: true } }]));
   return results;
 }
 
-export const constraintRuleFamily = {
-  id: "constraints",
-  evaluate: evaluateConstraintIR,
-};
+export const constraintRuleFamily = { id: "constraints", evaluate: evaluateConstraintIR };

--- a/tests/test-current-base-ref.mjs
+++ b/tests/test-current-base-ref.mjs
@@ -4,191 +4,86 @@ import { join, resolve, dirname } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const projectRoot = resolve(__dirname, "..");
+const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
 let failures = 0;
-
-function expect(label, condition) {
-  const passed = Boolean(condition);
-  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
-  if (!passed) failures++;
-}
-
-function git(cwd, ...args) {
-  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
-}
-
-function commit(cwd, message) {
-  git(cwd, "add", "-A");
-  git(cwd, "commit", "-m", message);
-  return git(cwd, "rev-parse", "HEAD");
-}
+const expect = (label, condition) => { const ok = Boolean(condition); console.log(`${ok ? "PASS" : "FAIL"}: ${label}`); if (!ok) failures++; };
+const git = (cwd, ...args) => execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
+const commit = (cwd, message) => { git(cwd, "add", "-A"); git(cwd, "commit", "-m", message); return git(cwd, "rev-parse", "HEAD"); };
 
 function writePolicy(root) {
-  const policy = {
-    policy_format_version: "0.1.0",
-    repository_kind: "library",
-    enforcement: { mode: "blocking" },
-    paths: {
-      forbidden: [],
-      canonical_docs: [],
-      governance_paths: ["governance.txt"],
-    },
-    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
-    content_rules: [],
-    cochange_rules: [],
-  };
-  writeFileSync(join(root, "repo-policy.json"), JSON.stringify(policy, null, 2));
+  writeFileSync(join(root, "repo-policy.json"), JSON.stringify({
+    policy_format_version: "0.1.0", repository_kind: "library", enforcement: { mode: "blocking" },
+    paths: { forbidden: [], canonical_docs: [], governance_paths: ["governance.txt"] },
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 }, content_rules: [], cochange_rules: [],
+  }, null, 2));
 }
 
-function contractBody() {
+function contractBody({ docs = false } = {}) {
+  const scope = docs ? ["src/**", "docs/**"] : ["src/**"];
+  const mustTouch = docs ? "docs/theory/Основания МТС.md" : "src/kernel.txt";
   return [
-    "```repo-guard-yaml",
-    "change_type: bugfix",
-    "scope:",
-    "  - src/**",
-    "budgets:",
-    "  max_new_files: 5",
-    "  max_net_added_lines: 500",
-    "must_touch:",
-    "  - src/kernel.txt",
-    "must_not_touch:",
-    "  - governance.txt",
-    "expected_effects:",
-    "  - kernel change only",
-    "```",
-  ].join("\n");
-}
-
-function unicodeContractBody() {
-  return [
-    "```repo-guard-yaml",
-    "change_type: docs",
-    "scope:",
-    "  - docs/**",
-    "budgets:",
-    "  max_new_files: 5",
-    "  max_new_docs: 5",
-    "  max_net_added_lines: 500",
-    "must_touch:",
-    "  - docs/theory/Основания МТС.md",
-    "must_not_touch:",
-    "  - governance.txt",
-    "expected_effects:",
-    "  - UTF-8 path is preserved",
-    "```",
+    "```repo-guard-yaml", `change_type: ${docs ? "docs" : "bugfix"}`, "scope:", ...scope.map((item) => `  - ${item}`),
+    "budgets:", "  max_new_files: 5", ...(docs ? ["  max_new_docs: 5"] : []), "  max_net_added_lines: 500",
+    "must_touch:", `  - ${mustTouch}`, "must_not_touch:", "  - governance.txt", "expected_effects:",
+    `  - ${docs ? "UTF-8 path is preserved" : "kernel change only"}`, "```",
   ].join("\n");
 }
 
 function setupRepo() {
   const root = mkdtempSync(join(tmpdir(), "repo-guard-current-base-"));
-  git(root, "init", "-b", "main");
-  git(root, "config", "user.email", "test@example.com");
-  git(root, "config", "user.name", "Test");
-  writePolicy(root);
-  mkdirSync(join(root, "src"), { recursive: true });
-  writeFileSync(join(root, "src/kernel.txt"), "base\n");
+  git(root, "init", "-b", "main"); git(root, "config", "user.email", "test@example.com"); git(root, "config", "user.name", "Test");
+  writePolicy(root); mkdirSync(join(root, "src"), { recursive: true }); writeFileSync(join(root, "src/kernel.txt"), "base\n");
   const oldBase = commit(root, "base");
-
   writeFileSync(join(root, "governance.txt"), "landed-on-base\n");
   const currentBase = commit(root, "advance base with unrelated governance");
-  git(root, "update-ref", "refs/remotes/origin/main", currentBase);
-
-  git(root, "switch", "-c", "feature");
+  git(root, "update-ref", "refs/remotes/origin/main", currentBase); git(root, "switch", "-c", "feature");
   writeFileSync(join(root, "src/kernel.txt"), "base\nfeature\n");
-  const head = commit(root, "feature kernel change");
-  return { root, oldBase, currentBase, head };
+  return { root, oldBase, currentBase, head: commit(root, "feature kernel change") };
 }
 
 function runCheck(root, event) {
-  const eventFile = join(root, "event.json");
-  writeFileSync(eventFile, JSON.stringify(event));
+  const eventFile = join(root, "event.json"); writeFileSync(eventFile, JSON.stringify(event));
   return spawnSync(process.execPath, [repoGuard, "--repo-root", root, "--enforcement", "blocking", "check-pr"], {
-    cwd: root,
-    env: { ...process.env, GITHUB_EVENT_PATH: eventFile },
-    encoding: "utf-8",
+    cwd: root, env: { ...process.env, GITHUB_EVENT_PATH: eventFile }, encoding: "utf-8",
   });
 }
+const event = (number, base, head, body, baseRef = "main") => ({
+  pull_request: { number, base: { sha: base, ref: baseRef }, head: { sha: head }, body }, repository: { full_name: "owner/repo" },
+});
+const output = (result) => `${result.stdout || ""}${result.stderr || ""}`;
 
 {
   const { root, oldBase, currentBase, head } = setupRepo();
-  const result = runCheck(root, {
-    pull_request: {
-      number: 100,
-      base: { sha: oldBase, ref: "main" },
-      head: { sha: head },
-      body: contractBody(),
-    },
-    repository: { full_name: "owner/repo" },
-  });
-  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  const result = runCheck(root, event(100, oldBase, head, contractBody())); const text = output(result);
   expect("advanced base: check-pr passes", result.status === 0);
-  expect("advanced base: diagnostic reports current base", output.includes(currentBase.slice(0, 7)));
-  expect("advanced base: old snapshot is recognized as stale", output.includes(oldBase.slice(0, 7)));
-  expect("advanced base: already-landed governance is not in PR diff", !output.includes("touched: governance.txt"));
+  expect("advanced base: diagnostic reports current base", text.includes(currentBase.slice(0, 7)));
+  expect("advanced base: old snapshot is recognized as stale", text.includes(oldBase.slice(0, 7)));
+  expect("advanced base: already-landed governance is not in PR diff", !text.includes("touched: governance.txt"));
   rmSync(root, { recursive: true, force: true });
 }
-
 {
-  const { root, oldBase, currentBase } = setupRepo();
-  writeFileSync(join(root, "governance.txt"), "landed-on-base\nchanged-by-pr\n");
-  const head = commit(root, "feature also changes governance");
-  const result = runCheck(root, {
-    pull_request: {
-      number: 101,
-      base: { sha: oldBase, ref: "main" },
-      head: { sha: head },
-      body: contractBody(),
-    },
-    repository: { full_name: "owner/repo" },
-  });
-  const output = `${result.stdout || ""}${result.stderr || ""}`;
-  expect("genuine governance delta: current base remains selected", output.includes(currentBase.slice(0, 7)));
+  const { root, oldBase, currentBase } = setupRepo(); writeFileSync(join(root, "governance.txt"), "landed-on-base\nchanged-by-pr\n");
+  const result = runCheck(root, event(101, oldBase, commit(root, "feature also changes governance"), contractBody())); const text = output(result);
+  expect("genuine governance delta: current base remains selected", text.includes(currentBase.slice(0, 7)));
   expect("genuine governance delta: blocking check fails", result.status === 1);
-  expect("genuine governance delta: must-not-touch reports governance file", output.includes("governance.txt"));
+  expect("genuine governance delta: must-not-touch reports governance file", text.includes("governance.txt"));
   rmSync(root, { recursive: true, force: true });
 }
-
 {
-  const { root, oldBase, head } = setupRepo();
-  const result = runCheck(root, {
-    pull_request: {
-      number: 102,
-      base: { sha: oldBase, ref: "missing-base" },
-      head: { sha: head },
-      body: contractBody(),
-    },
-    repository: { full_name: "owner/repo" },
-  });
-  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  const { root, oldBase, head } = setupRepo(); const result = runCheck(root, event(102, oldBase, head, contractBody(), "missing-base"));
   expect("missing current base ref: check-pr fails closed", result.status === 1);
-  expect("missing current base ref: diagnostic is explicit", output.includes("cannot resolve current PR base ref missing-base"));
+  expect("missing current base ref: diagnostic is explicit", output(result).includes("cannot resolve current PR base ref missing-base"));
   rmSync(root, { recursive: true, force: true });
 }
-
 {
-  const { root, oldBase } = setupRepo();
-  mkdirSync(join(root, "docs/theory"), { recursive: true });
+  const { root, oldBase } = setupRepo(); mkdirSync(join(root, "docs/theory"), { recursive: true });
   writeFileSync(join(root, "docs/theory/Основания МТС.md"), "# Основания МТС\n");
-  const head = commit(root, "add Cyrillic documentation path");
-  const result = runCheck(root, {
-    pull_request: {
-      number: 103,
-      base: { sha: oldBase, ref: "main" },
-      head: { sha: head },
-      body: unicodeContractBody(),
-    },
-    repository: { full_name: "owner/repo" },
-  });
-  const output = `${result.stdout || ""}${result.stderr || ""}`;
+  const result = runCheck(root, event(103, oldBase, commit(root, "add Cyrillic documentation path"), contractBody({ docs: true })));
   expect("UTF-8 diff path: check-pr passes", result.status === 0);
-  expect("UTF-8 diff path: must-touch does not lose Cyrillic filename", !output.includes("FAIL: must-touch"));
+  expect("UTF-8 diff path: must-touch does not lose Cyrillic filename", !output(result).includes("FAIL: must-touch"));
   rmSync(root, { recursive: true, force: true });
 }
 
-if (failures > 0) {
-  console.error(`\n${failures} current-base regression test(s) failed`);
-  process.exit(1);
-}
+if (failures) { console.error(`\n${failures} current-base regression test(s) failed`); process.exit(1); }
 console.log("\nAll current-base regression tests passed");

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -6,30 +6,15 @@ import { checkAdvisoryTextRules } from "../src/checks/rules/advisory-text-rules.
 import { checkChangeProfile } from "../src/checks/rules/change-profiles.mjs";
 import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
 import {
-  checkCanonicalDocsBudget,
-  checkCochangeRules,
-  checkForbiddenPaths,
-  checkMustNotTouch,
-  checkMustTouch,
-  checkNetAddedLinesBudget,
-  checkNewFilesBudget,
-  checkSurfaceDebt,
+  checkCanonicalDocsBudget, checkCochangeRules, checkForbiddenPaths, checkMustNotTouch, checkMustTouch,
+  checkNetAddedLinesBudget, checkNewFilesBudget, checkScope, checkSurfaceDebt,
 } from "../src/checks/rules/constraints.mjs";
 import { checkRegistryRules } from "../src/checks/rules/registry-rules.mjs";
 import { checkSizeRules, countTextLines } from "../src/checks/rules/size-rules.mjs";
 
 const sampleDiff = [
-  "diff --git a/src/app.mjs b/src/app.mjs",
-  "new file mode 100644",
-  "--- /dev/null",
-  "+++ b/src/app.mjs",
-  "+one",
-  "+two",
-  "diff --git a/README.md b/README.md",
-  "--- a/README.md",
-  "+++ b/README.md",
-  "-old",
-  "+new",
+  "diff --git a/src/app.mjs b/src/app.mjs", "new file mode 100644", "--- /dev/null", "+++ b/src/app.mjs", "+one", "+two",
+  "diff --git a/README.md b/README.md", "--- a/README.md", "+++ b/README.md", "-old", "+new",
 ].join("\n");
 const parsed = parseDiff(sampleDiff);
 assert.equal(parsed.length, 2);
@@ -48,6 +33,10 @@ assert.equal(checkCanonicalDocsBudget(files, ["README.md"], 0).ok, true);
 assert.equal(checkCochangeRules(files, [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }]).length, 0);
 assert.equal(checkMustTouch(files, ["tests/**"]).ok, true);
 assert.equal(checkMustNotTouch(files, ["schemas/**"]).ok, true);
+assert.equal(checkScope(files, ["src/**", "tests/**"]).ok, true);
+assert.deepEqual(checkScope(files, ["src/**"]).out_of_scope_paths, ["tests/a.test.mjs"]);
+assert.equal(checkScope([{ ...files[0], status: "deleted" }], ["src/**"]).ok, true);
+assert.equal(checkScope(files, null).ok, true);
 
 const forbidden = [{ path: "backup.bak", status: "added", addedLines: ["x"], deletedLines: [] }];
 assert.deepEqual(checkForbiddenPaths(forbidden, ["*.bak"]), ["backup.bak"]);
@@ -58,77 +47,42 @@ assert.equal(checkCochangeRules(files.slice(0, 1), [{ if_changed: ["src/**"], mu
 
 const growth = [{ path: "src/new.mjs", status: "added", addedLines: new Array(5).fill("x"), deletedLines: [] }];
 assert.equal(checkSurfaceDebt(growth, null).status, "undeclared");
-assert.equal(checkSurfaceDebt(growth, {
-  kind: "temporary_growth",
-  reason: "temporary",
-  expected_delta: { max_new_files: 1, max_net_added_lines: 5 },
-  repayment_issue: 1,
-}).status, "declared");
-assert.equal(checkSurfaceDebt(growth, {
-  kind: "temporary_growth",
-  reason: "temporary",
-  expected_delta: { max_new_files: 0 },
-  repayment_issue: 1,
-}).status, "declared_debt_exceeded");
+assert.equal(checkSurfaceDebt(growth, { kind: "temporary_growth", reason: "temporary", expected_delta: { max_new_files: 1, max_net_added_lines: 5 }, repayment_issue: 1 }).status, "declared");
+assert.equal(checkSurfaceDebt(growth, { kind: "temporary_growth", reason: "temporary", expected_delta: { max_new_files: 0 }, repayment_issue: 1 }).status, "declared_debt_exceeded");
 
-const filtered = filterOperationalPaths([
-  ...files,
-  { path: ".claude/state.json", status: "added", addedLines: ["{}"], deletedLines: [] },
-], [".claude/**"]);
+const filtered = filterOperationalPaths([...files, { path: ".claude/state.json", status: "added", addedLines: ["{}"], deletedLines: [] }], [".claude/**"]);
 assert.equal(filtered.length, 2);
+assert.equal(checkScope(filtered, ["src/**", "tests/**"]).ok, true);
 
 const surfaces = detectTouchedSurfaces(files, { source: ["src/**"], tests: ["tests/**"] });
 assert.deepEqual(surfaces.touched_surfaces, ["source", "tests"]);
 const classes = classifyNewFiles(files, { source: ["src/**"], test: ["tests/**"] });
 assert.deepEqual(classes.files_by_class.test, ["tests/a.test.mjs"]);
 
-const contentViolations = checkContentRules([
-  { path: "include/a.h", status: "modified", addedLines: ["/// @brief bad"], deletedLines: [] },
-], [{ id: "no-brief", glob: "include/**/*.h", mode: "added_lines", forbid_regex: ["@brief"] }]);
+const contentViolations = checkContentRules([{ path: "include/a.h", status: "modified", addedLines: ["/// @brief bad"], deletedLines: [] }], [{ id: "no-brief", glob: "include/**/*.h", mode: "added_lines", forbid_regex: ["@brief"] }]);
 assert.equal(contentViolations.length, 1);
 
 const profilePolicy = {
-  paths: { canonical_docs: ["README.md"] },
-  surfaces: { source: ["src/**"], tests: ["tests/**"] },
+  paths: { canonical_docs: ["README.md"] }, surfaces: { source: ["src/**"], tests: ["tests/**"] },
   new_file_classes: { source: ["src/**"], test: ["tests/**"] },
-  change_profiles: {
-    refactor: {
-      allow_surfaces: ["source", "tests"],
-      new_files: { allow_classes: ["test"] },
-      budgets: { max_new_files: 1, max_net_added_lines: 2 },
-    },
-  },
+  change_profiles: { refactor: { allow_surfaces: ["source", "tests"], new_files: { allow_classes: ["test"] }, budgets: { max_new_files: 1, max_net_added_lines: 2 } } },
 };
 assert.equal(checkChangeProfile(files, profilePolicy, "refactor").ok, true);
 assert.equal(checkChangeProfile(files, profilePolicy, "feature").ok, false);
 
 const readFile = (path) => ({
-  "src/a.mjs": "one\ntwo\n",
-  "docs/new.md": "# Same\nalpha beta gamma delta\n",
-  "README.md": "# Same\nalpha beta gamma delta\n",
-  "registry.json": JSON.stringify({ files: ["docs/a.md"] }),
-  "INDEX.md": "## Files\n- [A](docs/a.md)\n",
+  "src/a.mjs": "one\ntwo\n", "docs/new.md": "# Same\nalpha beta gamma delta\n", "README.md": "# Same\nalpha beta gamma delta\n",
+  "registry.json": JSON.stringify({ files: ["docs/a.md"] }), "INDEX.md": "## Files\n- [A](docs/a.md)\n",
 }[path]);
-const size = checkSizeRules(files, [{ id: "src-lines", scope: "file", metric: "lines", glob: "src/**", max: 2 }], {
-  trackedFiles: ["src/a.mjs"], readFile,
-});
+const size = checkSizeRules(files, [{ id: "src-lines", scope: "file", metric: "lines", glob: "src/**", max: 2 }], { trackedFiles: ["src/a.mjs"], readFile });
 assert.equal(size.ok, true);
 assert.equal(countTextLines("a\nb\n"), 2);
 
-const advisory = checkAdvisoryTextRules([
-  { path: "docs/new.md", status: "added", addedLines: [] },
-], { canonical_files: ["README.md"], warn_on_similarity_above: 0.5 }, {
-  allFiles: ["README.md", "docs/new.md"], readFile,
-});
+const advisory = checkAdvisoryTextRules([{ path: "docs/new.md", status: "added", addedLines: [] }], { canonical_files: ["README.md"], warn_on_similarity_above: 0.5 }, { allFiles: ["README.md", "docs/new.md"], readFile });
 assert.equal(advisory.advisory, true);
 assert.equal(advisory.matches.length, 1);
 
-const registry = checkRegistryRules([{
-  id: "docs-index",
-  kind: "set_equality",
-  left: { type: "json_array", file: "registry.json", json_pointer: "/files" },
-  right: { type: "markdown_section_links", file: "INDEX.md", section: "Files" },
-}], { readFile });
+const registry = checkRegistryRules([{ id: "docs-index", kind: "set_equality", left: { type: "json_array", file: "registry.json", json_pointer: "/files" }, right: { type: "markdown_section_links", file: "INDEX.md", section: "Files" } }], { readFile });
 assert.equal(registry.ok, true);
 
 console.log("Canonical diff/rule primitive tests passed.");


### PR DESCRIPTION
Fixes #129

Делает `contract.scope` исполняемой границей в canonical Constraint IR и одновременно расширяет compression audit semantic-метриками. Весь gate дал отрицательный diff: 111 additions / 192 deletions.

```repo-guard-yaml
change_type: refactor
scope:
  - src/checks/rules/constraints.mjs
  - scripts/compression-metrics.mjs
  - tests/**
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/checks/rules/constraints.mjs
must_not_touch:
  - schemas/**
expected_effects:
  - contract.scope блокирует изменения вне заявленной области
  - Compression 2.0 получает semantic baseline
```