### PR TITLE
Compression 2.0 3/8: schema/compiler boundary

### DIFF
--- a/src/policy-compiler.mjs
+++ b/src/policy-compiler.mjs
@@ -1,843 +1,93 @@
-export function compileForbidRegex(contentRules) {
+const list = (value) => Array.isArray(value) ? value : [];
+const object = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
+
+export function compileForbidRegex(contentRules = []) {
   const errors = [];
-  for (const rule of contentRules) {
-    if (!rule.forbid_regex) continue;
-    for (const pattern of rule.forbid_regex) {
-      try {
-        new RegExp(pattern);
-      } catch (e) {
-        errors.push({
-          rule_id: rule.id,
-          pattern,
-          message: e.message,
-        });
-      }
+  for (const rule of list(contentRules)) for (const pattern of list(rule?.forbid_regex)) {
+    try { new RegExp(pattern); }
+    catch (error) { errors.push({ rule_id: rule?.id, pattern, message: error.message }); }
+  }
+  return errors;
+}
+
+export function compileChangeProfiles(policy = {}) {
+  const errors = [], profiles = object(policy.change_profiles);
+  const surfaces = new Set(Object.keys(object(policy.surfaces)));
+  const classes = new Set(Object.keys(object(policy.new_file_classes)));
+  for (const [changeType, profile] of Object.entries(profiles)) {
+    const p = object(profile), allowed = new Set(list(p.allow_surfaces));
+    for (const field of ["allow_surfaces", "forbid_surfaces", "require_surfaces"]) for (const surface of list(p[field])) {
+      if (!surfaces.has(surface)) errors.push({ change_type: changeType, surface, message: `change_profiles["${changeType}"].${field} references unknown surface "${surface}"` });
+    }
+    for (const surface of list(p.forbid_surfaces)) if (allowed.has(surface)) {
+      errors.push({ change_type: changeType, surface, message: `change_profiles["${changeType}"] lists surface "${surface}" in both allow_surfaces and forbid_surfaces` });
+    }
+    const newFiles = object(p.new_files);
+    for (const fileClass of [...list(newFiles.allow_classes), ...Object.keys(object(newFiles.max_per_class))]) if (!classes.has(fileClass)) {
+      errors.push({ change_type: changeType, class: fileClass, message: `change_profiles["${changeType}"].new_files references unknown class "${fileClass}"` });
     }
   }
   return errors;
 }
 
-export function compileChangeProfiles(policy) {
-  const errors = [];
-  const changeProfiles = policy.change_profiles;
-  if (!changeProfiles) return errors;
-
-  const surfaceNames = new Set(Object.keys(policy.surfaces || {}));
-  const classNames = new Set(Object.keys(policy.new_file_classes || {}));
-
-  if (surfaceNames.size === 0) {
-    errors.push({ message: "change_profiles requires at least one named surface in surfaces" });
+export function compileAnchorPolicy(policy = {}) {
+  const errors = [], types = object(policy.anchors?.types), typeNames = new Set(Object.keys(types)), ids = new Set();
+  for (const [anchorType, config] of Object.entries(types)) for (const [sourceIndex, source] of list(config?.sources).entries()) {
+    if (source?.kind !== "regex") continue;
+    try { new RegExp(source.pattern); }
+    catch (error) { errors.push({ anchor_type: anchorType, source_index: sourceIndex, pattern: source.pattern, message: `anchors.types["${anchorType}"].sources[${sourceIndex}].pattern is invalid: ${error.message}` }); }
   }
-
-  for (const [changeType, profile] of Object.entries(changeProfiles)) {
-    for (const field of ["allow_surfaces", "forbid_surfaces", "require_surfaces"]) {
-      for (const surface of profile[field] || []) {
-        if (!surfaceNames.has(surface)) {
-          errors.push({
-            change_type: changeType,
-            surface,
-            message: `change_profiles["${changeType}"].${field} references unknown surface "${surface}"`,
-          });
-        }
-      }
+  for (const [index, rule] of list(policy.trace_rules).entries()) {
+    if (ids.has(rule?.id)) errors.push({ trace_rule: rule?.id, message: `trace_rules[${index}].id duplicates trace rule "${rule?.id}"` });
+    ids.add(rule?.id);
+    if (rule?.kind === "must_resolve") for (const field of ["from_anchor_type", "to_anchor_type"]) {
+      if (!typeNames.has(rule[field])) errors.push({ trace_rule: rule.id, anchor_type: rule[field], message: `trace_rules[${index}].${field} references unknown anchor type "${rule[field]}"` });
     }
-
-    const allowed = new Set(profile.allow_surfaces || []);
-    for (const surface of profile.forbid_surfaces || []) {
-      if (allowed.has(surface)) {
-        errors.push({
-          change_type: changeType,
-          surface,
-          message: `change_profiles["${changeType}"] lists surface "${surface}" in both allow_surfaces and forbid_surfaces`,
-        });
-      }
-    }
-
-    const newFiles = profile.new_files;
-    if (newFiles) {
-      if (!Object.hasOwn(newFiles, "allow_classes")) {
-        errors.push({
-          change_type: changeType,
-          message: `change_profiles["${changeType}"].new_files.allow_classes is required; use [] to forbid all new-file classes`,
-        });
-      }
-
-      const referencedClasses = [
-        ...(newFiles.allow_classes || []),
-        ...Object.keys(newFiles.max_per_class || {}),
-      ];
-      if (referencedClasses.length > 0 && classNames.size === 0) {
-        errors.push({
-          change_type: changeType,
-          message: `change_profiles["${changeType}"].new_files references new-file classes but new_file_classes is not declared`,
-        });
-      }
-
-      for (const fileClass of newFiles.allow_classes || []) {
-        if (!classNames.has(fileClass)) {
-          errors.push({
-            change_type: changeType,
-            class: fileClass,
-            message: `change_profiles["${changeType}"].new_files.allow_classes references unknown class "${fileClass}"`,
-          });
-        }
-      }
-
-      for (const fileClass of Object.keys(newFiles.max_per_class || {})) {
-        if (!classNames.has(fileClass)) {
-          errors.push({
-            change_type: changeType,
-            class: fileClass,
-            message: `change_profiles["${changeType}"].new_files.max_per_class references unknown class "${fileClass}"`,
-          });
-        }
-      }
-    }
-  }
-
-  return errors;
-}
-
-const REMOVED_POLICY_FIELDS = {
-  change_classes: "change_profiles keyed by change_type",
-  surface_matrix: "change_profiles[change_type].allow_surfaces / forbid_surfaces",
-  new_file_rules: "change_profiles[change_type].new_files",
-  change_type_rules: "change_profiles",
-  allow_unclassified_files: "change_profiles[change_type].allow_unclassified_surfaces",
-};
-
-const REMOVED_CONTRACT_FIELDS = {
-  change_class: "change_type (policies now key off change_type via change_profiles)",
-};
-
-export function checkRemovedPolicyFields(policy) {
-  const errors = [];
-  for (const [field, replacement] of Object.entries(REMOVED_POLICY_FIELDS)) {
-    if (Object.hasOwn(policy, field)) {
-      errors.push({
-        field,
-        message: `policy field "${field}" was removed; use ${replacement}`,
-      });
+    if (rule?.kind === "declared_anchors_require_evidence" && !["anchors.affects", "anchors.implements", "anchors.verifies"].includes(rule.contract_field)) {
+      errors.push({ trace_rule: rule.id, contract_field: rule.contract_field, message: `trace_rules[${index}].contract_field references unsupported contract anchor field` });
     }
   }
   return errors;
 }
 
-export function checkRemovedContractFields(contract) {
-  const errors = [];
-  for (const [field, replacement] of Object.entries(REMOVED_CONTRACT_FIELDS)) {
-    if (Object.hasOwn(contract, field)) {
-      errors.push({
-        field,
-        message: `contract field "${field}" was removed; use ${replacement}`,
-      });
+function semanticIntegrationEntries(integration) {
+  return ["workflows", "templates", "docs", "profiles"].flatMap((section) =>
+    list(integration?.[section]).map((entry, index) => ({ section, index, entry: object(entry) })));
+}
+
+export function compileIntegrationPolicy(policy = {}) {
+  const integration = object(policy.integration);
+  if (!policy.integration || Object.keys(integration).length === 0) return [];
+  const errors = [], seen = new Map(), profileIds = new Set(), references = [];
+  const entries = semanticIntegrationEntries(integration);
+
+  for (const { section, index, entry } of entries) {
+    const id = entry.id;
+    if (typeof id === "string" && id) {
+      if (seen.has(id)) {
+        const previous = seen.get(id);
+        errors.push({ section, id, index, previous_section: previous.section, previous_index: previous.index, message: `integration.${section}[${index}].id duplicates integration.${previous.section}[${previous.index}].id "${id}"` });
+      } else seen.set(id, { section, index });
+      if (section === "profiles") profileIds.add(id);
     }
+    for (const profileId of list(entry.profiles)) references.push({ section, index, field: "profiles", profileId });
+    if (section === "docs") for (const profileId of list(entry.must_mention_profiles)) references.push({ section, index, field: "must_mention_profiles", profileId });
+  }
+
+  for (const ref of references) if (!profileIds.has(ref.profileId)) {
+    errors.push({ section: ref.section, index: ref.index, field: ref.field, profile_id: ref.profileId, message: `integration.${ref.section}[${ref.index}].${ref.field} references unknown integration.profiles id "${ref.profileId}"` });
   }
   return errors;
 }
 
-export function compileAnchorPolicy(policy) {
-  const errors = [];
-  const anchors = policy.anchors;
-  const traceRules = policy.trace_rules || [];
-  const anchorTypes = anchors?.types || {};
-  const anchorTypeNames = new Set(Object.keys(anchorTypes));
-  const traceRuleIds = new Set();
-  const contractAnchorFields = new Set(["anchors.affects", "anchors.implements", "anchors.verifies"]);
-
-  if (!anchors && traceRules.length === 0) return errors;
-
-  if (traceRules.some((rule) => rule.kind === "must_resolve") && anchorTypeNames.size === 0) {
-    errors.push({ message: "trace_rules.kind = \"must_resolve\" requires anchor types in anchors.types" });
-  }
-
-  for (const [anchorType, config] of Object.entries(anchorTypes)) {
-    for (const [index, source] of (config.sources || []).entries()) {
-      if (source.kind === "regex") {
-        try {
-          new RegExp(source.pattern);
-        } catch (e) {
-          errors.push({
-            anchor_type: anchorType,
-            source_index: index,
-            pattern: source.pattern,
-            message: `anchors.types["${anchorType}"].sources[${index}].pattern is invalid: ${e.message}`,
-          });
-        }
-      }
-    }
-  }
-
-  for (const [index, rule] of traceRules.entries()) {
-    if (traceRuleIds.has(rule.id)) {
-      errors.push({
-        trace_rule: rule.id,
-        message: `trace_rules[${index}].id duplicates trace rule "${rule.id}"`,
-      });
-    }
-    traceRuleIds.add(rule.id);
-
-    if (rule.kind === "must_resolve") {
-      for (const field of ["from_anchor_type", "to_anchor_type"]) {
-        const anchorType = rule[field];
-        if (!anchorTypeNames.has(anchorType)) {
-          errors.push({
-            trace_rule: rule.id,
-            anchor_type: anchorType,
-            message: `trace_rules[${index}].${field} references unknown anchor type "${anchorType}"`,
-          });
-        }
-      }
-    } else if (rule.kind === "declared_anchors_require_evidence") {
-      if (!contractAnchorFields.has(rule.contract_field)) {
-        errors.push({
-          trace_rule: rule.id,
-          contract_field: rule.contract_field,
-          message: `trace_rules[${index}].contract_field must be one of ${[...contractAnchorFields].join(", ")}`,
-        });
-      }
-    }
-  }
-
-  return errors;
+export function warnReservedContractFields(contract = {}) {
+  return list(contract.overrides).length
+    ? [`overrides: contains ${contract.overrides.length} entry/entries but is reserved and not enforced at runtime`]
+    : [];
 }
 
-function isPlainObject(value) {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-const integrationSectionRules = {
-  workflows: {
-    requiredStrings: ["id", "kind", "path", "role"],
-    requiredBooleans: [],
-    optionalBooleans: [],
-    requiredStringArrays: [],
-    optionalStringArrays: ["profiles"],
-    profileReferenceArrays: new Set(["profiles"]),
-    allowedFields: new Set(["id", "kind", "path", "role", "expect", "profiles"]),
-    kinds: new Set(["github_actions"]),
-    roles: new Set(["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"]),
-  },
-  templates: {
-    requiredStrings: ["id", "kind", "path"],
-    optionalStrings: ["required_block_kind"],
-    requiredBooleans: ["requires_contract_block"],
-    optionalBooleans: ["optional"],
-    requiredStringArrays: [],
-    optionalStringArrays: ["profiles", "required_contract_fields"],
-    profileReferenceArrays: new Set(["profiles"]),
-    allowedFields: new Set([
-      "id",
-      "kind",
-      "path",
-      "requires_contract_block",
-      "optional",
-      "required_block_kind",
-      "required_contract_fields",
-      "profiles",
-    ]),
-    kinds: new Set(["github_issue_form", "markdown"]),
-    stringEnums: {
-      required_block_kind: new Set(["repo-guard-json", "repo-guard-yaml"]),
-    },
-  },
-  docs: {
-    requiredStrings: ["id", "path"],
-    optionalStrings: ["kind"],
-    requiredBooleans: [],
-    optionalBooleans: [],
-    requiredStringArrays: ["must_mention"],
-    optionalStringArrays: [
-      "profiles",
-      "must_reference_files",
-      "must_mention_profiles",
-      "must_mention_contract_fields",
-    ],
-    profileReferenceArrays: new Set(["profiles", "must_mention_profiles"]),
-    allowedFields: new Set([
-      "id",
-      "kind",
-      "path",
-      "must_mention",
-      "must_reference_files",
-      "must_mention_profiles",
-      "must_mention_contract_fields",
-      "profiles",
-    ]),
-    kinds: new Set(["markdown"]),
-  },
-  profiles: {
-    requiredStrings: ["id", "doc_path"],
-    requiredBooleans: [],
-    optionalBooleans: [],
-    requiredStringArrays: [],
-    optionalStringArrays: [],
-    profileReferenceArrays: new Set(),
-    allowedFields: new Set(["id", "doc_path"]),
-  },
-};
-
-const workflowExpectationRules = {
-  allowedFields: new Set([
-    "events",
-    "event_types",
-    "action",
-    "mode",
-    "enforcement",
-    "permissions",
-    "token_env",
-    "required_env",
-    "summary",
-    "disallow",
-  ]),
-  actionFields: new Set(["uses", "ref", "ref_pinning"]),
-  modes: new Set(["check-pr", "check-diff"]),
-  enforcementModes: new Set(["advisory", "blocking"]),
-  permissionValues: new Set(["none", "read", "write"]),
-  refPinning: new Set(["any", "local", "ref", "tag", "semver", "sha"]),
-  disallowedPatterns: new Set(["continue_on_error", "manual_clone", "direct_temp_cli_execution"]),
-};
-
-function formatAllowed(values) {
-  return [...values].sort().join(", ");
-}
-
-function compileIntegrationError(section, index, field, message, extra = {}) {
-  return {
-    section,
-    ...(index !== null && index !== undefined ? { index } : {}),
-    ...(field ? { field } : {}),
-    ...extra,
-    message,
-  };
-}
-
-function hasNonEmptyString(entry, field) {
-  return typeof entry[field] === "string" && entry[field].trim().length > 0;
-}
-
-function validateIntegrationString(errors, section, index, entry, field, { required = true } = {}) {
-  if (!Object.hasOwn(entry, field)) {
-    if (required) {
-      errors.push(compileIntegrationError(
-        section,
-        index,
-        field,
-        `integration.${section}[${index}].${field} is required`
-      ));
-    }
-    return false;
-  }
-
-  if (!hasNonEmptyString(entry, field)) {
-    errors.push(compileIntegrationError(
-      section,
-      index,
-      field,
-      `integration.${section}[${index}].${field} is required and must be a non-empty string`,
-      { value: entry[field] }
-    ));
-    return false;
-  }
-
-  return true;
-}
-
-function validateIntegrationBoolean(errors, section, index, entry, field, { required = true } = {}) {
-  if (!Object.hasOwn(entry, field)) {
-    if (required) {
-      errors.push(compileIntegrationError(
-        section,
-        index,
-        field,
-        `integration.${section}[${index}].${field} is required`
-      ));
-    }
-    return false;
-  }
-
-  if (typeof entry[field] !== "boolean") {
-    errors.push(compileIntegrationError(
-      section,
-      index,
-      field,
-      `integration.${section}[${index}].${field} must be a boolean`,
-      { value: entry[field] }
-    ));
-    return false;
-  }
-
-  return true;
-}
-
-function validateIntegrationStringArray(errors, section, index, entry, field, { required = true } = {}) {
-  if (!Object.hasOwn(entry, field)) {
-    if (required) {
-      errors.push(compileIntegrationError(
-        section,
-        index,
-        field,
-        `integration.${section}[${index}].${field} is required`
-      ));
-    }
-    return [];
-  }
-
-  const value = entry[field];
-  if (!Array.isArray(value)) {
-    errors.push(compileIntegrationError(
-      section,
-      index,
-      field,
-      `integration.${section}[${index}].${field} must be an array of non-empty strings`,
-      { value }
-    ));
-    return [];
-  }
-
-  const validValues = [];
-  for (const [itemIndex, item] of value.entries()) {
-    if (typeof item === "string" && item.trim().length > 0) {
-      validValues.push(item);
-      continue;
-    }
-
-    errors.push(compileIntegrationError(
-      section,
-      index,
-      field,
-      `integration.${section}[${index}].${field}[${itemIndex}] must be a non-empty string`,
-      { value: item }
-    ));
-  }
-
-  if (validValues.length === 0) {
-    errors.push(compileIntegrationError(
-      section,
-      index,
-      field,
-      `integration.${section}[${index}].${field} must contain at least one non-empty string`
-    ));
-  }
-
-  return validValues;
-}
-
-function integrationExpectationMessage(index, path, message) {
-  return `integration.workflows[${index}].expect.${path} ${message}`;
-}
-
-function pushWorkflowExpectationError(errors, index, path, message, extra = {}) {
-  errors.push(compileIntegrationError(
-    "workflows",
-    index,
-    `expect.${path}`,
-    integrationExpectationMessage(index, path, message),
-    extra
-  ));
-}
-
-function validateExpectationString(errors, index, source, path, { required = false, field = path } = {}) {
-  if (!Object.hasOwn(source, field)) {
-    if (required) {
-      pushWorkflowExpectationError(errors, index, path, "is required");
-    }
-    return false;
-  }
-
-  if (typeof source[field] !== "string" || source[field].trim().length === 0) {
-    pushWorkflowExpectationError(
-      errors,
-      index,
-      path,
-      "is required and must be a non-empty string",
-      { value: source[field] }
-    );
-    return false;
-  }
-
-  return true;
-}
-
-function validateExpectationEnum(errors, index, source, path, allowedValues, { required = false, field = path } = {}) {
-  if (!validateExpectationString(errors, index, source, path, { required, field })) {
-    return;
-  }
-
-  if (!allowedValues.has(source[field])) {
-    pushWorkflowExpectationError(
-      errors,
-      index,
-      path,
-      `must be one of ${formatAllowed(allowedValues)}`,
-      { value: source[field] }
-    );
-  }
-}
-
-function validateExpectationStringArray(errors, index, source, path, allowedValues = null) {
-  const value = source[path];
-  if (!Array.isArray(value)) {
-    pushWorkflowExpectationError(
-      errors,
-      index,
-      path,
-      "must be an array of non-empty strings",
-      { value }
-    );
-    return [];
-  }
-
-  const validValues = [];
-  for (const [itemIndex, item] of value.entries()) {
-    const itemPath = `${path}[${itemIndex}]`;
-    if (typeof item !== "string" || item.trim().length === 0) {
-      pushWorkflowExpectationError(
-        errors,
-        index,
-        itemPath,
-        "must be a non-empty string",
-        { value: item }
-      );
-      continue;
-    }
-
-    if (allowedValues && !allowedValues.has(item)) {
-      pushWorkflowExpectationError(
-        errors,
-        index,
-        itemPath,
-        `must be one of ${formatAllowed(allowedValues)}`,
-        { value: item }
-      );
-      continue;
-    }
-
-    validValues.push(item);
-  }
-
-  if (validValues.length === 0) {
-    pushWorkflowExpectationError(
-      errors,
-      index,
-      path,
-      "must contain at least one non-empty string"
-    );
-  }
-
-  return validValues;
-}
-
-function validateWorkflowExpectations(errors, index, entry) {
-  if (!Object.hasOwn(entry, "expect")) return;
-
-  const expect = entry.expect;
-  if (!isPlainObject(expect)) {
-    errors.push(compileIntegrationError(
-      "workflows",
-      index,
-      "expect",
-      `integration.workflows[${index}].expect must be an object`,
-      { value: expect }
-    ));
-    return;
-  }
-
-  for (const field of Object.keys(expect)) {
-    if (!workflowExpectationRules.allowedFields.has(field)) {
-      pushWorkflowExpectationError(errors, index, field, "is not supported");
-    }
-  }
-
-  for (const field of ["events", "event_types", "token_env", "required_env"]) {
-    if (Object.hasOwn(expect, field)) {
-      validateExpectationStringArray(errors, index, expect, field);
-    }
-  }
-
-  if (Object.hasOwn(expect, "mode")) {
-    validateExpectationEnum(errors, index, expect, "mode", workflowExpectationRules.modes);
-  }
-
-  if (Object.hasOwn(expect, "enforcement")) {
-    validateExpectationEnum(errors, index, expect, "enforcement", workflowExpectationRules.enforcementModes);
-  }
-
-  if (Object.hasOwn(expect, "summary") && typeof expect.summary !== "boolean") {
-    pushWorkflowExpectationError(
-      errors,
-      index,
-      "summary",
-      "must be a boolean",
-      { value: expect.summary }
-    );
-  }
-
-  if (Object.hasOwn(expect, "disallow")) {
-    validateExpectationStringArray(errors, index, expect, "disallow", workflowExpectationRules.disallowedPatterns);
-  }
-
-  if (Object.hasOwn(expect, "permissions")) {
-    if (!isPlainObject(expect.permissions)) {
-      pushWorkflowExpectationError(
-        errors,
-        index,
-        "permissions",
-        "must be an object",
-        { value: expect.permissions }
-      );
-    } else {
-      const entries = Object.entries(expect.permissions);
-      if (entries.length === 0) {
-        pushWorkflowExpectationError(errors, index, "permissions", "must declare at least one permission");
-      }
-      for (const [permission, value] of entries) {
-        if (!workflowExpectationRules.permissionValues.has(value)) {
-          pushWorkflowExpectationError(
-            errors,
-            index,
-            `permissions.${permission}`,
-            `must be one of ${formatAllowed(workflowExpectationRules.permissionValues)}`,
-            { value }
-          );
-        }
-      }
-    }
-  }
-
-  if (Object.hasOwn(expect, "action")) {
-    if (!isPlainObject(expect.action)) {
-      pushWorkflowExpectationError(
-        errors,
-        index,
-        "action",
-        "must be an object",
-        { value: expect.action }
-      );
-    } else {
-      for (const field of Object.keys(expect.action)) {
-        if (!workflowExpectationRules.actionFields.has(field)) {
-          pushWorkflowExpectationError(errors, index, `action.${field}`, "is not supported");
-        }
-      }
-      for (const field of ["uses", "ref"]) {
-        if (Object.hasOwn(expect.action, field)) {
-          validateExpectationString(errors, index, expect.action, `action.${field}`, { field });
-        }
-      }
-      if (Object.hasOwn(expect.action, "ref_pinning")) {
-        validateExpectationEnum(
-          errors,
-          index,
-          expect.action,
-          "action.ref_pinning",
-          workflowExpectationRules.refPinning,
-          { field: "ref_pinning" }
-        );
-      }
-    }
-  }
-}
-
-export function compileIntegrationPolicy(policy) {
-  const errors = [];
-  const integration = policy.integration;
-
-  if (!integration) return errors;
-
-  if (!isPlainObject(integration)) {
-    return [compileIntegrationError(null, null, null, "integration must be an object")];
-  }
-
-  const sectionNames = Object.keys(integrationSectionRules);
-  const profileReferences = [];
-  const profileIds = new Set();
-  const globalIds = new Map();
-
-  for (const section of Object.keys(integration)) {
-    if (!Object.hasOwn(integrationSectionRules, section)) {
-      errors.push(compileIntegrationError(
-        section,
-        null,
-        null,
-        `integration.${section} is not supported; use ${sectionNames.join(", ")}`
-      ));
-    }
-  }
-
-  for (const section of sectionNames) {
-    const rules = integrationSectionRules[section];
-    const seen = new Map();
-    const sectionValue = integration[section];
-    if (sectionValue === undefined) continue;
-
-    if (!Array.isArray(sectionValue)) {
-      errors.push(compileIntegrationError(
-        section,
-        null,
-        null,
-        `integration.${section} must be an array`
-      ));
-      continue;
-    }
-
-    const entries = sectionValue;
-    for (const [index, entry] of entries.entries()) {
-      if (!isPlainObject(entry)) {
-        errors.push(compileIntegrationError(
-          section,
-          index,
-          null,
-          `integration.${section}[${index}] must be an object`
-        ));
-        continue;
-      }
-
-      for (const field of Object.keys(entry)) {
-        if (!rules.allowedFields.has(field)) {
-          errors.push(compileIntegrationError(
-            section,
-            index,
-            field,
-            `integration.${section}[${index}].${field} is not supported`
-          ));
-        }
-      }
-
-      for (const field of rules.requiredStrings || []) {
-        validateIntegrationString(errors, section, index, entry, field);
-      }
-
-      for (const field of rules.optionalStrings || []) {
-        validateIntegrationString(errors, section, index, entry, field, { required: false });
-      }
-
-      for (const field of rules.requiredBooleans || []) {
-        validateIntegrationBoolean(errors, section, index, entry, field);
-      }
-
-      for (const field of rules.optionalBooleans || []) {
-        validateIntegrationBoolean(errors, section, index, entry, field, { required: false });
-      }
-
-      for (const field of rules.requiredStringArrays || []) {
-        const references = validateIntegrationStringArray(errors, section, index, entry, field);
-        if (rules.profileReferenceArrays?.has(field)) {
-          for (const profileId of references) {
-            profileReferences.push({ section, index, field, profileId });
-          }
-        }
-      }
-
-      for (const field of rules.optionalStringArrays || []) {
-        const references = validateIntegrationStringArray(errors, section, index, entry, field, { required: false });
-        if (rules.profileReferenceArrays?.has(field)) {
-          for (const profileId of references) {
-            profileReferences.push({ section, index, field, profileId });
-          }
-        }
-      }
-
-      if (rules.kinds && hasNonEmptyString(entry, "kind") && !rules.kinds.has(entry.kind)) {
-        errors.push(compileIntegrationError(
-          section,
-          index,
-          "kind",
-          `integration.${section}[${index}].kind must be one of ${formatAllowed(rules.kinds)}`,
-          { value: entry.kind }
-        ));
-      }
-
-      if (rules.roles && hasNonEmptyString(entry, "role") && !rules.roles.has(entry.role)) {
-        errors.push(compileIntegrationError(
-          section,
-          index,
-          "role",
-          `integration.${section}[${index}].role must be one of ${formatAllowed(rules.roles)}`,
-          { value: entry.role }
-        ));
-      }
-
-      for (const [field, allowedValues] of Object.entries(rules.stringEnums || {})) {
-        if (!hasNonEmptyString(entry, field) || allowedValues.has(entry[field])) continue;
-        errors.push(compileIntegrationError(
-          section,
-          index,
-          field,
-          `integration.${section}[${index}].${field} must be one of ${formatAllowed(allowedValues)}`,
-          { value: entry[field] }
-        ));
-      }
-
-      if (section === "workflows") {
-        validateWorkflowExpectations(errors, index, entry);
-      }
-
-      if (!hasNonEmptyString(entry, "id")) continue;
-
-      if (seen.has(entry.id)) {
-        errors.push({
-          section,
-          id: entry.id,
-          index,
-          message: `integration.${section}[${index}].id duplicates integration.${section}[${seen.get(entry.id)}].id "${entry.id}"`,
-        });
-      } else {
-        seen.set(entry.id, index);
-      }
-
-      if (globalIds.has(entry.id)) {
-        const previous = globalIds.get(entry.id);
-        if (previous.section !== section) {
-          errors.push({
-            section,
-            id: entry.id,
-            index,
-            previous_section: previous.section,
-            previous_index: previous.index,
-            message: `integration.${section}[${index}].id duplicates integration.${previous.section}[${previous.index}].id "${entry.id}"`,
-          });
-        }
-      } else {
-        globalIds.set(entry.id, { section, index });
-      }
-
-      if (section === "profiles") {
-        profileIds.add(entry.id);
-      }
-    }
-  }
-
-  for (const reference of profileReferences) {
-    if (profileIds.has(reference.profileId)) continue;
-    errors.push(compileIntegrationError(
-      reference.section,
-      reference.index,
-      reference.field,
-      `integration.${reference.section}[${reference.index}].${reference.field} references unknown integration.profiles id "${reference.profileId}"`,
-      { profile_id: reference.profileId }
-    ));
-  }
-
-  return errors;
-}
-
-export function warnReservedContractFields(contract) {
-  const warnings = [];
-  if (contract.overrides && contract.overrides.length > 0) {
-    warnings.push(
-      `overrides: contains ${contract.overrides.length} entry/entries but is reserved and not enforced at runtime`
-    );
-  }
-  return warnings;
-}
-
-export function warnReservedPolicyFields(policy) {
-  const warnings = [];
-  if (policy.paths?.public_api && policy.paths.public_api.length > 0) {
-    warnings.push(
-      "paths.public_api: defined but reserved for future use; not enforced at runtime"
-    );
-  }
-  return warnings;
+export function warnReservedPolicyFields(policy = {}) {
+  return list(policy.paths?.public_api).length
+    ? ["paths.public_api: defined but reserved for future use; not enforced at runtime"]
+    : [];
 }

--- a/src/runtime/validation.mjs
+++ b/src/runtime/validation.mjs
@@ -31,14 +31,14 @@ export function loadPolicyRuntimeFromObject(roots, rawPolicy, options = {}) {
 
   const profile = resolvePolicyProfile(rawPolicy);
   const policy = profile.policy;
-  const groups = [
+  const semanticGroups = [
     ["profile compilation", profile.errors, (error) => error.message],
     ["forbid_regex compilation", compileForbidRegex(policy.content_rules), (error) => `[${error.rule_id}] invalid regex /${error.pattern}/: ${error.message}`],
     ["change_profiles compilation", compileChangeProfiles(policy), (error) => error.message],
     ["anchor policy compilation", compileAnchorPolicy(policy), (error) => error.message],
     ["integration policy compilation", compileIntegrationPolicy(policy), (error) => error.message],
   ];
-  for (const [group, errors, format] of groups) if (errors.length) {
+  for (const [group, errors, format] of semanticGroups) if (errors.length) {
     ok = false;
     if (!quiet) { console.error(`FAIL: ${group}`); for (const error of errors) console.error(`  ${format(error)}`); }
   }

--- a/src/runtime/validation.mjs
+++ b/src/runtime/validation.mjs
@@ -1,96 +1,51 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import {
-  checkRemovedPolicyFields,
-  compileAnchorPolicy,
-  compileChangeProfiles,
-  compileForbidRegex,
-  compileIntegrationPolicy,
-  warnReservedPolicyFields,
-} from "../policy-compiler.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
 import { resolvePolicyProfile } from "../policy-profiles.mjs";
 
-export function loadJSON(path) {
-  return JSON.parse(readFileSync(path, "utf-8"));
-}
+export const loadJSON = (path) => JSON.parse(readFileSync(path, "utf-8"));
+export const createAjv = () => new Ajv({ allErrors: true });
+export const ajvErrors = (errors) => (errors || []).map((error) => `${error.instancePath || "/"} ${error.message}`);
 
-export function createAjv() {
-  return new Ajv({ allErrors: true });
-}
-
-export function ajvErrors(errors) {
-  return (errors || []).map((err) => `${err.instancePath || "/"} ${err.message}`);
-}
-
-export function validate(ajv, schema, data, label, options = {}) {
+export function validate(ajv, schema, data, label, { quiet = false } = {}) {
   const valid = ajv.validate(schema, data);
-  if (!valid) {
-    if (!options.quiet) {
-      console.error(`FAIL: ${label}`);
-      for (const err of ajv.errors) {
-        console.error(`  ${err.instancePath || "/"} ${err.message}`);
-      }
-    }
-    return false;
+  if (!quiet) {
+    console[valid ? "log" : "error"](`${valid ? "OK" : "FAIL"}: ${label}`);
+    if (!valid) for (const error of ajv.errors) console.error(`  ${error.instancePath || "/"} ${error.message}`);
   }
-  if (!options.quiet) console.log(`OK: ${label}`);
-  return true;
+  return valid;
 }
 
 export function validationCheck(ajv, schema, data, label) {
-  const valid = ajv.validate(schema, data);
-  if (valid) return { ok: true };
-  return {
-    ok: false,
-    message: `${label} failed schema validation`,
-    errors: ajvErrors(ajv.errors),
+  return ajv.validate(schema, data) ? { ok: true } : {
+    ok: false, message: `${label} failed schema validation`, errors: ajvErrors(ajv.errors),
   };
 }
 
 export function loadPolicyRuntimeFromObject(roots, rawPolicy, options = {}) {
   const policySchema = loadJSON(resolve(roots.packageRoot, "schemas/repo-policy.schema.json"));
   const contractSchema = loadJSON(resolve(roots.packageRoot, "schemas/change-contract.schema.json"));
-  const ajv = createAjv();
-  const quiet = options.quiet || false;
-  const label = options.label || "repo-policy.json";
+  const ajv = createAjv(), quiet = options.quiet || false, label = options.label || "repo-policy.json";
+  let ok = validate(ajv, policySchema, rawPolicy, label, { quiet });
 
-  let ok = true;
-  ok = validate(ajv, policySchema, rawPolicy, label, { quiet }) && ok;
-
-  const profileResult = resolvePolicyProfile(rawPolicy);
-  const policy = profileResult.policy;
-
-  const compileGroups = [
-    ["removed policy fields", checkRemovedPolicyFields(rawPolicy), (e) => e.message],
-    ["profile compilation", profileResult.errors, (e) => e.message],
-    ["forbid_regex compilation", compileForbidRegex(policy.content_rules), (e) => `[${e.rule_id}] invalid regex /${e.pattern}/: ${e.message}`],
-    ["change_profiles compilation", compileChangeProfiles(policy), (e) => e.message],
-    ["anchor policy compilation", compileAnchorPolicy(policy), (e) => e.message],
-    ["integration policy compilation", compileIntegrationPolicy(policy), (e) => e.message],
+  const profile = resolvePolicyProfile(rawPolicy);
+  const policy = profile.policy;
+  const groups = [
+    ["profile compilation", profile.errors, (error) => error.message],
+    ["forbid_regex compilation", compileForbidRegex(policy.content_rules), (error) => `[${error.rule_id}] invalid regex /${error.pattern}/: ${error.message}`],
+    ["change_profiles compilation", compileChangeProfiles(policy), (error) => error.message],
+    ["anchor policy compilation", compileAnchorPolicy(policy), (error) => error.message],
+    ["integration policy compilation", compileIntegrationPolicy(policy), (error) => error.message],
   ];
-
-  for (const [label, errors, format] of compileGroups) {
-    if (errors.length === 0) continue;
+  for (const [group, errors, format] of groups) if (errors.length) {
     ok = false;
-    if (!quiet) {
-      console.error(`FAIL: ${label}`);
-      for (const error of errors) {
-        console.error(`  ${format(error)}`);
-      }
-    }
+    if (!quiet) { console.error(`FAIL: ${group}`); for (const error of errors) console.error(`  ${format(error)}`); }
   }
-
-  if (!quiet) {
-    for (const warning of warnReservedPolicyFields(policy)) {
-      console.warn(`WARN: ${warning}`);
-    }
-  }
-
+  if (!quiet) for (const warning of warnReservedPolicyFields(policy)) console.warn(`WARN: ${warning}`);
   return { ok, ajv, policy, contractSchema };
 }
 
 export function loadPolicyRuntime(roots, options = {}) {
-  const rawPolicy = loadJSON(resolve(roots.repoRoot, "repo-policy.json"));
-  return loadPolicyRuntimeFromObject(roots, rawPolicy, options);
+  return loadPolicyRuntimeFromObject(roots, loadJSON(resolve(roots.repoRoot, "repo-policy.json")), options);
 }

--- a/tests/test-doctor.mjs
+++ b/tests/test-doctor.mjs
@@ -71,8 +71,6 @@ function runDoctor(args = "", opts = {}) {
   return runRepoGuard(args, opts);
 }
 
-// --- self-hosting: doctor runs on this repo ---
-
 console.log("\n--- self-hosting: doctor on repo-guard itself ---");
 {
   const { stdout, code } = runDoctor("doctor");
@@ -87,16 +85,12 @@ console.log("\n--- self-hosting: doctor on repo-guard itself ---");
   expectNotIncludes("no failures in summary", stdout, "1 failed");
 }
 
-// --- self-hosting: doctor catches broken fixture ---
-
 console.log("\n--- self-hosting: doctor catches broken-policy fixture ---");
 {
   const dir = makeTmpDir();
   initGitRepo(dir);
   const brokenPolicy = resolve(projectRoot, "tests/fixtures/broken-policy.json");
-  const dest = resolve(dir, "repo-policy.json");
-  writeFileSync(dest, readFileSync(brokenPolicy, "utf-8"));
-
+  writeFileSync(resolve(dir, "repo-policy.json"), readFileSync(brokenPolicy, "utf-8"));
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 1 for broken policy", code, 1);
   expectIncludes("detects invalid forbid_regex", stdout, "FAIL: repo-policy.json");
@@ -104,106 +98,71 @@ console.log("\n--- self-hosting: doctor catches broken-policy fixture ---");
   expectIncludes("summary shows failure", stdout, "1 failed");
 }
 
-// --- missing repo-policy.json ---
-
 console.log("\n--- missing repo-policy.json ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
-
+  const dir = makeTmpDir(); initGitRepo(dir);
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 1 for missing policy", code, 1);
   expectIncludes("policy FAIL", stdout, "FAIL: repo-policy.json");
   expectIncludes("hint mentions init", stdout, "repo-guard init");
 }
 
-// --- invalid JSON in repo-policy.json ---
-
 console.log("\n--- malformed JSON in repo-policy.json ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
+  const dir = makeTmpDir(); initGitRepo(dir);
   writeFileSync(resolve(dir, "repo-policy.json"), "{ not valid json }}");
-
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 1 for malformed json", code, 1);
   expectIncludes("policy FAIL with parse error", stdout, "FAIL: repo-policy.json");
   expectIncludes("mentions parse error", stdout, "Parse error");
 }
 
-// --- schema-invalid policy ---
-
 console.log("\n--- schema-invalid repo-policy.json ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
+  const dir = makeTmpDir(); initGitRepo(dir);
   writeFileSync(resolve(dir, "repo-policy.json"), JSON.stringify({
-    policy_format_version: "0.3.0",
-    repository_kind: "unknown_kind",
-    paths: {},
-    diff_rules: {}
+    policy_format_version: "0.3.0", repository_kind: "unknown_kind", paths: {}, diff_rules: {}
   }));
-
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 1 for invalid schema", code, 1);
   expectIncludes("policy FAIL with schema error", stdout, "FAIL: repo-policy.json");
   expectIncludes("mentions schema validation", stdout, "Schema validation failed");
 }
 
-// --- integration compile diagnostics surface through validate and doctor ---
-
 console.log("\n--- integration compile diagnostics surface through validate and doctor ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
+  const dir = makeTmpDir(); initGitRepo(dir);
   writeFileSync(resolve(dir, "repo-policy.json"), JSON.stringify({
-    policy_format_version: "0.3.0",
-    repository_kind: "tooling",
+    policy_format_version: "0.3.0", repository_kind: "tooling",
     integration: {
-      workflows: [
-        {
-          id: "pr-gate",
-          kind: "github_actions",
-          path: ".github/workflows/repo-guard.yml",
-          role: "custom_gate",
-          profiles: ["missing-profile"],
-        },
-      ],
+      workflows: [{ id: "pr-gate", kind: "github_actions", path: ".github/workflows/repo-guard.yml", role: "custom_gate", profiles: ["missing-profile"] }],
       profiles: [],
     },
     paths: { forbidden: [], canonical_docs: ["README.md"], governance_paths: ["repo-policy.json"] },
-    diff_rules: { max_new_docs: 2, max_new_files: 15 },
-    content_rules: [],
-    cochange_rules: [],
+    diff_rules: { max_new_docs: 2, max_new_files: 15 }, content_rules: [], cochange_rules: [],
   }));
 
   const validate = runRepoGuard(`--repo-root ${dir}`);
   expect("validate exit code 1 for invalid integration", validate.code, 1);
   expectIncludes("validate reports integration compilation", validate.stderr, "FAIL: integration policy compilation");
-  expectIncludes("validate reports unknown workflow role", validate.stderr, "role must be one of");
+  expectIncludes("validate reports workflow role through schema", validate.stderr, "/integration/workflows/0/role must be equal to one of the allowed values");
   expectIncludes("validate reports missing profile reference", validate.stderr, "missing-profile");
 
   const doctor = runDoctor(`--repo-root ${dir} doctor`);
   expect("doctor exit code 1 for invalid integration", doctor.code, 1);
   expectIncludes("doctor reports invalid integration policy", doctor.stdout, "Invalid integration policy");
-  expectIncludes("doctor reports unknown workflow role", doctor.stdout, "role must be one of");
+  expectIncludes("doctor reports workflow role through schema", doctor.stdout, "/integration/workflows/0/role must be equal to one of the allowed values");
   expectIncludes("doctor reports missing profile reference", doctor.stdout, "missing-profile");
 }
 
-// --- not a git repo ---
-
 console.log("\n--- not a git repository ---");
 {
-  const dir = makeTmpDir();
-  writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
-
+  const dir = makeTmpDir(); writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 0 (warns, no fails)", code, 0);
   expectIncludes("git WARN for non-repo", stdout, "WARN: git-available");
   expectIncludes("hint mentions git init", stdout, "git init");
 }
-
-// --- non-existent repo root ---
 
 console.log("\n--- non-existent repo root ---");
 {
@@ -212,68 +171,45 @@ console.log("\n--- non-existent repo root ---");
   expectIncludes("root FAIL", stdout, "FAIL: repository-root");
 }
 
-// --- no workflow directory ---
-
 console.log("\n--- no workflow directory ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
-  writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
-
+  const dir = makeTmpDir(); initGitRepo(dir); writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 0 (warns, no fails)", code, 0);
   expectIncludes("workflow WARN for missing dir", stdout, "WARN: workflow-config");
   expectIncludes("hint mentions init", stdout, "repo-guard init");
 }
 
-// --- workflow without repo-guard reference ---
-
 console.log("\n--- workflow without repo-guard reference ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
-  writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
+  const dir = makeTmpDir(); initGitRepo(dir); writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
   mkdirSync(resolve(dir, ".github/workflows"), { recursive: true });
   writeFileSync(resolve(dir, ".github/workflows/ci.yml"), "name: CI\non:\n  push:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n");
-
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 0 (warns, no fails)", code, 0);
   expectIncludes("workflow WARN for no repo-guard ref", stdout, "WARN: workflow-config");
   expectIncludes("mentions no workflow references", stdout, "No workflow references repo-guard");
 }
 
-// --- workflow missing fetch-depth: 0 ---
-
 console.log("\n--- workflow missing fetch-depth ---");
 {
-  const dir = makeTmpDir();
-  initGitRepo(dir);
-  writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
+  const dir = makeTmpDir(); initGitRepo(dir); writeFileSync(resolve(dir, "repo-policy.json"), validPolicy());
   mkdirSync(resolve(dir, ".github/workflows"), { recursive: true });
   writeFileSync(resolve(dir, ".github/workflows/ci.yml"), "name: CI\non:\n  push:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npx repo-guard check-pr\n");
-
   const { stdout, code } = runDoctor(`--repo-root ${dir} doctor`);
   expect("exit code 0 (warns)", code, 0);
   expectIncludes("workflow WARN for missing config", stdout, "WARN: workflow-config");
   expectIncludes("mentions fetch-depth", stdout, "fetch-depth");
 }
 
-// --- pass/warn/fail distinction ---
-
 console.log("\n--- output distinguishes pass / warn / fail ---");
 {
   const { stdout } = runDoctor("doctor");
   expectIncludes("contains PASS", stdout, "PASS:");
-  if (process.env.GITHUB_EVENT_PATH) {
-    // In CI with GH_TOKEN, all checks may PASS — WARN is not guaranteed
-    console.log("PASS: skipping WARN check (CI with full context may have no warnings)");
-  } else {
-    expectIncludes("contains WARN", stdout, "WARN:");
-  }
+  if (process.env.GITHUB_EVENT_PATH) console.log("PASS: skipping WARN check (CI with full context may have no warnings)");
+  else expectIncludes("contains WARN", stdout, "WARN:");
   expectIncludes("contains Summary", stdout, "Summary:");
 }
-
-// --- event context adapts to environment ---
 
 console.log("\n--- event context adapts to environment ---");
 {
@@ -284,16 +220,13 @@ console.log("\n--- event context adapts to environment ---");
     expectIncludes("mentions not in GitHub Actions", stdout, "not in GitHub Actions");
   } else {
     const event = JSON.parse(readFileSync(eventPath, "utf-8"));
-    if (event.pull_request) {
-      expectIncludes("event-context PASS for pull_request event", stdout, "PASS: event-context");
-    } else {
+    if (event.pull_request) expectIncludes("event-context PASS for pull_request event", stdout, "PASS: event-context");
+    else {
       expectIncludes("event-context WARN for non-PR GitHub event", stdout, "WARN: event-context");
       expectIncludes("non-PR event is explained", stdout, "not a pull_request event");
     }
   }
 }
-
-// --- gh/auth are optional unless linked-issue fallback is used ---
 
 console.log("\n--- gh/auth are optional unless linked-issue fallback is used ---");
 {
@@ -302,8 +235,6 @@ console.log("\n--- gh/auth are optional unless linked-issue fallback is used ---
   expectNotIncludes("auth-token is never FAIL (auth only needed for linked-issue fallback)", stdout, "FAIL: auth-token");
 }
 
-// --- --repo-root works with doctor ---
-
 console.log("\n--- --repo-root flag works with doctor ---");
 {
   const { stdout, code } = runDoctor(`--repo-root ${projectRoot} doctor`);
@@ -311,12 +242,6 @@ console.log("\n--- --repo-root flag works with doctor ---");
   expectIncludes("shows repo root path", stdout, projectRoot);
 }
 
-// --- summary ---
-
 console.log("\n=========================");
-if (failures > 0) {
-  console.error(`${failures} test(s) FAILED`);
-  process.exit(1);
-} else {
-  console.log("All doctor tests passed");
-}
+if (failures > 0) { console.error(`${failures} test(s) FAILED`); process.exit(1); }
+else console.log("All doctor tests passed");

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -5,112 +5,58 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { execSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import {
-  checkRemovedContractFields,
-  checkRemovedPolicyFields,
-  compileAnchorPolicy,
-  compileChangeProfiles,
-  compileForbidRegex,
-  compileIntegrationPolicy,
-  warnReservedContractFields,
-  warnReservedPolicyFields,
-} from "../src/policy-compiler.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedContractFields, warnReservedPolicyFields } from "../src/policy-compiler.mjs";
 import { checkMustTouch } from "../src/checks/rules/constraints.mjs";
 import { checkIssueFallbackPrerequisites, checkPrerequisites } from "../src/github-pr.mjs";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
-const runRepoGuard = (args, options = {}) => spawnSync(process.execPath, [repoGuard, ...args], {
-  cwd: options.cwd || projectRoot,
-  env: options.env || process.env,
-  encoding: "utf-8",
-});
+const runRepoGuard = (args, options = {}) => spawnSync(process.execPath, [repoGuard, ...args], { cwd: options.cwd || projectRoot, env: options.env || process.env, encoding: "utf-8" });
 
 function initTinyRepo(prefix) {
   const root = mkdtempSync(join(tmpdir(), prefix));
-  execSync("git init", { cwd: root, stdio: "pipe" });
-  execSync("git config user.email test@test.com", { cwd: root, stdio: "pipe" });
-  execSync("git config user.name Test", { cwd: root, stdio: "pipe" });
+  execSync("git init", { cwd: root, stdio: "pipe" }); execSync("git config user.email test@test.com", { cwd: root, stdio: "pipe" }); execSync("git config user.name Test", { cwd: root, stdio: "pipe" });
   writeFileSync(join(root, "repo-policy.json"), JSON.stringify({
-    policy_format_version: "0.1.0",
-    repository_kind: "library",
+    policy_format_version: "0.1.0", repository_kind: "library",
     paths: { forbidden: [], canonical_docs: ["README.md"], governance_paths: ["repo-policy.json"] },
-    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 },
-    content_rules: [],
-    cochange_rules: [],
+    diff_rules: { max_new_docs: 5, max_new_files: 20, max_net_added_lines: 500 }, content_rules: [], cochange_rules: [],
   }));
-  writeFileSync(join(root, "a.txt"), "a\nb\n");
-  execSync("git add -A && git commit -m init", { cwd: root, stdio: "pipe" });
-  writeFileSync(join(root, "a.txt"), "a\n");
-  execSync("git add -A && git commit -m second", { cwd: root, stdio: "pipe" });
+  writeFileSync(join(root, "a.txt"), "a\nb\n"); execSync("git add -A && git commit -m init", { cwd: root, stdio: "pipe" });
+  writeFileSync(join(root, "a.txt"), "a\n"); execSync("git add -A && git commit -m second", { cwd: root, stdio: "pipe" });
   return root;
 }
 
-describe("compiler hardening", () => {
-  it("eagerly rejects malformed regexes", () => {
+describe("semantic compiler hardening", () => {
+  it("eagerly compiles regexes", () => {
     const errors = compileForbidRegex([{ id: "bad", forbid_regex: ["[invalid(", "ok"] }]);
-    assert.equal(errors.length, 1);
-    assert.equal(errors[0].rule_id, "bad");
+    assert.equal(errors.length, 1); assert.equal(errors[0].rule_id, "bad");
   });
 
   it("rejects contradictory and unknown change-profile references", () => {
     const errors = compileChangeProfiles({
-      surfaces: { source: ["src/**"] },
-      new_file_classes: { test: ["tests/**"] },
-      change_profiles: {
-        feature: {
-          allow_surfaces: ["source", "missing"],
-          forbid_surfaces: ["source"],
-          new_files: { allow_classes: ["test", "generated"] },
-        },
-      },
+      surfaces: { source: ["src/**"] }, new_file_classes: { test: ["tests/**"] },
+      change_profiles: { feature: { allow_surfaces: ["source", "missing"], forbid_surfaces: ["source"], new_files: { allow_classes: ["test", "generated"] } } },
     });
-    assert.ok(errors.some((error) => error.message.includes("missing")));
-    assert.ok(errors.some((error) => error.message.includes("both allow_surfaces and forbid_surfaces")));
-    assert.ok(errors.some((error) => error.message.includes("generated")));
+    assert.ok(errors.some((e) => e.message.includes("missing"))); assert.ok(errors.some((e) => e.message.includes("both allow_surfaces"))); assert.ok(errors.some((e) => e.message.includes("generated")));
   });
 
-  it("rejects removed DSL fields instead of silently accepting legacy semantics", () => {
-    assert.equal(checkRemovedPolicyFields({ change_classes: [], surface_matrix: {} }).length, 2);
-    assert.equal(checkRemovedContractFields({ change_class: "legacy" }).length, 1);
-  });
-
-  it("validates anchor references, duplicate rule ids and extractor regexes", () => {
-    const unknown = compileAnchorPolicy({
-      anchors: { types: { requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**", field: "id" }] } } },
-      trace_rules: [{ id: "resolve", kind: "must_resolve", from_anchor_type: "missing", to_anchor_type: "requirement_id" }],
-    });
-    assert.equal(unknown.length, 1);
-    const duplicate = compileAnchorPolicy({
-      anchors: { types: { requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**", field: "id" }] } } },
-      trace_rules: [
-        { id: "same", kind: "must_resolve", from_anchor_type: "requirement_id", to_anchor_type: "requirement_id" },
-        { id: "same", kind: "must_resolve", from_anchor_type: "requirement_id", to_anchor_type: "requirement_id" },
-      ],
-    });
-    assert.ok(duplicate.some((error) => error.message.includes("duplicates")));
+  it("validates anchor cross-references, duplicate ids and regexes", () => {
+    const anchors = { types: { requirement_id: { sources: [{ kind: "json_field", glob: "requirements/**", field: "id" }] } } };
+    assert.equal(compileAnchorPolicy({ anchors, trace_rules: [{ id: "resolve", kind: "must_resolve", from_anchor_type: "missing", to_anchor_type: "requirement_id" }] }).length, 1);
+    assert.ok(compileAnchorPolicy({ anchors, trace_rules: [
+      { id: "same", kind: "must_resolve", from_anchor_type: "requirement_id", to_anchor_type: "requirement_id" },
+      { id: "same", kind: "must_resolve", from_anchor_type: "requirement_id", to_anchor_type: "requirement_id" },
+    ] }).some((e) => e.message.includes("duplicates")));
     assert.equal(compileAnchorPolicy({ anchors: { types: { ref: { sources: [{ kind: "regex", glob: "src/**", pattern: "[bad" }] } } } }).length, 1);
   });
 
-  it("validates integration ids, references and PR-gate expectations", () => {
-    const valid = compileIntegrationPolicy({ integration: {
-      workflows: [{
-        id: "gate", kind: "github_actions", path: ".github/workflows/ci.yml", role: "repo_guard_pr_gate",
-        profiles: ["strict"],
-        expect: { events: ["pull_request"], action: { uses: "./", ref_pinning: "local" }, mode: "check-pr", enforcement: "blocking" },
-      }],
+  it("keeps integration compiler focused on ids and cross-references", () => {
+    assert.deepEqual(compileIntegrationPolicy({ integration: {
+      workflows: [{ id: "gate", kind: "github_actions", path: "ci.yml", role: "repo_guard_pr_gate", profiles: ["strict"] }],
       profiles: [{ id: "strict", doc_path: "README.md" }],
-    } });
-    assert.deepEqual(valid, []);
-
-    const invalid = compileIntegrationPolicy({ integration: {
-      workflows: [
-        { id: "dup", kind: "github_actions", path: "a.yml", role: "repo_guard_pr_gate" },
-        { id: "dup", kind: "github_actions", path: "b.yml", role: "repo_guard_pr_gate", profiles: ["missing"] },
-      ],
-    } });
-    assert.ok(invalid.some((error) => error.message.includes("duplicates")));
-    assert.ok(invalid.some((error) => error.message.includes("missing")));
+    } }), []);
+    const invalid = compileIntegrationPolicy({ integration: { workflows: [{ id: "dup" }, { id: "dup", profiles: ["missing"] }] } });
+    assert.ok(invalid.some((e) => e.message.includes("duplicates"))); assert.ok(invalid.some((e) => e.message.includes("missing")));
   });
 
   it("keeps reserved fields visibly non-enforcing", () => {
@@ -124,52 +70,26 @@ describe("runtime hardening", () => {
   it("preserves must_touch any-of semantics", () => {
     const files = [{ path: "src/app.mjs" }, { path: "tests/app.test.mjs" }];
     assert.equal(checkMustTouch(files, ["docs/**", "tests/**"]).ok, true);
-    const failed = checkMustTouch(files, ["docs/**"]);
-    assert.equal(failed.ok, false);
-    assert.match(failed.hint, /any-of/);
+    const failed = checkMustTouch(files, ["docs/**"]); assert.equal(failed.ok, false); assert.match(failed.hint, /any-of/);
   });
 
   it("separates mandatory git prerequisites from optional linked-issue gh lookup", () => {
-    const originalEvent = process.env.GITHUB_EVENT_PATH;
-    delete process.env.GITHUB_EVENT_PATH;
-    try {
-      assert.ok(checkPrerequisites().some((item) => item.includes("GITHUB_EVENT_PATH")));
-    } finally {
-      if (originalEvent !== undefined) process.env.GITHUB_EVENT_PATH = originalEvent;
-    }
-
-    const root = mkdtempSync(join(tmpdir(), "rg-no-gh-"));
-    const fakeGit = join(root, "git");
-    writeFileSync(fakeGit, "#!/bin/sh\nprintf 'git version 2.0.0\\n'\n");
-    chmodSync(fakeGit, 0o755);
-    const originalPath = process.env.PATH;
-    process.env.PATH = root;
-    process.env.GITHUB_EVENT_PATH = join(root, "event.json");
-    try {
-      assert.equal(checkPrerequisites().some((item) => item.includes("gh CLI")), false);
-      assert.equal(checkIssueFallbackPrerequisites().some((item) => item.includes("gh CLI")), true);
-    } finally {
-      process.env.PATH = originalPath;
-      if (originalEvent !== undefined) process.env.GITHUB_EVENT_PATH = originalEvent;
-      else delete process.env.GITHUB_EVENT_PATH;
-      rmSync(root, { recursive: true, force: true });
-    }
+    const originalEvent = process.env.GITHUB_EVENT_PATH; delete process.env.GITHUB_EVENT_PATH;
+    try { assert.ok(checkPrerequisites().some((item) => item.includes("GITHUB_EVENT_PATH"))); }
+    finally { if (originalEvent !== undefined) process.env.GITHUB_EVENT_PATH = originalEvent; }
+    const root = mkdtempSync(join(tmpdir(), "rg-no-gh-")), fakeGit = join(root, "git");
+    writeFileSync(fakeGit, "#!/bin/sh\nprintf 'git version 2.0.0\\n'\n"); chmodSync(fakeGit, 0o755);
+    const originalPath = process.env.PATH; process.env.PATH = root; process.env.GITHUB_EVENT_PATH = join(root, "event.json");
+    try { assert.equal(checkPrerequisites().some((item) => item.includes("gh CLI")), false); assert.equal(checkIssueFallbackPrerequisites().some((item) => item.includes("gh CLI")), true); }
+    finally { process.env.PATH = originalPath; if (originalEvent !== undefined) process.env.GITHUB_EVENT_PATH = originalEvent; else delete process.env.GITHUB_EVENT_PATH; rmSync(root, { recursive: true, force: true }); }
   });
 
   it("passes shell-looking refs to git without shell execution", () => {
     const root = initTinyRepo("rg-ref-injection-");
     try {
       const marker = join(root, "injected");
-      const result = runRepoGuard([
-        "check-diff", "--repo-root", root,
-        "--base", `HEAD~1; touch ${marker}; #`,
-        "--head", "HEAD",
-      ]);
-      assert.equal(result.status, 1);
-      assert.match(`${result.stdout}${result.stderr}`, /git diff failed/);
-      assert.equal(existsSync(marker), false);
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
+      const result = runRepoGuard(["check-diff", "--repo-root", root, "--base", `HEAD~1; touch ${marker}; #`, "--head", "HEAD"]);
+      assert.equal(result.status, 1); assert.match(`${result.stdout}${result.stderr}`, /git diff failed/); assert.equal(existsSync(marker), false);
+    } finally { rmSync(root, { recursive: true, force: true }); }
   });
 });


### PR DESCRIPTION
Fixes #131

JSON Schema теперь остаётся единственным источником structural validation DSL, а `policy-compiler.mjs` проверяет только семантику: regex compilation, cross-references, contradictions и duplicate ids. Удалено дублирование структуры integration/change profiles без изменения публичной schema. Тест doctor теперь проверяет schema-owned enum diagnostic вместо удалённого semantic дубля.

Structural diff остаётся сильно отрицательным; `schemas/**` не затронут.

```repo-guard-yaml
change_type: refactor
scope:
  - src/policy-compiler.mjs
  - src/runtime/validation.mjs
  - tests/**
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/policy-compiler.mjs
must_not_touch:
  - schemas/**
expected_effects:
  - JSON Schema единолично проверяет shape/types/enums DSL
  - semantic compiler проверяет только cross-reference и executable semantics
  - compiler surface существенно сокращается
```