### PR TITLE
Governance: reserve governance ChangeIntent type

### DIFF
--- a/src/checks/rules/change-profiles.mjs
+++ b/src/checks/rules/change-profiles.mjs
@@ -44,6 +44,7 @@ function checkProfileNewFiles(files, classes, rule, changeType, detected = null)
 
 export function checkChangeProfile(files, policy, changeType, derived = {}) {
   const profiles = policy.change_profiles || {};
+  if (changeType === "governance") return { ok: true, change_type: changeType, delegated_to: "governance-change-authorization" };
   if (!Object.keys(profiles).length) return { ok: true };
   if (!changeType) return { ok: false, message: "change_profiles requires a declared change_type", change_type: null, hint: "Set change_type in the ChangeIntent." };
   const profile = profiles[changeType];

--- a/src/checks/rules/governance-paths.mjs
+++ b/src/checks/rules/governance-paths.mjs
@@ -10,11 +10,13 @@ const trusted = (authorizer) => Boolean(authorizer && (
 
 export function checkGovernanceChangeAuthorization({ files, governancePaths, governanceGrant, trustedAuthorizer, changeIntentType = null }) {
   const patterns = expandGovernancePatterns(governancePaths || []), governanceChange = changeIntentType === "governance";
-  const matchesBoundary = (path) => patterns.some((pattern) => matchesAny(path, pattern));
+  const matchesBoundary = (path) => matchesAny(path, patterns);
   if (!patterns.length && !governanceChange) return { ok: true };
 
   const touched = files.filter((file) => matchesBoundary(file.path)).map((file) => file.path);
   const nonGovernance = governanceChange ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path) : [];
+  if (!governanceChange && !touched.length) return { ok: true, touched_governance_paths: [] };
+
   const declared = Array.isArray(governanceGrant?.authorized_governance_paths) ? governanceGrant.authorized_governance_paths : [];
   const sourceTrusted = trusted(trustedAuthorizer), authorized = sourceTrusted ? declared : [];
   const unauthorized = touched.filter((path) => !matchesAny(path, expandGovernancePatterns(authorized)));

--- a/src/checks/rules/governance-paths.mjs
+++ b/src/checks/rules/governance-paths.mjs
@@ -8,27 +8,34 @@ const trusted = (authorizer) => Boolean(authorizer && (
   authorizer.issue_author_permission_trusted || authorizer.governance_approved_label || authorizer.codeowner_approved || authorizer.trusted_team_approval
 ));
 
-export function checkGovernanceChangeAuthorization({ files, governancePaths, governanceGrant, trustedAuthorizer }) {
-  if (!governancePaths?.length) return { ok: true };
-  const touched = files.filter((file) => governancePaths.some((pattern) => matchesAny(file.path, expand(pattern)))).map((file) => file.path);
-  if (!touched.length) return { ok: true, touched_governance_paths: [] };
+export function checkGovernanceChangeAuthorization({ files, governancePaths, governanceGrant, trustedAuthorizer, changeIntentType = null }) {
+  const patterns = expandGovernancePatterns(governancePaths || []), governanceChange = changeIntentType === "governance";
+  const matchesBoundary = (path) => patterns.some((pattern) => matchesAny(path, pattern));
+  if (!patterns.length && !governanceChange) return { ok: true };
 
+  const touched = files.filter((file) => matchesBoundary(file.path)).map((file) => file.path);
+  const nonGovernance = governanceChange ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path) : [];
   const declared = Array.isArray(governanceGrant?.authorized_governance_paths) ? governanceGrant.authorized_governance_paths : [];
-  const sourceTrusted = trusted(trustedAuthorizer);
-  const authorized = sourceTrusted ? declared : [];
+  const sourceTrusted = trusted(trustedAuthorizer), authorized = sourceTrusted ? declared : [];
   const unauthorized = touched.filter((path) => !matchesAny(path, expandGovernancePatterns(authorized)));
-  const details = unauthorized.map((path) => `governance path ${path} changed without matching GovernanceGrant authorization`);
+  const details = [
+    ...nonGovernance.map((path) => `governance ChangeIntent cannot change non-governance path ${path}`),
+    ...unauthorized.map((path) => `governance path ${path} changed without matching GovernanceGrant authorization`),
+  ];
   if (declared.length && !sourceTrusted) details.push("GovernanceGrant is ignored because no trusted authorizer was detected");
-  const ok = !unauthorized.length;
+  const ok = !nonGovernance.length && !unauthorized.length;
   return {
     ok,
-    message: ok ? undefined : "governance paths changed without trusted GovernanceGrant",
+    message: ok ? undefined : governanceChange && nonGovernance.length
+      ? "governance ChangeIntent includes files outside trusted governance paths"
+      : "governance paths changed without trusted GovernanceGrant",
     touched_governance_paths: touched,
+    non_governance_paths: nonGovernance,
     trusted_authorized_governance_paths: authorized,
     unauthorized_paths: unauthorized,
     untrusted_governance_grant_ignored: declared.length > 0 && !sourceTrusted,
     details,
-    hint: ok ? undefined : "Add a repo-guard-grant block to the linked issue and have that issue sanctioned by a trusted maintainer or governance approval source.",
+    hint: ok ? undefined : "Use a dedicated governance-only diff and authorize every touched governance path from a trusted linked-issue GovernanceGrant.",
   };
 }
 
@@ -36,12 +43,13 @@ export const governancePathsRuleFamily = {
   id: "governance-paths",
   applies(facts) {
     const paths = Array.isArray(facts.trustedGovernancePaths) ? facts.trustedGovernancePaths : facts.policy.paths?.governance_paths;
-    return Boolean(paths?.length);
+    return Boolean(paths?.length) || facts.changeIntent?.change_type === "governance";
   },
   evaluate(facts) {
     const governancePaths = Array.isArray(facts.trustedGovernancePaths) ? facts.trustedGovernancePaths : facts.policy.paths?.governance_paths;
     return { name: "governance-change-authorization", check: checkGovernanceChangeAuthorization({
       files: facts.diff.files.checked, governancePaths, governanceGrant: facts.governanceGrant, trustedAuthorizer: facts.trustedAuthorizer,
+      changeIntentType: facts.changeIntent?.change_type,
     }) };
   },
 };

--- a/tests/test-governance-paths.mjs
+++ b/tests/test-governance-paths.mjs
@@ -1,7 +1,6 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { checkGovernanceChangeAuthorization } from "../src/checks/rules/governance-paths.mjs";
-import { checkChangeProfile } from "../src/checks/rules/change-profiles.mjs";
 import { createDefaultRuleRegistry } from "../src/checks/default-rule-families.mjs";
 import { buildPolicyFacts } from "../src/facts/input.mjs";
 import { runPolicyChecks } from "../src/checks/orchestrator.mjs";
@@ -13,7 +12,7 @@ const TRUSTED = { issue_author_permission_trusted: true, governance_approved_lab
 const UNTRUSTED = { issue_author_permission_trusted: false, governance_approved_label: false, codeowner_approved: false, trusted_team_approval: false };
 const file = (path) => ({ path, status: "modified", addedLines: ["+"], deletedLines: [] });
 const grant = (...paths) => ({ authorized_governance_paths: paths });
-const governanceIntent = { change_type: "governance", scope: ["**"], budgets: {}, must_touch: [], must_not_touch: [], expected_effects: ["governance"] };
+const intent = (changeType) => ({ change_type: changeType, scope: ["**"], budgets: {}, must_touch: [], must_not_touch: [], expected_effects: [changeType] });
 
 describe("GovernanceGrant authorization", () => {
   it("passes when governance is untouched for ordinary changes", () => assert.equal(checkGovernanceChangeAuthorization({ files: [file("src/a.mjs")], governancePaths: PATHS }).ok, true));
@@ -62,13 +61,6 @@ describe("reserved governance ChangeIntent", () => {
     const result = checkGovernanceChangeAuthorization({ files: [file("repo-policy.json")], governancePaths: [], changeIntentType: "governance" });
     assert.equal(result.ok, false); assert.deepEqual(result.non_governance_paths, ["repo-policy.json"]);
   });
-  it("delegates governance out of repository-specific change_profiles", () => {
-    const result = checkChangeProfile([file("repo-policy.json")], { change_profiles: { feature: {} }, paths: { canonical_docs: [] } }, "governance");
-    assert.equal(result.ok, true); assert.equal(result.delegated_to, "governance-change-authorization");
-  });
-  it("keeps ordinary unknown change types rejected", () => {
-    assert.equal(checkChangeProfile([], { change_profiles: { feature: {} }, paths: { canonical_docs: [] } }, "unknown").ok, false);
-  });
 });
 
 describe("GovernanceGrant markdown", () => {
@@ -83,7 +75,8 @@ describe("governance authorization through pipeline", () => {
   const policy = {
     policy_format_version: "0.3.0", repository_kind: "tooling",
     paths: { forbidden: [], canonical_docs: ["README.md"], operational_paths: [], governance_paths: ["repo-policy.json", "schemas/"] },
-    diff_rules: { max_new_docs: 5, max_new_files: 5, max_net_added_lines: 2000 }, content_rules: [], cochange_rules: [],
+    diff_rules: { max_new_docs: 5, max_new_files: 5, max_net_added_lines: 2000 },
+    change_profiles: { feature: {} }, content_rules: [], cochange_rules: [],
   };
   const diff = (path) => ["diff --git a/" + path + " b/" + path, "--- a/" + path, "+++ b/" + path, "+x"].join("\n");
   function run({ path = "repo-policy.json", governanceGrant = null, trustedAuthorizer = null, trustedGovernancePaths = policy.paths.governance_paths, runtimePolicy = policy, changeIntent = null }) {
@@ -97,10 +90,19 @@ describe("governance authorization through pipeline", () => {
   it("blocks without grant", () => assert.ok(run({}).violations.some((item) => item.rule === "governance-change-authorization")));
   it("allows trusted grant", () => assert.equal(run({ governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED }).ruleResults.find((item) => item.rule === "governance-change-authorization").ok, true));
   it("blocks untrusted grant", () => assert.equal(run({ governanceGrant: grant("repo-policy.json"), trustedAuthorizer: UNTRUSTED }).violations.find((item) => item.rule === "governance-change-authorization").data.untrusted_governance_grant_ignored, true));
+  it("delegates governance away from repository-specific change_profiles", () => {
+    const result = run({ path: "repo-policy.json", governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED, changeIntent: intent("governance") });
+    assert.equal(result.violations.some((item) => item.rule === "change-profiles"), false);
+    assert.equal(result.ruleResults.find((item) => item.rule === "governance-change-authorization").ok, true);
+  });
   it("blocks governance ChangeIntent outside trusted governance paths", () => {
-    const result = run({ path: "src/a.mjs", governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED, changeIntent: governanceIntent });
+    const result = run({ path: "src/a.mjs", governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED, changeIntent: intent("governance") });
     const violation = result.violations.find((item) => item.rule === "governance-change-authorization");
     assert.deepEqual(violation.data.non_governance_paths, ["src/a.mjs"]);
+  });
+  it("keeps ordinary unknown change types rejected by change_profiles", () => {
+    const result = run({ path: "src/a.mjs", changeIntent: intent("unknown") });
+    assert.equal(result.violations.some((item) => item.rule === "change-profiles"), true);
   });
   it("base governance boundary cannot be narrowed by head policy", () => {
     const narrowed = { ...policy, paths: { ...policy.paths, governance_paths: ["nonexistent.json"] } };

--- a/tests/test-governance-paths.mjs
+++ b/tests/test-governance-paths.mjs
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { checkGovernanceChangeAuthorization } from "../src/checks/rules/governance-paths.mjs";
+import { checkChangeProfile } from "../src/checks/rules/change-profiles.mjs";
 import { createDefaultRuleRegistry } from "../src/checks/default-rule-families.mjs";
 import { buildPolicyFacts } from "../src/facts/input.mjs";
 import { runPolicyChecks } from "../src/checks/orchestrator.mjs";
@@ -12,9 +13,10 @@ const TRUSTED = { issue_author_permission_trusted: true, governance_approved_lab
 const UNTRUSTED = { issue_author_permission_trusted: false, governance_approved_label: false, codeowner_approved: false, trusted_team_approval: false };
 const file = (path) => ({ path, status: "modified", addedLines: ["+"], deletedLines: [] });
 const grant = (...paths) => ({ authorized_governance_paths: paths });
+const governanceIntent = { change_type: "governance", scope: ["**"], budgets: {}, must_touch: [], must_not_touch: [], expected_effects: ["governance"] };
 
 describe("GovernanceGrant authorization", () => {
-  it("passes when governance is untouched", () => assert.equal(checkGovernanceChangeAuthorization({ files: [file("src/a.mjs")], governancePaths: PATHS }).ok, true));
+  it("passes when governance is untouched for ordinary changes", () => assert.equal(checkGovernanceChangeAuthorization({ files: [file("src/a.mjs")], governancePaths: PATHS }).ok, true));
   it("blocks governance without grant", () => {
     const result = checkGovernanceChangeAuthorization({ files: [file("repo-policy.json")], governancePaths: PATHS });
     assert.equal(result.ok, false); assert.deepEqual(result.unauthorized_paths, ["repo-policy.json"]);
@@ -38,7 +40,35 @@ describe("GovernanceGrant authorization", () => {
     const result = checkGovernanceChangeAuthorization({ files: [file("repo-policy.json"), file("schemas/a.json")], governancePaths: PATHS, governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED });
     assert.deepEqual(result.unauthorized_paths, ["schemas/a.json"]);
   });
-  it("is a no-op for empty trusted boundary", () => assert.equal(checkGovernanceChangeAuthorization({ files: [file("repo-policy.json")], governancePaths: [] }).ok, true));
+  it("is a no-op for empty trusted boundary on ordinary changes", () => assert.equal(checkGovernanceChangeAuthorization({ files: [file("repo-policy.json")], governancePaths: [] }).ok, true));
+});
+
+describe("reserved governance ChangeIntent", () => {
+  it("allows only trusted and granted governance files", () => {
+    const result = checkGovernanceChangeAuthorization({
+      files: [file("repo-policy.json"), file("schemas/a.json")], governancePaths: PATHS,
+      governanceGrant: grant("repo-policy.json", "schemas/**"), trustedAuthorizer: TRUSTED, changeIntentType: "governance",
+    });
+    assert.equal(result.ok, true); assert.deepEqual(result.non_governance_paths, []);
+  });
+  it("blocks any ordinary file mixed into a governance change", () => {
+    const result = checkGovernanceChangeAuthorization({
+      files: [file("repo-policy.json"), file("src/a.mjs")], governancePaths: PATHS,
+      governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED, changeIntentType: "governance",
+    });
+    assert.equal(result.ok, false); assert.deepEqual(result.non_governance_paths, ["src/a.mjs"]);
+  });
+  it("fails closed when governance type has no trusted governance boundary", () => {
+    const result = checkGovernanceChangeAuthorization({ files: [file("repo-policy.json")], governancePaths: [], changeIntentType: "governance" });
+    assert.equal(result.ok, false); assert.deepEqual(result.non_governance_paths, ["repo-policy.json"]);
+  });
+  it("delegates governance out of repository-specific change_profiles", () => {
+    const result = checkChangeProfile([file("repo-policy.json")], { change_profiles: { feature: {} }, paths: { canonical_docs: [] } }, "governance");
+    assert.equal(result.ok, true); assert.equal(result.delegated_to, "governance-change-authorization");
+  });
+  it("keeps ordinary unknown change types rejected", () => {
+    assert.equal(checkChangeProfile([], { change_profiles: { feature: {} }, paths: { canonical_docs: [] } }, "unknown").ok, false);
+  });
 });
 
 describe("GovernanceGrant markdown", () => {
@@ -56,9 +86,9 @@ describe("governance authorization through pipeline", () => {
     diff_rules: { max_new_docs: 5, max_new_files: 5, max_net_added_lines: 2000 }, content_rules: [], cochange_rules: [],
   };
   const diff = (path) => ["diff --git a/" + path + " b/" + path, "--- a/" + path, "+++ b/" + path, "+x"].join("\n");
-  function run({ path = "repo-policy.json", governanceGrant = null, trustedAuthorizer = null, trustedGovernancePaths = policy.paths.governance_paths, runtimePolicy = policy }) {
+  function run({ path = "repo-policy.json", governanceGrant = null, trustedAuthorizer = null, trustedGovernancePaths = policy.paths.governance_paths, runtimePolicy = policy, changeIntent = null }) {
     const facts = buildPolicyFacts({ mode: "check-pr", repositoryRoot: "/tmp/repo-guard-governance-test", policy: runtimePolicy,
-      changeIntent: null, changeIntentSource: "none", governanceGrant, trustedGovernancePaths, trustedAuthorizer,
+      changeIntent, changeIntentSource: changeIntent ? "test" : "none", governanceGrant, trustedGovernancePaths, trustedAuthorizer,
       enforcement: { mode: "blocking" }, diffText: diff(path), trackedFiles: [path, "README.md"] });
     const reporter = createAnalysisCollector({ mode: "blocking" });
     runPolicyChecks(facts, reporter, { registry: createDefaultRuleRegistry() });
@@ -67,9 +97,14 @@ describe("governance authorization through pipeline", () => {
   it("blocks without grant", () => assert.ok(run({}).violations.some((item) => item.rule === "governance-change-authorization")));
   it("allows trusted grant", () => assert.equal(run({ governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED }).ruleResults.find((item) => item.rule === "governance-change-authorization").ok, true));
   it("blocks untrusted grant", () => assert.equal(run({ governanceGrant: grant("repo-policy.json"), trustedAuthorizer: UNTRUSTED }).violations.find((item) => item.rule === "governance-change-authorization").data.untrusted_governance_grant_ignored, true));
+  it("blocks governance ChangeIntent outside trusted governance paths", () => {
+    const result = run({ path: "src/a.mjs", governanceGrant: grant("repo-policy.json"), trustedAuthorizer: TRUSTED, changeIntent: governanceIntent });
+    const violation = result.violations.find((item) => item.rule === "governance-change-authorization");
+    assert.deepEqual(violation.data.non_governance_paths, ["src/a.mjs"]);
+  });
   it("base governance boundary cannot be narrowed by head policy", () => {
     const narrowed = { ...policy, paths: { ...policy.paths, governance_paths: ["nonexistent.json"] } };
     assert.ok(run({ path: "schemas/repo-policy.schema.json", runtimePolicy: narrowed, trustedGovernancePaths: policy.paths.governance_paths }).violations.some((item) => item.rule === "governance-change-authorization"));
   });
-  it("empty trusted boundary disables this check", () => assert.equal(run({ trustedGovernancePaths: [] }).ruleResults.some((item) => item.rule === "governance-change-authorization"), false));
+  it("empty trusted boundary disables this check for ordinary changes", () => assert.equal(run({ trustedGovernancePaths: [] }).ruleResults.some((item) => item.rule === "governance-change-authorization"), false));
 });


### PR DESCRIPTION
Fixes #172.
Refs #173, #163.

```repo-guard-yaml
change_type: feature
scope:
  - src/checks/rules/**
  - tests/test-governance-paths.mjs
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 500
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/checks/rules/governance-paths.mjs
  - tests/test-governance-paths.mjs
must_not_touch:
  - repo-policy.json
  - schemas/**
  - action.yml
  - .github/**
expected_effects:
  - governance changes are constrained to trusted governance paths
  - ordinary change profiles remain unchanged
```