### PR TITLE
Исправить отсутствующий импорт node:test в markdown-contract тестах

### DIFF
--- a/tests/test-markdown-contract.mjs
+++ b/tests/test-markdown-contract.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { describe, it } from "node:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { extractContract, extractGovernanceGrant, extractLinkedIssueNumbers, resolveContract } from "../src/markdown-contract.mjs";


### PR DESCRIPTION
Исправляет падение `CI / validate (push)` после Compression 2.0: `tests/test-markdown-contract.mjs` использует `describe`/`it`, но не импортирует их из `node:test`.

Изменение минимальное: добавлен только явный импорт `{ describe, it }`.

```repo-guard-yaml
change_type: bugfix
scope:
  - tests/test-markdown-contract.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 1
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - tests/test-markdown-contract.mjs
must_not_touch:
  - src/**
  - schemas/**
  - repo-policy.json
expected_effects:
  - discovered test suite больше не падает с ReferenceError describe is not defined в test-markdown-contract.mjs
```