### PR TITLE
Compression 2.0 5/8: relation kernel

### DIFF
--- a/docs/self-hosting-coverage.json
+++ b/docs/self-hosting-coverage.json
@@ -2,10 +2,8 @@
   "$comment": "Нормальный список возможностей выводится tests/test-self-hosting.mjs из command/rule/profile registries. Здесь хранятся только реальные исключения, которые нельзя честно применить к самому repo-guard.",
   "schema_version": "2.0.0",
   "exceptions": {
-    "rule:registry-rules": "В repo-guard нет естественной пары канонических реестров JSON/Markdown; искусственный реестр был бы фиктивным покрытием.",
     "rule:advisory-text-rules": "Репозиторий намеренно не хранит дублирующий Markdown ради проверки эвристики похожих документов.",
     "rule:anchor-extraction": "В repo-guard нет собственных requirement anchors; механизм покрывается специализированными тестами.",
-    "rule:trace-rules": "Trace rules требуют реальных anchor declarations, которых в этом инструментальном репозитории нет.",
     "profile:requirements-strict": "Встроенный профиль требует канонические requirements/*.json; добавлять фиктивные требования ради dogfooding нельзя.",
     "contract-format:repo-guard-json": "YAML является канонической собственной формой; второй JSON-блок в шаблоне был бы искусственным покрытием, формат проверяется тестами parser-а."
   }

--- a/src/checks/constraint-program.mjs
+++ b/src/checks/constraint-program.mjs
@@ -9,33 +9,21 @@ const set = (relation, value, metadata) => compare(relation, array(value), metad
 const exact = (value, metadata) => compare("equal_or_incomparable", value, metadata);
 const entity = (metadata) => compare("required_entity", true, metadata);
 
-/** Canonical semantic program. Front-end policy/contract constructs compile here once;
- * runtime and self-relaxation consume different projections of the same entries. */
 export function compileConstraintProgram(policy = {}, contract = null) {
-  const program = [];
-  const diff = policy.diff_rules || {}, budgets = contract?.budgets || {};
+  const program = [], diff = policy.diff_rules || {}, budgets = contract?.budgets || {};
   const add = (key, runtime = null, strictness = null) => program.push({ key, runtime, strictness });
 
-  add("paths:forbidden",
-    { kind: "forbid_paths", name: "forbidden-paths", patterns: policy.paths?.forbidden || [] },
-    set("superset_stricter", policy.paths?.forbidden, {
-      pointer: "/paths/forbidden", weakenKind: "forbidden_path_removed", itemField: "pattern",
-      message: (item) => `paths.forbidden removed: ${item}`,
-    }));
+  add("paths:forbidden", { kind: "forbid_paths", name: "forbidden-paths", patterns: policy.paths?.forbidden || [] },
+    set("superset_stricter", policy.paths?.forbidden, { pointer: "/paths/forbidden", weakenKind: "forbidden_path_removed", itemField: "pattern", message: (item) => `paths.forbidden removed: ${item}` }));
 
   for (const [field, metric, name] of [
-    ["max_new_docs", "new_docs", "canonical-docs-budget"],
-    ["max_new_files", "new_files", "max-new-files"],
-    ["max_net_added_lines", "net_added_lines", "max-net-added-lines"],
+    ["max_new_docs", "new_docs", "canonical-docs-budget"], ["max_new_files", "new_files", "max-new-files"], ["max_net_added_lines", "net_added_lines", "max-net-added-lines"],
   ]) {
     const value = diff[field];
-    add(`diff:${field}`,
-      { kind: "max_metric", name, metric, max: budgets[field] ?? value },
-      typeof value === "number" ? scalar("lower_stricter", value, {
-        pointer: `/diff_rules/${field}`, weakenKind: "diff_rule_budget_increased", removeKind: "diff_rule_budget_removed", field,
-        message: (before, after) => `diff_rules.${field}: ${before} -> ${after}`,
-        removeMessage: `diff_rules.${field} removed (was ${value})`,
-      }) : null);
+    add(`diff:${field}`, { kind: "max_metric", name, metric, max: budgets[field] ?? value }, typeof value === "number" ? scalar("lower_stricter", value, {
+      pointer: `/diff_rules/${field}`, weakenKind: "diff_rule_budget_increased", removeKind: "diff_rule_budget_removed", field,
+      message: (before, after) => `diff_rules.${field}: ${before} -> ${after}`, removeMessage: `diff_rules.${field} removed (was ${value})`,
+    }) : null);
   }
 
   for (const [key, field, relation, kind, message] of [
@@ -53,10 +41,8 @@ export function compileConstraintProgram(policy = {}, contract = null) {
   for (const rule of array(policy.size_rules)) {
     const owner = `size:${rule.id}`, pointer = `/size_rules/${rule.id}`;
     add(owner, null, entity({ owner, pointer, removeKind: "size_rule_removed", rule_id: rule.id,
-      removeBefore: { present: true, glob: rule.glob, max: rule.max }, removeAfter: { present: false },
-      removeMessage: `size_rules entry "${rule.id}" removed (glob: ${rule.glob ?? "?"}, max: ${rule.max ?? "?"})` }));
-    add(`${owner}:shape`, null, exact({ scope: rule.scope, metric: rule.metric, glob: rule.glob, applies_to_change_types: rule.applies_to_change_types },
-      { owner, pointer, incomparableMessage: `size_rules[${rule.id}] changed selector/scope semantics` }));
+      removeBefore: { present: true, glob: rule.glob, max: rule.max }, removeAfter: { present: false }, removeMessage: `size_rules entry "${rule.id}" removed (glob: ${rule.glob ?? "?"}, max: ${rule.max ?? "?"})` }));
+    add(`${owner}:shape`, null, exact({ scope: rule.scope, metric: rule.metric, glob: rule.glob, applies_to_change_types: rule.applies_to_change_types }, { owner, pointer, incomparableMessage: `size_rules[${rule.id}] changed selector/scope semantics` }));
     add(`${owner}:max`, null, scalar("lower_stricter", rule.max, { owner, pointer: `${pointer}/max`, weakenKind: "size_rule_max_increased", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].max: ${a} -> ${b}` }));
     add(`${owner}:level`, null, scalar("higher_stricter", RANKS.enforcement[rule.level || "blocking"], { owner, raw: rule.level || "blocking", pointer: `${pointer}/level`, weakenKind: "size_rule_level_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].level: ${a} -> ${b}` }));
     add(`${owner}:count`, null, scalar("higher_stricter", RANKS.count[rule.count || "all_tracked"], { owner, raw: rule.count || "all_tracked", pointer: `${pointer}/count`, weakenKind: "size_rule_count_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].count: ${a} -> ${b}` }));
@@ -72,14 +58,17 @@ export function compileConstraintProgram(policy = {}, contract = null) {
     add(owner, null, entity({ owner, pointer, removeKind: "integration_workflow_removed", workflow_id: workflow.id,
       removeBefore: { present: true, role: workflow.role, path: workflow.path }, removeAfter: { present: false }, removeMessage: `integration.workflows entry "${workflow.id}" removed` }));
     const { enforcement, ...otherExpect } = workflow.expect || {};
-    add(`${owner}:shape`, null, exact({ kind: workflow.kind, path: workflow.path, role: workflow.role, profiles: workflow.profiles, expect: otherExpect },
-      { owner, pointer, incomparableMessage: `integration.workflows[${workflow.id}] changed non-monotonic wiring semantics` }));
+    add(`${owner}:shape`, null, exact({ kind: workflow.kind, path: workflow.path, role: workflow.role, profiles: workflow.profiles, expect: otherExpect }, { owner, pointer, incomparableMessage: `integration.workflows[${workflow.id}] changed non-monotonic wiring semantics` }));
     if (enforcement) add(`${owner}:enforcement`, null, scalar("higher_stricter", RANKS.enforcement[enforcement], {
       owner, raw: enforcement, pointer: `${pointer}/expect/enforcement`, weakenKind: "integration_workflow_expectation_weakened", removeKind: "integration_workflow_expectation_removed", workflow_id: workflow.id,
       message: (a, b) => `integration.workflows[${workflow.id}].expect.enforcement: ${a} -> ${b}`, removeMessage: `integration.workflows[${workflow.id}].expect.enforcement removed (was ${enforcement})`,
     }));
   }
 
+  if (array(policy.size_rules).length) add("runtime:size-rules", { kind: "size_rules", name: "size-rules", rules: policy.size_rules });
+  if (array(policy.registry_rules).length) add("runtime:registry-rules", { kind: "registry_rules", name: "registry-rules", rules: policy.registry_rules });
+  if (array(policy.trace_rules).length) add("runtime:trace-rules", { kind: "trace_rules", name: "trace-rules" });
+  if (policy.change_profiles) add("runtime:change-profile", { kind: "change_profile", name: "change-profiles" });
   add("surface-debt", { kind: "surface_debt", name: "surface-debt", debt: contract?.surface_debt });
   array(policy.cochange_rules).forEach((rule, index) => add(`cochange:${index}`, { kind: "implies_nonempty", name: "cochange", ...rule }));
   if (contract) {
@@ -92,54 +81,35 @@ export function compileConstraintProgram(policy = {}, contract = null) {
 
 export const runtimeConstraints = (program) => program.flatMap((entry) => entry.runtime ? [{ key: entry.key, ...entry.runtime }] : []);
 const comparisonConstraints = (policy) => compileConstraintProgram(policy).flatMap((entry) => entry.strictness ? [{ key: entry.key, ...entry.strictness }] : []);
-
-function canonical(value) {
-  if (Array.isArray(value)) return value.map(canonical);
-  if (value && typeof value === "object") return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])]));
-  return value;
-}
+function canonical(value) { if (Array.isArray(value)) return value.map(canonical); if (value && typeof value === "object") return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])])); return value; }
 const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
 const clone = (value) => value === undefined ? undefined : structuredClone(value);
-
 function unknownProjection(policy = {}) {
-  const copy = clone(policy) || {};
-  delete copy.enforcement; delete copy.diff_rules; delete copy.size_rules;
-  if (copy.paths) {
-    for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"]) delete copy.paths[field];
-    if (!Object.keys(copy.paths).length) delete copy.paths;
-  }
+  const copy = clone(policy) || {}; delete copy.enforcement; delete copy.diff_rules; delete copy.size_rules;
+  if (copy.paths) { for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"]) delete copy.paths[field]; if (!Object.keys(copy.paths).length) delete copy.paths; }
   if (copy.integration) { delete copy.integration.workflows; if (!Object.keys(copy.integration).length) delete copy.integration; }
   return copy;
 }
-
 const relaxation = (entry, before, after = null, kind = entry.weakenKind, message = null, extra = {}) => ({
-  kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}),
-  ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
+  kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}), ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
   message: message || entry.message?.(before, after) || entry.removeMessage, ...extra,
 });
-const incomparable = (entry, before, after) => ({ kind: "policy_incomparable", pointer: entry.pointer, before, after,
-  message: entry.incomparableMessage || `policy constraint ${entry.key} changed with no proven monotonic ordering` });
+const incomparable = (entry, before, after) => ({ kind: "policy_incomparable", pointer: entry.pointer, before, after, message: entry.incomparableMessage || `policy constraint ${entry.key} changed with no proven monotonic ordering` });
 
 export function compareConstraintPrograms(basePolicy, headPolicy) {
   if (!basePolicy || !headPolicy) return { relation: "equal", relaxations: [], incomparable: [] };
   const base = comparisonConstraints(basePolicy), head = new Map(comparisonConstraints(headPolicy).map((item) => [item.key, item]));
-  const relaxations = [], incomparableChanges = [], removedOwners = new Set();
-  let tightened = false, changed = false;
+  const relaxations = [], incomparableChanges = [], removedOwners = new Set(); let tightened = false, changed = false;
   for (const entry of base) {
     if (entry.owner && removedOwners.has(entry.owner)) continue;
     const next = head.get(entry.key);
-    if (!next) {
-      if (entry.removeKind) { relaxations.push(relaxation(entry, entry.removeBefore ?? entry.raw ?? entry.value, entry.removeAfter ?? null, entry.removeKind, entry.removeMessage)); changed = true; if (entry.relation === "required_entity") removedOwners.add(entry.key); }
-      continue;
-    }
+    if (!next) { if (entry.removeKind) { relaxations.push(relaxation(entry, entry.removeBefore ?? entry.raw ?? entry.value, entry.removeAfter ?? null, entry.removeKind, entry.removeMessage)); changed = true; if (entry.relation === "required_entity") removedOwners.add(entry.key); } continue; }
     if (entry.relation === "lower_stricter" || entry.relation === "higher_stricter") {
       const weaker = entry.relation === "lower_stricter" ? next.value > entry.value : next.value < entry.value;
       const stricter = entry.relation === "lower_stricter" ? next.value < entry.value : next.value > entry.value;
-      if (weaker) relaxations.push(relaxation(entry, entry.raw ?? entry.value, next.raw ?? next.value));
-      tightened ||= stricter; changed ||= next.value !== entry.value;
+      if (weaker) relaxations.push(relaxation(entry, entry.raw ?? entry.value, next.raw ?? next.value)); tightened ||= stricter; changed ||= next.value !== entry.value;
     } else if (["superset_stricter", "subset_stricter"].includes(entry.relation)) {
-      const before = new Set(entry.value), after = new Set(next.value);
-      const removed = entry.value.filter((item) => !after.has(item)), added = next.value.filter((item) => !before.has(item));
+      const before = new Set(entry.value), after = new Set(next.value), removed = entry.value.filter((item) => !after.has(item)), added = next.value.filter((item) => !before.has(item));
       const weaker = entry.relation === "superset_stricter" ? removed : added;
       for (const item of weaker) relaxations.push(relaxation(entry, item, null, entry.weakenKind, entry.message(item), { [entry.itemField]: item }));
       tightened ||= (entry.relation === "superset_stricter" ? added : removed).length > 0; changed ||= removed.length > 0 || added.length > 0;

--- a/src/checks/default-rule-families.mjs
+++ b/src/checks/default-rule-families.mjs
@@ -1,24 +1,17 @@
 import { advisoryTextRuleFamily } from "./rules/advisory-text-rules.mjs";
-import { anchorExtractionRuleFamily, traceRuleFamily } from "./rules/anchor-rules.mjs";
-import { changeProfileRuleFamily } from "./rules/change-profiles.mjs";
+import { anchorExtractionRuleFamily } from "./rules/anchor-rules.mjs";
 import { constraintRuleFamily } from "./rules/constraints.mjs";
 import { contentRuleFamily } from "./rules/content-rules.mjs";
 import { governancePathsRuleFamily } from "./rules/governance-paths.mjs";
 import { policyRelaxationRuleFamily } from "./rules/policy-delta-rules.mjs";
-import { registryRuleFamily } from "./rules/registry-rules.mjs";
-import { sizeRuleFamily } from "./rules/size-rules.mjs";
 import { createRuleRegistry } from "./rule-registry.mjs";
 
 export const defaultRuleFamilies = [
   constraintRuleFamily,
   governancePathsRuleFamily,
   policyRelaxationRuleFamily,
-  sizeRuleFamily,
-  registryRuleFamily,
   advisoryTextRuleFamily,
   anchorExtractionRuleFamily,
-  traceRuleFamily,
-  changeProfileRuleFamily,
   contentRuleFamily,
 ];
 

--- a/src/checks/relation-kernel.mjs
+++ b/src/checks/relation-kernel.mjs
@@ -1,0 +1,14 @@
+const set = (values = []) => new Set(values);
+
+export function compareSets(left = [], right = [], relation = "equal") {
+  const l = set(left), r = set(right);
+  const missing = left.filter((value) => !r.has(value));
+  const extra = right.filter((value) => !l.has(value));
+  const ok = relation === "left_subset" ? !missing.length
+    : relation === "right_subset" ? !extra.length
+      : !missing.length && !extra.length;
+  return { ok, missing, extra };
+}
+
+export const implies = (trigger, evidence) => !trigger || Boolean(evidence);
+export const maxBound = (actual, max) => max === undefined || actual <= max;

--- a/src/checks/rules/anchor-rules.mjs
+++ b/src/checks/rules/anchor-rules.mjs
@@ -1,28 +1,7 @@
 import { checkAnchorExtraction } from "../../extractors/anchors.mjs";
-import { checkTraceRuleResult } from "../trace-rules.mjs";
 
 export const anchorExtractionRuleFamily = {
   id: "anchor-extraction",
-  applies(facts) {
-    return Boolean(facts.policy.anchors);
-  },
-  evaluate(facts) {
-    return {
-      name: "anchor-extraction",
-      check: checkAnchorExtraction(facts.anchors),
-    };
-  },
-};
-
-export const traceRuleFamily = {
-  id: "trace-rules",
-  applies(facts) {
-    return Boolean(facts.policy.trace_rules && facts.policy.trace_rules.length > 0);
-  },
-  evaluate(_facts, context = {}) {
-    return (context.anchorDiagnostics?.traceRuleResults || []).map((traceResult) => ({
-      name: `trace-rule: ${traceResult.id}`,
-      check: checkTraceRuleResult(traceResult),
-    }));
-  },
+  applies: (facts) => Boolean(facts.policy.anchors),
+  evaluate: (facts) => ({ name: "anchor-extraction", check: checkAnchorExtraction(facts.anchors) }),
 };

--- a/src/checks/rules/change-profiles.mjs
+++ b/src/checks/rules/change-profiles.mjs
@@ -1,107 +1,83 @@
 import { classifyNewFiles, detectTouchedSurfaces } from "../../diff/classification.mjs";
 import { formatList, uniqueSorted } from "../../utils/collections.mjs";
-import { checkCanonicalDocsBudget, checkNetAddedLinesBudget, checkNewFilesBudget } from "./constraints.mjs";
+import { maxBound } from "../relation-kernel.mjs";
+
+function budget(actual, max, files = undefined) {
+  return max === undefined ? { ok: true } : { ok: maxBound(actual, max), actual, limit: max, ...(files ? { files } : {}) };
+}
+function profileBudgets(files, canonicalDocs, limits = {}) {
+  const added = files.filter((file) => file.status === "added");
+  const docs = added.filter((file) => /\.md$/i.test(file.path) && !canonicalDocs.includes(file.path));
+  const net = files.reduce((sum, file) => sum + (file.addedLines?.length || 0) - (file.deletedLines?.length || 0), 0);
+  return {
+    docs: budget(docs.length, limits.max_new_docs, docs.map((file) => file.path)),
+    files: budget(added.length, limits.max_new_files, added.map((file) => file.path)),
+    lines: budget(net, limits.max_net_added_lines),
+  };
+}
 
 function checkProfileNewFiles(files, classes, rule, changeType, detected = null) {
   if (!rule) return { ok: true };
   detected ||= classifyNewFiles(files, classes || {});
   const newFiles = detected.new_files;
-  if (newFiles.length === 0) return {
-    ok: true, change_type: changeType, new_files: newFiles,
-    files_by_class: detected.files_by_class, unclassified_files: detected.unclassified_files,
-  };
-
-  const allowedClasses = uniqueSorted(rule.allow_classes || []);
-  const allowed = new Set(allowedClasses);
+  if (!newFiles.length) return { ok: true, change_type: changeType, new_files: [], files_by_class: detected.files_by_class, unclassified_files: detected.unclassified_files };
+  const allowedClasses = uniqueSorted(rule.allow_classes || []), allowed = new Set(allowedClasses);
   const touchedClasses = uniqueSorted(Object.keys(detected.files_by_class));
   const violatingClasses = allowedClasses.length ? touchedClasses.filter((name) => !allowed.has(name)) : touchedClasses;
   const unclassifiedFiles = detected.unclassified_files;
   const classBudgetViolations = Object.entries(rule.max_per_class || {}).flatMap(([fileClass, limit]) => {
-    const filesInClass = detected.files_by_class[fileClass] || [];
-    return filesInClass.length > limit ? [{ class: fileClass, actual: filesInClass.length, limit, files: filesInClass }] : [];
+    const selected = detected.files_by_class[fileClass] || [];
+    return maxBound(selected.length, limit) ? [] : [{ class: fileClass, actual: selected.length, limit, files: selected }];
   });
-  const exceedsMax = rule.max_new_files !== undefined && newFiles.length > rule.max_new_files;
+  const exceedsMax = !maxBound(newFiles.length, rule.max_new_files);
   const details = [
     ...violatingClasses.map((name) => `class ${name} is not allowed by change_profiles["${changeType}"].new_files.allow_classes; files: ${detected.files_by_class[name].join(", ")}`),
     ...unclassifiedFiles.map((file) => `file ${file} detected class: unclassified; violated rule: change_profiles["${changeType}"].new_files.allow_classes`),
     ...classBudgetViolations.map((v) => `class ${v.class} has ${v.actual} new file(s), limit ${v.limit}; files: ${v.files.join(", ")}`),
   ];
   if (exceedsMax) details.push(`new files ${newFiles.length} exceeds change_profiles["${changeType}"].new_files.max_new_files ${rule.max_new_files}`);
-  const ok = violatingClasses.length === 0 && unclassifiedFiles.length === 0 && classBudgetViolations.length === 0 && !exceedsMax;
-  const message = violatingClasses.length
-    ? `change_type "${changeType}" cannot add new-file classes: ${violatingClasses.join(", ")}`
-    : unclassifiedFiles.length
-      ? `change_profiles["${changeType}"].new_files found added files that match no declared new_file_class: ${unclassifiedFiles.join(", ")}`
-      : !ok ? `change_type "${changeType}" exceeds change_profiles["${changeType}"].new_files budget` : undefined;
-
+  const ok = !violatingClasses.length && !unclassifiedFiles.length && !classBudgetViolations.length && !exceedsMax;
   return {
-    ok, message, change_type: changeType, new_files: newFiles,
-    actual: exceedsMax ? newFiles.length : undefined,
-    limit: exceedsMax ? rule.max_new_files : undefined,
-    allowed_classes: allowedClasses, touched_classes: touchedClasses, violating_classes: violatingClasses,
-    class_budget_violations: classBudgetViolations, files_by_class: detected.files_by_class,
-    unclassified_files: unclassifiedFiles, details,
+    ok, message: violatingClasses.length ? `change_type "${changeType}" cannot add new-file classes: ${violatingClasses.join(", ")}`
+      : unclassifiedFiles.length ? `change_profiles["${changeType}"].new_files found added files that match no declared new_file_class: ${unclassifiedFiles.join(", ")}`
+        : !ok ? `change_type "${changeType}" exceeds change_profiles["${changeType}"].new_files budget` : undefined,
+    change_type: changeType, new_files: newFiles, actual: exceedsMax ? newFiles.length : undefined, limit: exceedsMax ? rule.max_new_files : undefined,
+    allowed_classes: allowedClasses, touched_classes: touchedClasses, violating_classes: violatingClasses, class_budget_violations: classBudgetViolations,
+    files_by_class: detected.files_by_class, unclassified_files: unclassifiedFiles, details,
     hint: unclassifiedFiles.length ? "Add matching new_file_classes globs or update the change_profile.new_files.allow_classes." : undefined,
   };
 }
 
 export function checkChangeProfile(files, policy, changeType, derived = {}) {
   const profiles = policy.change_profiles || {};
-  if (Object.keys(profiles).length === 0) return { ok: true };
+  if (!Object.keys(profiles).length) return { ok: true };
   if (!changeType) return { ok: false, message: "change_profiles requires a declared change_type", change_type: null, hint: "Set change_type in the contract." };
   const profile = profiles[changeType];
-  if (!profile) return {
-    ok: false, message: `change_type "${changeType}" is not defined in change_profiles`, change_type: changeType,
-    details: [`known change types: ${formatList(Object.keys(profiles).sort())}`],
-    hint: "Define the change type in change_profiles or use one of the configured types.",
-  };
+  if (!profile) return { ok: false, message: `change_type "${changeType}" is not defined in change_profiles`, change_type: changeType, details: [`known change types: ${formatList(Object.keys(profiles).sort())}`], hint: "Define the change type in change_profiles or use one of the configured types." };
 
   const detected = derived.touchedSurfaces || detectTouchedSurfaces(files, policy.surfaces);
-  const touched = detected.touched_surfaces;
-  const required = uniqueSorted(profile.require_surfaces || []);
-  const allowed = uniqueSorted(profile.allow_surfaces || []);
-  const forbidden = uniqueSorted(profile.forbid_surfaces || []);
-  const touchedSet = new Set(touched);
-  const usesConstraints = required.length + allowed.length + forbidden.length > 0;
+  const touched = detected.touched_surfaces, required = uniqueSorted(profile.require_surfaces || []), allowed = uniqueSorted(profile.allow_surfaces || []), forbidden = uniqueSorted(profile.forbid_surfaces || []);
+  const touchedSet = new Set(touched), usesConstraints = required.length + allowed.length + forbidden.length > 0;
   const hasUnclassified = usesConstraints && detected.unclassified_files.length > 0 && !profile.allow_unclassified_surfaces;
   const missing = required.filter((surface) => !touchedSet.has(surface));
-  const violating = uniqueSorted([
-    ...(allowed.length ? touched.filter((surface) => !allowed.includes(surface)) : []),
-    ...touched.filter((surface) => forbidden.includes(surface)),
-  ]);
+  const violating = uniqueSorted([...(allowed.length ? touched.filter((surface) => !allowed.includes(surface)) : []), ...touched.filter((surface) => forbidden.includes(surface))]);
   const newFiles = checkProfileNewFiles(files, policy.new_file_classes, profile.new_files, changeType, derived.newFileClasses);
-  const budgets = profile.budgets || {};
-  const docsBudget = checkCanonicalDocsBudget(files, policy.paths.canonical_docs, budgets.max_new_docs);
-  const newFilesBudget = checkNewFilesBudget(files, budgets.max_new_files);
-  const netLinesBudget = checkNetAddedLinesBudget(files, budgets.max_net_added_lines);
+  const budgets = profileBudgets(files, policy.paths.canonical_docs, profile.budgets);
   const details = [
     ...missing.map((surface) => `required surface ${surface} was not touched by change_profiles["${changeType}"].require_surfaces`),
     ...violating.map((surface) => `surface ${surface} violated change_profiles["${changeType}"] surface constraints; files: ${detected.files_by_surface[surface].join(", ")}`),
   ];
   if (hasUnclassified) details.push(`changed files matched no declared surface: ${detected.unclassified_files.join(", ")}`);
-  if (!docsBudget.ok) details.push(`new docs ${docsBudget.actual} exceeds change_profiles["${changeType}"].budgets.max_new_docs ${docsBudget.limit}; files: ${docsBudget.files.join(", ")}`);
-  if (!newFilesBudget.ok) details.push(`new files ${newFilesBudget.actual} exceeds change_profiles["${changeType}"].budgets.max_new_files ${newFilesBudget.limit}; files: ${newFilesBudget.files.join(", ")}`);
-  if (!netLinesBudget.ok) details.push(`net added lines ${netLinesBudget.actual} exceeds change_profiles["${changeType}"].budgets.max_net_added_lines ${netLinesBudget.limit}`);
+  if (!budgets.docs.ok) details.push(`new docs ${budgets.docs.actual} exceeds change_profiles["${changeType}"].budgets.max_new_docs ${budgets.docs.limit}; files: ${budgets.docs.files.join(", ")}`);
+  if (!budgets.files.ok) details.push(`new files ${budgets.files.actual} exceeds change_profiles["${changeType}"].budgets.max_new_files ${budgets.files.limit}; files: ${budgets.files.files.join(", ")}`);
+  if (!budgets.lines.ok) details.push(`net added lines ${budgets.lines.actual} exceeds change_profiles["${changeType}"].budgets.max_net_added_lines ${budgets.lines.limit}`);
   if (!newFiles.ok) details.push(...(newFiles.details || [newFiles.message]).filter(Boolean));
-  const ok = missing.length === 0 && violating.length === 0 && !hasUnclassified && docsBudget.ok && newFilesBudget.ok && netLinesBudget.ok && newFiles.ok;
-
+  const ok = !missing.length && !violating.length && !hasUnclassified && budgets.docs.ok && budgets.files.ok && budgets.lines.ok && newFiles.ok;
   return {
     ok, message: ok ? undefined : `change_type "${changeType}" violated change_profiles`, change_type: changeType,
     touched_surfaces: touched, required_surfaces: required, allowed_surfaces: allowed, forbidden_surfaces: forbidden,
-    missing_required_surfaces: missing, violating_surfaces: violating, files_by_surface: detected.files_by_surface,
-    unclassified_files: detected.unclassified_files, docs_budget: docsBudget, new_files_budget: newFilesBudget,
-    net_added_lines_budget: netLinesBudget, new_files: newFiles, details,
+    missing_required_surfaces: missing, violating_surfaces: violating, files_by_surface: detected.files_by_surface, unclassified_files: detected.unclassified_files,
+    docs_budget: budgets.docs, new_files_budget: budgets.files, net_added_lines_budget: budgets.lines, new_files: newFiles, details,
     hint: hasUnclassified ? "Add matching surface globs or set change_profiles[change_type].allow_unclassified_surfaces: true." : undefined,
   };
 }
-
-export const changeProfileRuleFamily = {
-  id: "change-profiles",
-  applies: (facts) => Boolean(facts.policy.change_profiles),
-  evaluate(facts) {
-    return {
-      name: "change-profiles",
-      check: checkChangeProfile(facts.diff.files.checked, facts.policy, facts.contract?.change_type, facts.derived),
-    };
-  },
-};

--- a/src/checks/rules/constraints.mjs
+++ b/src/checks/rules/constraints.mjs
@@ -2,6 +2,10 @@ import { calculateDiffGrowth } from "../../diff/growth.mjs";
 import { selectPaths } from "../../diff/classification.mjs";
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
+import { checkTraceRuleResult } from "../trace-rules.mjs";
+import { checkChangeProfile } from "./change-profiles.mjs";
+import { checkRegistryRules } from "./registry-rules.mjs";
+import { checkSizeRules } from "./size-rules.mjs";
 
 function budget(selected, max) {
   if (max === undefined) return { ok: true };
@@ -42,7 +46,6 @@ export function checkMustNotTouch(files, patterns) {
 }
 export const checkCochangeRules = (files, rules = []) => rules.flatMap((rule) => selectPaths(files, rule.if_changed).length && !selectPaths(files, rule.must_change_any).length ? [{ if_changed: rule.if_changed, must_change_any: rule.must_change_any }] : []);
 
-/** Compatibility name for tests/consumers; the compiler itself is now canonical. */
 export function compileConstraintIR(facts) {
   return { files: facts.diff.files.checked, constraints: runtimeConstraints(compileConstraintProgram(facts.policy, facts.contract)) };
 }
@@ -53,7 +56,7 @@ function evaluateMetric(files, constraint, policy) {
   return checkNetAddedLinesBudget(files, constraint.max);
 }
 
-export function evaluateConstraintIR(facts) {
+export function evaluateConstraintIR(facts, context = {}) {
   const { files, constraints } = compileConstraintIR(facts), results = [], cochange = [];
   for (const constraint of constraints) {
     let check;
@@ -67,11 +70,31 @@ export function evaluateConstraintIR(facts) {
     } else if (constraint.kind === "implies_nonempty") {
       if (selectPaths(files, constraint.if_changed).length && !selectPaths(files, constraint.must_change_any).length) cochange.push(constraint);
       continue;
-    }
+    } else if (constraint.kind === "size_rules") {
+      const result = checkSizeRules(files, constraint.rules, {
+        repoRoot: facts.repositoryRoot, trackedFiles: facts.trackedFiles, readFile: facts.readFile,
+        ignorePatterns: facts.policy.paths.operational_paths, changeType: facts.contract?.change_type,
+      });
+      results.push({ name: constraint.name, check: result });
+      if (result.advisory_violations.length) results.push({
+        name: "size-rules-advisory",
+        check: { ok: false, advisory: true, size_violations: result.advisory_violations, details: result.advisory_details, growth: result.growth },
+      });
+      continue;
+    } else if (constraint.kind === "registry_rules") {
+      check = checkRegistryRules(constraint.rules, { repoRoot: facts.repositoryRoot, readFile: facts.readFile, documents: facts.documents });
+    } else if (constraint.kind === "change_profile") {
+      check = checkChangeProfile(files, facts.policy, facts.contract?.change_type, facts.derived);
+    } else if (constraint.kind === "trace_rules") {
+      for (const trace of context.anchorDiagnostics?.traceRuleResults || []) {
+        results.push({ name: `trace-rule: ${trace.id}`, check: checkTraceRuleResult(trace) });
+      }
+      continue;
+    } else continue;
     results.push({ name: constraint.name, check });
   }
   results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed.join(",")} -> ${item.must_change_any.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));
   return results;
 }
 
-export const constraintRuleFamily = { id: "constraints", evaluate: evaluateConstraintIR };
+export const constraintRuleFamily = { id: "constraints", evaluate: (facts, context) => evaluateConstraintIR(facts, context) };

--- a/src/checks/rules/registry-rules.mjs
+++ b/src/checks/rules/registry-rules.mjs
@@ -1,32 +1,26 @@
 import { createDocumentReader, markdownSection } from "../../document-facts.mjs";
+import { compareSets } from "../relation-kernel.mjs";
 import { formatList, uniqueSorted } from "../../utils/collections.mjs";
 import { normalizePathEntry } from "../../utils/path-patterns.mjs";
 
 const normalizeAll = (values) => uniqueSorted(values.map(normalizePathEntry).filter(Boolean));
-
 function resolveJsonPointer(data, pointer) {
   if (pointer === "") return data;
   if (!pointer?.startsWith("/")) throw new Error(`invalid json_pointer "${pointer}"`);
   let current = data;
   for (const raw of pointer.slice(1).split("/")) {
     const part = raw.replace(/~1/g, "/").replace(/~0/g, "~");
-    if (current == null || !Object.prototype.hasOwnProperty.call(current, part)) throw new Error(`json_pointer "${pointer}" does not exist`);
+    if (current == null || !Object.hasOwn(current, part)) throw new Error(`json_pointer "${pointer}" does not exist`);
     current = current[part];
   }
   return current;
 }
-
 function normalizeMarkdownLinkTarget(target, source) {
   const clean = normalizePathEntry(target.split("#")[0].split("?")[0]);
   if (!clean || /^[a-z][a-z0-9+.-]*:/i.test(clean) || clean.startsWith("#")) return "";
   const sourceDir = source.file.includes("/") ? source.file.split("/").slice(0, -1).join("/") : "";
-  const candidate = clean.startsWith("/") ? clean.slice(1) : normalizePathEntry(`${sourceDir}/${clean}`);
-  const parts = [];
-  for (const part of candidate.split("/")) {
-    if (!part || part === ".") continue;
-    if (part === "..") parts.pop();
-    else parts.push(part);
-  }
+  const candidate = clean.startsWith("/") ? clean.slice(1) : normalizePathEntry(`${sourceDir}/${clean}`), parts = [];
+  for (const part of candidate.split("/")) { if (!part || part === ".") continue; if (part === "..") parts.pop(); else parts.push(part); }
   let result = parts.join("/");
   if (source.prefix) {
     const prefix = normalizePathEntry(source.prefix);
@@ -34,18 +28,13 @@ function normalizeMarkdownLinkTarget(target, source) {
   }
   return result;
 }
-
 function readRegistrySource(source, documents) {
   if (source.type === "json_array") {
     const value = resolveJsonPointer(documents.json(source.file), source.json_pointer);
-    if (!Array.isArray(value)) throw new Error(`${source.file}${source.json_pointer} is not a JSON array`);
-    if (value.some((entry) => typeof entry !== "string")) throw new Error(`${source.file}${source.json_pointer} must contain only strings`);
+    if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) throw new Error(`${source.file}${source.json_pointer} must be an array of strings`);
     return normalizeAll(value);
   }
-  if (source.type === "markdown_section_links") {
-    const section = markdownSection(documents.markdown(source.file), source.section);
-    return normalizeAll(section.links.map((link) => normalizeMarkdownLinkTarget(link.target, source)).filter(Boolean));
-  }
+  if (source.type === "markdown_section_links") return normalizeAll(markdownSection(documents.markdown(source.file), source.section).links.map((link) => normalizeMarkdownLinkTarget(link.target, source)).filter(Boolean));
   throw new Error(`unsupported registry source type "${source.type}"`);
 }
 
@@ -54,50 +43,18 @@ export function checkRegistryRules(rules = [], options = {}) {
   const documents = options.documents || createDocumentReader(options);
   const results = rules.map((rule) => {
     try {
-      const leftEntries = readRegistrySource(rule.left, documents);
-      const rightEntries = readRegistrySource(rule.right, documents);
-      const left = new Set(leftEntries);
-      const right = new Set(rightEntries);
-      const missing = leftEntries.filter((entry) => !right.has(entry));
-      const extra = rightEntries.filter((entry) => !left.has(entry));
-      const ok = rule.kind === "set_equality" ? !missing.length && !extra.length
-        : rule.kind === "left_subset_of_right" ? !missing.length
-          : rule.kind === "right_subset_of_left" ? !extra.length
-            : (() => { throw new Error(`unsupported registry rule kind "${rule.kind}"`); })();
-      return {
-        ok, rule_id: rule.id, kind: rule.kind, left_entries: leftEntries, right_entries: rightEntries,
-        missing_from_right: missing, extra_in_right: extra,
-        message: ok ? undefined : `registry rule "${rule.id}" failed ${rule.kind}`,
-      };
+      const leftEntries = readRegistrySource(rule.left, documents), rightEntries = readRegistrySource(rule.right, documents);
+      const relation = rule.kind === "left_subset_of_right" ? "left_subset" : rule.kind === "right_subset_of_left" ? "right_subset" : "equal";
+      const compared = compareSets(leftEntries, rightEntries, relation);
+      return { ok: compared.ok, rule_id: rule.id, kind: rule.kind, left_entries: leftEntries, right_entries: rightEntries,
+        missing_from_right: compared.missing, extra_in_right: compared.extra, message: compared.ok ? undefined : `registry rule "${rule.id}" failed ${rule.kind}` };
     } catch (error) {
-      return {
-        ok: false, rule_id: rule.id, kind: rule.kind, left_entries: [], right_entries: [],
-        missing_from_right: [], extra_in_right: [], message: `registry rule "${rule.id}" could not be evaluated`, details: [error.message],
-      };
+      return { ok: false, rule_id: rule.id, kind: rule.kind, left_entries: [], right_entries: [], missing_from_right: [], extra_in_right: [], message: `registry rule "${rule.id}" could not be evaluated`, details: [error.message] };
     }
   });
   const failed = results.filter((result) => !result.ok);
-  return {
-    ok: failed.length === 0, results, failed_rules: failed.map((result) => result.rule_id),
-    details: failed.flatMap((result) => [
-      `[${result.rule_id}] ${result.message}`,
-      `left entries: ${formatList(result.left_entries)}`,
-      `right entries: ${formatList(result.right_entries)}`,
-      `missing from right: ${formatList(result.missing_from_right)}`,
-      `extra in right: ${formatList(result.extra_in_right)}`,
-      ...(result.details || []),
-    ]),
-  };
+  return { ok: !failed.length, results, failed_rules: failed.map((result) => result.rule_id), details: failed.flatMap((result) => [
+    `[${result.rule_id}] ${result.message}`, `left entries: ${formatList(result.left_entries)}`, `right entries: ${formatList(result.right_entries)}`,
+    `missing from right: ${formatList(result.missing_from_right)}`, `extra in right: ${formatList(result.extra_in_right)}`, ...(result.details || []),
+  ]) };
 }
-
-export const registryRuleFamily = {
-  id: "registry-rules",
-  evaluate(facts) {
-    return {
-      name: "registry-rules",
-      check: checkRegistryRules(facts.policy.registry_rules, {
-        repoRoot: facts.repositoryRoot, readFile: facts.readFile, documents: facts.documents,
-      }),
-    };
-  },
-};

--- a/src/checks/rules/size-rules.mjs
+++ b/src/checks/rules/size-rules.mjs
@@ -1,271 +1,82 @@
 import { uniqueSorted } from "../../utils/collections.mjs";
-import {
-  matchesAny,
-  normalizePathEntry,
-  normalizePathList,
-} from "../../utils/path-patterns.mjs";
+import { matchesAny, normalizePathEntry, normalizePathList } from "../../utils/path-patterns.mjs";
 import { readRepositoryBufferFile } from "../../utils/repository-files.mjs";
+import { maxBound } from "../relation-kernel.mjs";
 
-function changedPaths(files, options = {}) {
-  const includeDeleted = Boolean(options.includeDeleted);
-  return normalizePathList(
-    (files || [])
-      .filter((file) => includeDeleted || file.status !== "deleted")
-      .map((file) => file.path)
-  );
+const changedPaths = (files, { includeDeleted = false } = {}) => normalizePathList((files || []).filter((file) => includeDeleted || file.status !== "deleted").map((file) => file.path));
+const allKnownPaths = (files, options = {}) => normalizePathList([...(options.trackedFiles || options.allFiles || []), ...changedPaths(files)]);
+function matchesRule(path, rule, options = {}) {
+  const ignored = [...(options.ignorePatterns || []), ...(rule.ignore || [])];
+  return matchesAny(path, [rule.glob || "**"]) && !(ignored.length && matchesAny(path, ignored));
 }
-
-function allKnownPaths(files, options = {}) {
-  return normalizePathList([
-    ...(options.trackedFiles || options.allFiles || []),
-    ...changedPaths(files),
-  ]);
-}
-
-function ignoredBySizeRule(path, rule, options = {}) {
-  const ignored = [
-    ...(options.ignorePatterns || []),
-    ...(rule.ignore || []),
-  ];
-  return ignored.length > 0 && matchesAny(path, ignored);
-}
-
-function matchesSizeRule(path, rule, options = {}) {
-  const glob = rule.glob || "**";
-  return matchesAny(path, [glob]) && !ignoredBySizeRule(path, rule, options);
-}
-
-function matchingSizeRulePaths(paths, rule, options = {}) {
-  return normalizePathList(paths).filter((path) => matchesSizeRule(path, rule, options));
-}
-
-function sizeRuleApplies(rule, options = {}) {
-  const changeType = options.changeType || null;
-  if (
-    rule.applies_to_change_types &&
-    !rule.applies_to_change_types.includes(changeType)
-  ) {
-    return false;
-  }
-  return true;
-}
+const matchingPaths = (paths, rule, options) => normalizePathList(paths).filter((path) => matchesRule(path, rule, options));
+const applies = (rule, options) => !rule.applies_to_change_types || rule.applies_to_change_types.includes(options.changeType || null);
 
 export function countTextLines(content) {
-  if (content.length === 0) return 0;
+  if (!content.length) return 0;
   const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-  let lines = 1;
-  for (const char of normalized) {
-    if (char === "\n") lines++;
-  }
+  const lines = (normalized.match(/\n/g) || []).length + 1;
   return normalized.endsWith("\n") ? lines - 1 : lines;
 }
-
-function measureSizeRuleFile(path, metric, options = {}) {
+function measureFile(path, metric, options) {
   if (metric === "files") return { skipped: false, actual: 1 };
   const content = readRepositoryBufferFile(path, options);
   if (content === null) return { skipped: true, actual: 0 };
-  if (metric === "bytes") return { skipped: false, actual: content.length };
-  return { skipped: false, actual: countTextLines(content.toString("utf-8")) };
+  return { skipped: false, actual: metric === "bytes" ? content.length : countTextLines(content.toString("utf-8")) };
 }
-
-function measureDirectory(paths, rule, options = {}) {
+function measureDirectory(paths, rule, options) {
   if (rule.metric === "files") return paths.length;
-  let actual = 0;
-  for (const path of paths) {
-    const measured = measureSizeRuleFile(path, rule.metric, options);
-    if (!measured.skipped) actual += measured.actual;
-  }
-  return actual;
+  return paths.reduce((sum, path) => { const measured = measureFile(path, rule.metric, options); return sum + (measured.skipped ? 0 : measured.actual); }, 0);
 }
-
-function directoryPathFromGlob(glob) {
-  const normalized = normalizePathEntry(glob).replace(/\\/g, "/");
-  const parts = normalized.split("/").filter(Boolean);
-  const stableParts = [];
-  for (const part of parts) {
-    if (/[*?[\]{}()]/.test(part)) break;
-    stableParts.push(part);
-  }
-  return stableParts.length > 0 ? stableParts.join("/") : (normalized || ".");
+function directoryPath(glob) {
+  const normalized = normalizePathEntry(glob).replace(/\\/g, "/"), stable = [];
+  for (const part of normalized.split("/").filter(Boolean)) { if (/[*?[\]{}()]/.test(part)) break; stable.push(part); }
+  return stable.length ? stable.join("/") : (normalized || ".");
 }
-
-function calculateGrowth(files, rule, options = {}) {
+function growth(files, rule, options) {
   if (rule.max_growth === undefined) return null;
-  if (rule.scope !== "directory") {
-    throw new Error("max_growth is supported only for directory size rules");
-  }
-  if (rule.metric === "bytes") {
-    throw new Error("max_growth for bytes is not supported; use an absolute byte max together with line/file growth");
-  }
-
-  let delta = 0;
-  for (const file of files || []) {
-    if (!matchesSizeRule(file.path, rule, options)) continue;
-    if (rule.metric === "files") {
-      if (file.status === "added") delta += 1;
-      else if (file.status === "deleted") delta -= 1;
-      continue;
-    }
-    delta += (file.addedLines?.length || 0) - (file.deletedLines?.length || 0);
-  }
-  return delta;
+  if (rule.scope !== "directory") throw new Error("max_growth is supported only for directory size rules");
+  if (rule.metric === "bytes") throw new Error("max_growth for bytes is not supported; use an absolute byte max together with line/file growth");
+  return (files || []).reduce((delta, file) => {
+    if (!matchesRule(file.path, rule, options)) return delta;
+    if (rule.metric === "files") return delta + (file.status === "added" ? 1 : file.status === "deleted" ? -1 : 0);
+    return delta + (file.addedLines?.length || 0) - (file.deletedLines?.length || 0);
+  }, 0);
 }
-
-function formatSizeViolation(violation) {
-  if (violation.kind === "growth") {
-    return `[${violation.ruleId}] ${violation.path} changed ${violation.metric}: ${violation.before} -> ${violation.after} (delta ${violation.delta}, max growth ${violation.maxGrowth})`;
-  }
-  return `[${violation.ruleId}] ${violation.path} has ${violation.actual} ${violation.metric} (max ${violation.max})`;
+function formatViolation(v) {
+  return v.kind === "growth"
+    ? `[${v.ruleId}] ${v.path} changed ${v.metric}: ${v.before} -> ${v.after} (delta ${v.delta}, max growth ${v.maxGrowth})`
+    : `[${v.ruleId}] ${v.path} has ${v.actual} ${v.metric} (max ${v.max})`;
 }
 
 export function checkSizeRules(files, rules = [], options = {}) {
-  if (!rules || rules.length === 0) {
-    return {
-      ok: true,
-      size_violations: [],
-      advisory_violations: [],
-      failed_rules: [],
-      details: [],
-      growth: [],
-    };
-  }
-
-  const blockingViolations = [];
-  const advisoryViolations = [];
-  const errors = [];
-  const growthReports = [];
-  const allPaths = allKnownPaths(files, options);
-  const changedNonDeletedPaths = changedPaths(files);
-  const changedIncludingDeletedPaths = changedPaths(files, { includeDeleted: true });
-
-  for (const rule of rules) {
-    if (!sizeRuleApplies(rule, options)) continue;
-
-    const count = rule.count || "all_tracked";
-    const level = rule.level || "blocking";
-    const addViolation = (violation) => {
-      if (level === "advisory") advisoryViolations.push(violation);
-      else blockingViolations.push(violation);
-    };
-
+  const blocking = [], advisory = [], errors = [], growthReports = [];
+  const allPaths = allKnownPaths(files, options), changed = changedPaths(files), changedAll = changedPaths(files, { includeDeleted: true });
+  for (const rule of rules || []) {
+    if (!applies(rule, options)) continue;
+    const count = rule.count || "all_tracked", level = rule.level || "blocking";
+    const fail = (violation) => (level === "advisory" ? advisory : blocking).push(violation);
     try {
       if (rule.scope === "file") {
-        if (rule.metric === "files") {
-          throw new Error("metric=files is supported only for directory size rules");
-        }
-        const sourcePaths = count === "changed_only" ? changedNonDeletedPaths : allPaths;
-        const paths = matchingSizeRulePaths(sourcePaths, rule, options);
-        for (const path of paths) {
-          const measured = measureSizeRuleFile(path, rule.metric, options);
-          if (measured.skipped || measured.actual <= rule.max) continue;
-          addViolation({
-            ruleId: rule.id,
-            rule_id: rule.id,
-            kind: "absolute",
-            scope: "file",
-            path,
-            metric: rule.metric,
-            actual: measured.actual,
-            max: rule.max,
-            count,
-            level,
-          });
+        if (rule.metric === "files") throw new Error("metric=files is supported only for directory size rules");
+        for (const path of matchingPaths(count === "changed_only" ? changed : allPaths, rule, options)) {
+          const measured = measureFile(path, rule.metric, options);
+          if (!measured.skipped && !maxBound(measured.actual, rule.max)) fail({ ruleId: rule.id, rule_id: rule.id, kind: "absolute", scope: "file", path, metric: rule.metric, actual: measured.actual, max: rule.max, count, level });
         }
       } else if (rule.scope === "directory") {
-        const changedMatches = matchingSizeRulePaths(changedIncludingDeletedPaths, rule, options);
-        if (count === "changed_only" && changedMatches.length === 0) continue;
-
-        const paths = matchingSizeRulePaths(allPaths, rule, options);
-        const actual = measureDirectory(paths, rule, options);
-        if (actual > rule.max) {
-          addViolation({
-            ruleId: rule.id,
-            rule_id: rule.id,
-            kind: "absolute",
-            scope: "directory",
-            path: directoryPathFromGlob(rule.glob),
-            metric: rule.metric,
-            actual,
-            max: rule.max,
-            count,
-            level,
-            files: paths,
-          });
-        }
-
-        const delta = calculateGrowth(files, rule, options);
+        if (count === "changed_only" && !matchingPaths(changedAll, rule, options).length) continue;
+        const paths = matchingPaths(allPaths, rule, options), actual = measureDirectory(paths, rule, options), path = directoryPath(rule.glob);
+        if (!maxBound(actual, rule.max)) fail({ ruleId: rule.id, rule_id: rule.id, kind: "absolute", scope: "directory", path, metric: rule.metric, actual, max: rule.max, count, level, files: paths });
+        const delta = growth(files, rule, options);
         if (delta !== null) {
-          const report = {
-            ruleId: rule.id,
-            rule_id: rule.id,
-            scope: "directory",
-            path: directoryPathFromGlob(rule.glob),
-            metric: rule.metric,
-            before: actual - delta,
-            after: actual,
-            delta,
-            maxGrowth: rule.max_growth,
-            max_growth: rule.max_growth,
-            level,
-          };
+          const report = { ruleId: rule.id, rule_id: rule.id, scope: "directory", path, metric: rule.metric, before: actual - delta, after: actual, delta, maxGrowth: rule.max_growth, max_growth: rule.max_growth, level };
           growthReports.push(report);
-          if (delta > rule.max_growth) {
-            addViolation({ ...report, kind: "growth" });
-          }
+          if (!maxBound(delta, rule.max_growth)) fail({ ...report, kind: "growth" });
         }
       }
-    } catch (error) {
-      errors.push(`[${rule.id}] ${error.message}`);
-    }
+    } catch (error) { errors.push(`[${rule.id}] ${error.message}`); }
   }
-
-  const failedRules = uniqueSorted([
-    ...blockingViolations.map((violation) => violation.ruleId),
-    ...(errors.length > 0 ? ["read-errors"] : []),
-  ]);
-
-  return {
-    ok: blockingViolations.length === 0 && errors.length === 0,
-    size_violations: blockingViolations,
-    advisory_violations: advisoryViolations,
-    failed_rules: failedRules,
-    details: blockingViolations.map(formatSizeViolation),
-    advisory_details: advisoryViolations.map(formatSizeViolation),
-    errors,
-    growth: growthReports,
-  };
+  const failedRules = uniqueSorted([...blocking.map((v) => v.ruleId), ...(errors.length ? ["read-errors"] : [])]);
+  return { ok: !blocking.length && !errors.length, size_violations: blocking, advisory_violations: advisory, failed_rules: failedRules,
+    details: blocking.map(formatViolation), advisory_details: advisory.map(formatViolation), errors, growth: growthReports };
 }
-
-export const sizeRuleFamily = {
-  id: "size-rules",
-  evaluate(facts) {
-    const result = checkSizeRules(facts.diff.files.checked, facts.policy.size_rules, {
-      repoRoot: facts.repositoryRoot,
-      trackedFiles: facts.trackedFiles,
-      readFile: facts.readFile,
-      ignorePatterns: facts.policy.paths.operational_paths,
-      changeType: facts.contract?.change_type,
-    });
-    const entries = [
-      {
-        name: "size-rules",
-        check: result,
-      },
-    ];
-
-    if (result.advisory_violations.length > 0) {
-      entries.push({
-        name: "size-rules-advisory",
-        check: {
-          ok: false,
-          advisory: true,
-          size_violations: result.advisory_violations,
-          details: result.advisory_details,
-          growth: result.growth,
-        },
-      });
-    }
-
-    return entries;
-  },
-};

--- a/src/checks/trace-rules.mjs
+++ b/src/checks/trace-rules.mjs
@@ -1,227 +1,77 @@
 import { uniqueSorted } from "../utils/collections.mjs";
 import { matchesAny } from "../utils/path-patterns.mjs";
+import { compareSets, implies } from "./relation-kernel.mjs";
 
 const CONTRACT_ANCHOR_FIELDS = new Map([
-  ["anchors.affects", ["anchors", "affects"]],
-  ["anchors.implements", ["anchors", "implements"]],
-  ["anchors.verifies", ["anchors", "verifies"]],
+  ["anchors.affects", ["anchors", "affects"]], ["anchors.implements", ["anchors", "implements"]], ["anchors.verifies", ["anchors", "verifies"]],
 ]);
-
-function formatAnchorLocation(instance) {
-  const line = instance.line ? `:${instance.line}` : "";
-  const column = instance.column ? `:${instance.column}` : "";
-  return `${instance.file}${line}${column}`;
-}
-
-function cloneAnchorInstance(instance) {
-  return { ...instance };
-}
-
-function groupByValue(instances) {
+const location = (instance) => `${instance.file}${instance.line ? `:${instance.line}` : ""}${instance.column ? `:${instance.column}` : ""}`;
+function group(instances = []) {
   const grouped = new Map();
-  for (const instance of instances || []) {
-    if (!grouped.has(instance.value)) grouped.set(instance.value, []);
-    grouped.get(instance.value).push(cloneAnchorInstance(instance));
-  }
+  for (const instance of instances) (grouped.get(instance.value) || grouped.set(instance.value, []).get(instance.value)).push({ ...instance });
   return grouped;
 }
-
-function changedPaths(facts) {
-  return (facts.diff?.files?.checked || []).map((file) => file.path);
-}
-
-function matchingPaths(paths, patterns) {
-  return uniqueSorted(paths.filter((path) => matchesAny(path, patterns || [])));
-}
-
-function contractFieldValues(contract, field) {
+const changedPaths = (facts) => (facts.diff?.files?.checked || []).map((file) => file.path);
+const matchingPaths = (paths, patterns) => uniqueSorted(paths.filter((path) => matchesAny(path, patterns || [])));
+function contractValues(contract, field) {
   const path = CONTRACT_ANCHOR_FIELDS.get(field);
   if (!path) return [];
-
-  let current = contract || {};
-  for (const segment of path) {
-    current = current?.[segment];
-  }
-  if (!Array.isArray(current)) return [];
-  return uniqueSorted(current.map((value) => String(value)));
+  let value = contract || {};
+  for (const segment of path) value = value?.[segment];
+  return Array.isArray(value) ? uniqueSorted(value.map(String)) : [];
 }
 
-function buildMustResolveDiagnostics(rule, anchorExtraction) {
-  const fromInstances = anchorExtraction.byType?.[rule.from_anchor_type] || [];
-  const toInstances = anchorExtraction.byType?.[rule.to_anchor_type] || [];
-  const fromByValue = groupByValue(fromInstances);
-  const toByValue = groupByValue(toInstances);
-  const resolved = [];
-  const unresolved = [];
-
-  for (const value of [...fromByValue.keys()].sort()) {
-    const from = fromByValue.get(value);
-    const to = toByValue.get(value) || [];
-    if (to.length > 0) {
-      resolved.push({ value, from, to });
-    } else {
-      unresolved.push({ value, instances: from });
-    }
-  }
-
-  return {
-    id: rule.id,
-    kind: rule.kind,
-    fromAnchorType: rule.from_anchor_type,
-    toAnchorType: rule.to_anchor_type,
-    ok: unresolved.length === 0,
-    resolved,
-    unresolved,
-    stats: {
-      fromInstances: fromInstances.length,
-      fromValues: fromByValue.size,
-      toInstances: toInstances.length,
-      toValues: toByValue.size,
-      resolved: resolved.length,
-      unresolved: unresolved.length,
-    },
-  };
+function mustResolve(rule, anchors) {
+  const fromInstances = anchors.byType?.[rule.from_anchor_type] || [], toInstances = anchors.byType?.[rule.to_anchor_type] || [];
+  const from = group(fromInstances), to = group(toInstances), values = [...from.keys()].sort();
+  const relation = compareSets(values, [...to.keys()], "left_subset");
+  const unresolved = relation.missing.map((value) => ({ value, instances: from.get(value) }));
+  const resolved = values.filter((value) => !relation.missing.includes(value)).map((value) => ({ value, from: from.get(value), to: to.get(value) || [] }));
+  return { id: rule.id, kind: rule.kind, fromAnchorType: rule.from_anchor_type, toAnchorType: rule.to_anchor_type, ok: relation.ok, resolved, unresolved,
+    stats: { fromInstances: fromInstances.length, fromValues: from.size, toInstances: toInstances.length, toValues: to.size, resolved: resolved.length, unresolved: unresolved.length } };
 }
-
-function buildChangedFilesRequireEvidenceDiagnostics(rule, facts) {
-  const paths = changedPaths(facts);
-  const changedFiles = matchingPaths(paths, rule.if_changed);
-  const evidenceFiles = matchingPaths(paths, rule.must_touch_any);
-
-  return {
-    id: rule.id,
-    kind: rule.kind,
-    ok: changedFiles.length === 0 || evidenceFiles.length > 0,
-    ifChanged: [...(rule.if_changed || [])],
-    mustTouchAny: [...(rule.must_touch_any || [])],
-    changedFiles,
-    evidenceFiles,
-    stats: {
-      changedFiles: changedFiles.length,
-      evidenceFiles: evidenceFiles.length,
-    },
-  };
-}
-
-function buildDeclaredAnchorsRequireEvidenceDiagnostics(rule, facts) {
-  const paths = changedPaths(facts);
-  const declaredAnchors = contractFieldValues(facts.contract, rule.contract_field);
-  const evidenceFiles = matchingPaths(paths, rule.must_touch_any);
-
-  return {
-    id: rule.id,
-    kind: rule.kind,
-    ok: declaredAnchors.length === 0 || evidenceFiles.length > 0,
-    contractField: rule.contract_field,
-    mustTouchAny: [...(rule.must_touch_any || [])],
-    declaredAnchors,
-    evidenceFiles,
-    stats: {
-      declaredAnchors: declaredAnchors.length,
-      evidenceFiles: evidenceFiles.length,
-    },
-  };
+function evidence(rule, facts, declared = null) {
+  const paths = changedPaths(facts), evidenceFiles = matchingPaths(paths, rule.must_touch_any);
+  const trigger = declared ?? matchingPaths(paths, rule.if_changed);
+  const common = { id: rule.id, kind: rule.kind, ok: implies(trigger.length, evidenceFiles.length), mustTouchAny: [...(rule.must_touch_any || [])], evidenceFiles };
+  return declared === null
+    ? { ...common, ifChanged: [...(rule.if_changed || [])], changedFiles: trigger, stats: { changedFiles: trigger.length, evidenceFiles: evidenceFiles.length } }
+    : { ...common, contractField: rule.contract_field, declaredAnchors: trigger, stats: { declaredAnchors: trigger.length, evidenceFiles: evidenceFiles.length } };
 }
 
 export function buildTraceRuleDiagnostics(facts) {
   return (facts.policy.trace_rules || []).map((rule) => {
-    if (rule.kind === "must_resolve") {
-      return buildMustResolveDiagnostics(rule, facts.anchors || {});
-    }
-    if (rule.kind === "changed_files_require_evidence") {
-      return buildChangedFilesRequireEvidenceDiagnostics(rule, facts);
-    }
-    if (rule.kind === "declared_anchors_require_evidence") {
-      return buildDeclaredAnchorsRequireEvidenceDiagnostics(rule, facts);
-    }
-
-    return {
-      id: rule.id,
-      kind: rule.kind,
-      ok: true,
-      stats: {},
-    };
+    if (rule.kind === "must_resolve") return mustResolve(rule, facts.anchors || {});
+    if (rule.kind === "changed_files_require_evidence") return evidence(rule, facts);
+    if (rule.kind === "declared_anchors_require_evidence") return evidence(rule, facts, contractValues(facts.contract, rule.contract_field));
+    return { id: rule.id, kind: rule.kind, ok: true, stats: {} };
   });
 }
 
-function checkMustResolveTraceRuleResult(result) {
-  const unresolvedAnchors = (result.unresolved || []).map((item) => {
-    const instances = item.instances || [];
-    return {
-      value: item.value,
-      fromAnchorType: result.fromAnchorType,
-      toAnchorType: result.toAnchorType,
-      locations: instances.map(formatAnchorLocation),
-      instances,
-    };
-  });
-
-  const details = [];
-  for (const anchor of unresolvedAnchors) {
-    for (const location of anchor.locations) {
-      details.push(`${anchor.value} (${anchor.fromAnchorType} -> ${anchor.toAnchorType}) at ${location}`);
-    }
-  }
-
+function checkMustResolve(result) {
+  const unresolved = (result.unresolved || []).map((item) => ({
+    value: item.value, fromAnchorType: result.fromAnchorType, toAnchorType: result.toAnchorType,
+    locations: (item.instances || []).map(location), instances: item.instances || [],
+  }));
   return {
-    ok: unresolvedAnchors.length === 0,
-    message: unresolvedAnchors.length > 0
-      ? `unresolved anchor reference(s) for trace rule "${result.id}"`
-      : undefined,
-    trace_rule: result.id,
-    trace_kind: result.kind,
-    from_anchor_type: result.fromAnchorType,
-    to_anchor_type: result.toAnchorType,
-    unresolved_anchors: unresolvedAnchors,
-    files: uniqueSorted(unresolvedAnchors.flatMap((anchor) =>
-      anchor.instances.map((instance) => instance.file)
-    )),
-    details,
+    ok: !unresolved.length, message: unresolved.length ? `unresolved anchor reference(s) for trace rule "${result.id}"` : undefined,
+    trace_rule: result.id, trace_kind: result.kind, from_anchor_type: result.fromAnchorType, to_anchor_type: result.toAnchorType,
+    unresolved_anchors: unresolved, files: uniqueSorted(unresolved.flatMap((anchor) => anchor.instances.map((instance) => instance.file))),
+    details: unresolved.flatMap((anchor) => anchor.locations.map((where) => `${anchor.value} (${anchor.fromAnchorType} -> ${anchor.toAnchorType}) at ${where}`)),
   };
 }
-
-function evidenceDetails(result) {
+function checkEvidence(result) {
   const details = [];
   if (result.changedFiles) details.push(`changed_files: ${result.changedFiles.join(", ")}`);
   if (result.contractField) details.push(`contract_field: ${result.contractField}`);
   if (result.declaredAnchors) details.push(`declared_anchors: ${result.declaredAnchors.join(", ")}`);
-  details.push(`must_touch_any: ${result.mustTouchAny.join(", ")}`);
-  details.push(`evidence_files: ${result.evidenceFiles.length > 0 ? result.evidenceFiles.join(", ") : "(none)"}`);
-  return details;
+  details.push(`must_touch_any: ${result.mustTouchAny.join(", ")}`, `evidence_files: ${result.evidenceFiles.length ? result.evidenceFiles.join(", ") : "(none)"}`);
+  return { ok: result.ok, message: result.ok ? undefined : `missing evidence for trace rule "${result.id}"`, trace_rule: result.id, trace_kind: result.kind,
+    if_changed: result.ifChanged, must_touch_any: result.mustTouchAny, changed_files: result.changedFiles, contract_field: result.contractField,
+    declared_anchors: result.declaredAnchors, evidence_files: result.evidenceFiles, files: uniqueSorted([...(result.changedFiles || []), ...(result.evidenceFiles || [])]), details };
 }
-
-function checkEvidenceTraceRuleResult(result) {
-  return {
-    ok: result.ok,
-    message: result.ok ? undefined : `missing evidence for trace rule "${result.id}"`,
-    trace_rule: result.id,
-    trace_kind: result.kind,
-    if_changed: result.ifChanged,
-    must_touch_any: result.mustTouchAny,
-    changed_files: result.changedFiles,
-    contract_field: result.contractField,
-    declared_anchors: result.declaredAnchors,
-    evidence_files: result.evidenceFiles,
-    files: uniqueSorted([...(result.changedFiles || []), ...(result.evidenceFiles || [])]),
-    details: evidenceDetails(result),
-  };
-}
-
 export function checkTraceRuleResult(result) {
-  if (result.kind === "must_resolve") {
-    return checkMustResolveTraceRuleResult(result);
-  }
-  if (
-    result.kind === "changed_files_require_evidence" ||
-    result.kind === "declared_anchors_require_evidence"
-  ) {
-    return checkEvidenceTraceRuleResult(result);
-  }
-
-  return {
-    ok: true,
-    trace_rule: result.id,
-    trace_kind: result.kind,
-    details: [],
-  };
+  if (result.kind === "must_resolve") return checkMustResolve(result);
+  if (["changed_files_require_evidence", "declared_anchors_require_evidence"].includes(result.kind)) return checkEvidence(result);
+  return { ok: true, trace_rule: result.id, trace_kind: result.kind, details: [] };
 }

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -1,3 +1,4 @@
+import { defaultRuleFamilies } from "../src/checks/default-rule-families.mjs";
 import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
 import { compileConstraintIR, evaluateConstraintIR } from "../src/checks/rules/constraints.mjs";
 import { comparePolicyStrictness } from "../src/checks/rules/policy-delta-rules.mjs";
@@ -14,6 +15,7 @@ function expect(label, actual, expected) {
     console.error(`  expected: ${expected}, got: ${actual}`);
   }
 }
+expect("relation-like runtime rules collapse into six default families", defaultRuleFamilies.length, 6);
 
 const markdown = parseMarkdown("# Заголовок\nТекст [ссылка](docs/a.md)\n```js\ncode()\n```\nПосле\n");
 expect("document facts parse headings once", markdown.headings[0].text, "Заголовок");
@@ -33,7 +35,7 @@ expect("selector status view isolates additions", selectPaths(selectorFiles, ["*
 const constraintFacts = {
   diff: { files: { checked: selectorFiles } },
   policy: {
-    paths: { forbidden: ["*.bak"], canonical_docs: [] },
+    paths: { forbidden: ["*.bak"], canonical_docs: [], operational_paths: [] },
     diff_rules: { max_new_docs: 0, max_new_files: 2, max_net_added_lines: 5 },
     cochange_rules: [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }],
   },


### PR DESCRIPTION
Fixes #133

Сводит повторяющуюся set/metric/implication семантику к компактному relation kernel и маршрутизирует `size_rules`, `registry_rules`, `change_profiles` и `trace_rules` через canonical Constraint Program. Отдельные runtime-family wrappers для этих четырёх механизмов удалены: default families **10 → 6**.

Structural diff остаётся сильно отрицательным. Новый `relation-kernel.mjs` содержит только три primitives (`compareSets`, `implies`, `maxBound`) и сразу окупается удалением специализированного boilerplate. После family collapse удаляются и ставшие stale self-hosting exceptions.

```repo-guard-yaml
change_type: refactor
scope:
  - src/checks/**
  - tests/**
  - docs/self-hosting-coverage.json
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 0
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/checks/**
must_not_touch:
  - schemas/**
expected_effects:
  - set metric implication semantics используют общий relation kernel
  - size registry profiles trace исполняются через Constraint Program
  - default runtime families сокращаются с 10 до 6
  - self-hosting exceptions не содержат удалённых family identifiers
```