### PR TITLE
Compression 2.0 2/8: declarative CLI registry

### DIFF
--- a/src/check-diff.mjs
+++ b/src/check-diff.mjs
@@ -6,83 +6,56 @@ import { renderAnalysisReport } from "./reporting/renderers.mjs";
 import { loadJSON, loadPolicyRuntime, validationCheck } from "./runtime/validation.mjs";
 import { runPolicyPipeline } from "./runtime/pipeline.mjs";
 
-const CHECK_DIFF_USAGE = "Usage: repo-guard check-diff [--base <ref>] [--head <ref>] [--contract <path>] [--format <text|json|summary>] [--enforcement <advisory|blocking>]";
-const FORMATS = new Set(["text", "json", "summary"]);
-const OPTIONS = new Set(["--base", "--head", "--contract", "--format"]);
+const value = (args, name) => {
+  const i = args.indexOf(name);
+  return i < 0 ? null : args[i + 1];
+};
 
-function parseCheckDiffArgs(roots, args) {
-  const result = { ok: true, base: null, head: null, contractPath: null, format: "text" };
-  for (let i = 0; i < args.length; i++) {
-    const option = args[i];
-    const value = args[i + 1];
-    if (option.startsWith("-") && !OPTIONS.has(option)) return { ok: false, message: `Unknown option for check-diff: ${option}` };
-    if (!OPTIONS.has(option) || !value) continue;
-    if (option === "--base") result.base = value;
-    else if (option === "--head") result.head = value;
-    else if (option === "--contract") result.contractPath = resolve(roots.repoRoot, value);
-    else result.format = value;
-    i++;
-  }
-  if (!FORMATS.has(result.format)) return { ok: false, message: `Unknown check-diff format: ${result.format}` };
-  return result;
-}
-
-export function runCheckDiff(roots, args) {
-  const parsed = parseCheckDiffArgs(roots, args);
-  if (!parsed.ok) {
-    console.error(`${parsed.message}\n${CHECK_DIFF_USAGE}`);
+export function runCheckDiff(roots, args = []) {
+  const base = value(args, "--base"), head = value(args, "--head");
+  const contractArg = value(args, "--contract");
+  const contractPath = contractArg ? resolve(roots.repoRoot, contractArg) : null;
+  const format = value(args, "--format") || "text";
+  if (!["text", "json", "summary"].includes(format)) {
+    console.error(`Unknown check-diff format: ${format}`);
     return 1;
   }
 
-  const quiet = parsed.format !== "text";
+  const quiet = format !== "text";
   const runtime = loadPolicyRuntime(roots, { quiet });
   const { ajv, policy, contractSchema } = runtime;
   if (!runtime.ok) {
     if (!quiet) console.error("\nPolicy compilation failed; aborting enforcement.");
     return 1;
   }
-
   const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
-  if (!enforcement.ok) {
-    console.error(`ERROR: ${enforcement.message}`);
-    return 1;
-  }
+  if (!enforcement.ok) { console.error(`ERROR: ${enforcement.message}`); return 1; }
 
   let contract = null;
   const initialChecks = [];
-  if (parsed.contractPath) {
+  if (contractPath) {
     try {
-      const loaded = loadJSON(parsed.contractPath);
-      const check = validationCheck(ajv, contractSchema, loaded, parsed.contractPath);
+      const loaded = loadJSON(contractPath);
+      const check = validationCheck(ajv, contractSchema, loaded, contractPath);
       initialChecks.push({ name: "change-contract", check });
       if (check.ok) {
         contract = loaded;
         if (!quiet) for (const warning of warnReservedContractFields(contract)) console.warn(`WARN: ${warning}`);
       }
     } catch (error) {
-      initialChecks.push({ name: "change-contract", check: { ok: false, message: `Cannot read ${parsed.contractPath}: ${error.message}` } });
+      initialChecks.push({ name: "change-contract", check: { ok: false, message: `Cannot read ${contractPath}: ${error.message}` } });
     }
   }
 
   let diffText;
-  try {
-    diffText = getDiff(parsed.base, parsed.head, roots.repoRoot);
-  } catch (error) {
-    console.error(`Error: ${error.message}`);
-    return 1;
-  }
+  try { diffText = getDiff(base, head, roots.repoRoot); }
+  catch (error) { console.error(`Error: ${error.message}`); return 1; }
 
   const report = runPolicyPipeline({
-    mode: "check-diff",
-    repositoryRoot: roots.repoRoot,
-    policy,
-    contract,
-    contractSource: parsed.contractPath ? "cli file" : "none",
-    enforcement,
-    diffText,
-    initialChecks,
+    mode: "check-diff", repositoryRoot: roots.repoRoot, policy, contract,
+    contractSource: contractPath ? "cli file" : "none", enforcement, diffText, initialChecks,
   }, { quiet });
-  const output = renderAnalysisReport(report, { format: parsed.format });
+  const output = renderAnalysisReport(report, { format });
   if (output) console.log(output);
   return report.exitCode;
 }

--- a/src/repo-guard.mjs
+++ b/src/repo-guard.mjs
@@ -6,58 +6,85 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
-export const COMMANDS = Object.freeze(["validate", "check-diff", "check-pr", "init", "doctor", "validate-integration"]);
-const MODES = new Set(COMMANDS.slice(1));
-const USAGE = "Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [check-diff|check-pr|init|doctor|validate-integration] [options]";
+const valueOptions = (...names) => Object.fromEntries(names.map((name) => [name, true]));
+
+const COMMAND_SPECS = {
+  validate: {
+    options: {}, positionals: 1,
+    run: async (roots, args) => (await import("./validate.mjs")).runValidate(roots, args),
+  },
+  "check-diff": {
+    options: valueOptions("--base", "--head", "--contract", "--format"), positionals: 0,
+    run: async (roots, args) => (await import("./check-diff.mjs")).runCheckDiff(roots, args),
+  },
+  "check-pr": {
+    options: {}, positionals: 0,
+    run: async (roots, args) => (await import("./github-pr.mjs")).runCheckPR(roots, args),
+  },
+  init: {
+    options: { ...valueOptions("--preset", "--mode"), "--help": false }, positionals: 0,
+    run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
+  },
+  doctor: {
+    options: { "--integration": false, ...valueOptions("--format") }, positionals: 0,
+    run: async (roots, args) => args.includes("--integration")
+      ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
+      : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
+  },
+  "validate-integration": {
+    options: valueOptions("--format"), positionals: 0,
+    run: async (roots, args) => (await import("./integration-validator.mjs")).runValidateIntegration(roots, args),
+  },
+};
+
+export const COMMANDS = Object.freeze(Object.keys(COMMAND_SPECS));
+const USAGE = `Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [${COMMANDS.join("|")}] [options]`;
 
 export function resolveRoots(args) {
-  let repoRoot = process.cwd();
-  let enforcementMode = null;
+  let repoRoot = process.cwd(), enforcementMode = null;
   const filtered = [];
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--repo-root" || args[i] === "--enforcement" || args[i] === "--enforcement-mode") {
-      const option = args[i];
-      const next = args[i + 1];
-      if (!next || next.startsWith("-")) {
-        const subject = option === "--repo-root" ? "a path" : "a mode";
-        throw new Error(`${option} requires ${subject} argument\n${USAGE}`);
-      }
-      if (option === "--repo-root") repoRoot = resolve(next);
-      else enforcementMode = next;
-      i++;
-    } else {
-      filtered.push(args[i]);
-    }
+    const option = args[i];
+    if (!["--repo-root", "--enforcement", "--enforcement-mode"].includes(option)) { filtered.push(option); continue; }
+    const next = args[++i];
+    if (!next || next.startsWith("-")) throw new Error(`${option} requires ${option === "--repo-root" ? "a path" : "a mode"} argument\n${USAGE}`);
+    if (option === "--repo-root") repoRoot = resolve(next); else enforcementMode = next;
   }
   return { packageRoot, repoRoot, enforcementMode, args: filtered };
 }
 
-function sameEntrypointPath(left, right) {
-  try {
-    return realpathSync(left) === realpathSync(right);
-  } catch {
-    return resolve(left) === resolve(right);
+function parseCommand(args) {
+  const remaining = [...args];
+  const first = remaining[0];
+  const command = COMMAND_SPECS[first] ? remaining.shift() : "validate";
+  if (first?.startsWith("-") && command === "validate") throw new Error(`Unknown option: ${first}\n${USAGE}`);
+  const spec = COMMAND_SPECS[command];
+  let positionals = 0;
+  for (let i = 0; i < remaining.length; i++) {
+    const token = remaining[i];
+    if (!token.startsWith("-")) { positionals++; continue; }
+    if (!Object.hasOwn(spec.options, token)) throw new Error(`Unknown option for ${command}: ${token}\n${USAGE}`);
+    if (!spec.options[token]) continue;
+    const value = remaining[++i];
+    if (!value || value.startsWith("-")) throw new Error(`${token} requires a value\n${USAGE}`);
   }
+  if (positionals > spec.positionals) throw new Error(`Unexpected argument for ${command}\n${USAGE}`);
+  return { command, args: remaining };
+}
+
+function sameEntrypointPath(left, right) {
+  try { return realpathSync(left) === realpathSync(right); }
+  catch { return resolve(left) === resolve(right); }
 }
 
 async function dispatch(roots) {
-  const command = roots.args.shift();
-  if (command?.startsWith("-") && !MODES.has(command)) throw new Error(`Unknown option: ${command}\n${USAGE}`);
-  if (command === "check-diff") return (await import("./check-diff.mjs")).runCheckDiff(roots, roots.args);
-  if (command === "check-pr") return (await import("./github-pr.mjs")).runCheckPR(roots, roots.args);
-  if (command === "init") return (await import("./init.mjs")).runInit(roots, roots.args);
-  if (command === "doctor" && !roots.args.includes("--integration")) return (await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0;
-  if (command === "doctor" || command === "validate-integration") return (await import("./integration-validator.mjs")).runValidateIntegration(roots, roots.args);
-  return (await import("./validate.mjs")).runValidate(roots, command ? [command, ...roots.args] : roots.args);
+  const parsed = parseCommand(roots.args);
+  return COMMAND_SPECS[parsed.command].run(roots, parsed.args);
 }
 
 export async function runCli(args = process.argv.slice(2)) {
-  try {
-    return await dispatch(resolveRoots([...args]));
-  } catch (error) {
-    console.error(`ERROR: ${error.message}`);
-    return 1;
-  }
+  try { return await dispatch(resolveRoots([...args])); }
+  catch (error) { console.error(`ERROR: ${error.message}`); return 1; }
 }
 
 const isMain = process.argv[1] && sameEntrypointPath(process.argv[1], resolve(__dirname, "repo-guard.mjs"));

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -5,17 +5,21 @@ const originalError = console.error;
 const errors = [];
 console.error = (...args) => errors.push(args.join(" "));
 
-try {
-  const unknown = await runCli(["--definitely-unknown"]);
-  assert.equal(unknown, 1);
-  assert.match(errors.join("\n"), /Unknown option/);
-
+async function fails(args, pattern) {
   errors.length = 0;
-  const missingRoot = await runCli(["--repo-root"]);
-  assert.equal(missingRoot, 1);
-  assert.match(errors.join("\n"), /--repo-root requires a path argument/);
+  assert.equal(await runCli(args), 1);
+  assert.match(errors.join("\n"), pattern);
+}
+
+try {
+  await fails(["--definitely-unknown"], /Unknown option/);
+  await fails(["--repo-root"], /--repo-root requires a path argument/);
+  await fails(["check-diff", "--base"], /--base requires a value/);
+  await fails(["check-pr", "extra"], /Unexpected argument for check-pr/);
+  await fails(["validate", "one.json", "two.json"], /Unexpected argument for validate/);
+  await fails(["init", "--bogus"], /Unknown option for init/);
 } finally {
   console.error = originalError;
 }
 
-console.log("CLI runtime returns exit codes without terminating imported callers.");
+console.log("Declarative CLI grammar returns errors without terminating imported callers.");

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -1,25 +1,16 @@
 import assert from "node:assert/strict";
 import { runCli } from "../src/repo-guard.mjs";
 
-const originalError = console.error;
-const errors = [];
+const originalError = console.error, errors = [];
 console.error = (...args) => errors.push(args.join(" "));
-
-async function fails(args, pattern) {
-  errors.length = 0;
-  assert.equal(await runCli(args), 1);
-  assert.match(errors.join("\n"), pattern);
-}
-
+const cases = [
+  [["--definitely-unknown"], /Unknown option/], [["--repo-root"], /--repo-root requires a path argument/],
+  [["check-diff", "--base"], /--base requires a value/], [["check-pr", "extra"], /Unexpected argument for check-pr/],
+  [["validate", "one.json", "two.json"], /Unexpected argument for validate/], [["init", "--bogus"], /Unknown option for init/],
+];
 try {
-  await fails(["--definitely-unknown"], /Unknown option/);
-  await fails(["--repo-root"], /--repo-root requires a path argument/);
-  await fails(["check-diff", "--base"], /--base requires a value/);
-  await fails(["check-pr", "extra"], /Unexpected argument for check-pr/);
-  await fails(["validate", "one.json", "two.json"], /Unexpected argument for validate/);
-  await fails(["init", "--bogus"], /Unknown option for init/);
-} finally {
-  console.error = originalError;
-}
-
+  for (const [args, pattern] of cases) {
+    errors.length = 0; assert.equal(await runCli(args), 1); assert.match(errors.join("\n"), pattern);
+  }
+} finally { console.error = originalError; }
 console.log("Declarative CLI grammar returns errors without terminating imported callers.");


### PR DESCRIPTION
Fixes #130

CLI-команды теперь объявлены в одном registry: список команд, допустимые options, arity и dispatch выводятся из одной структуры. `check-diff` больше не содержит собственного grammar validator. Gate сохраняет `src/**` без роста и весь diff отрицательный.

```repo-guard-yaml
change_type: refactor
scope:
  - src/repo-guard.mjs
  - src/check-diff.mjs
  - tests/test-cli-runtime.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/repo-guard.mjs
must_not_touch:
  - schemas/**
expected_effects:
  - command registry становится source of truth для CLI grammar и dispatch
  - malformed CLI fail-fast до запуска command handler
```