### PR TITLE
Release correctness: make init Action refs explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ node src/repo-guard.mjs
 ## Быстрый старт
 
 ```bash
-repo-guard init --preset application --mode advisory
+repo-guard init --action-ref "$REPO_GUARD_SHA" --preset application --mode advisory
 repo-guard doctor
 ```
+
+`REPO_GUARD_SHA` должен быть полным 40-символьным commit SHA. Вместо SHA можно явно указать строгий version tag `vX.Y.Z`, но он обязан совпадать с текущей `package.json.version`. `init` не использует `main`, `latest` и не выводит ref из версии автоматически: без `--action-ref` команда завершается ошибкой **до записи любых файлов**.
 
 `init` создаёт, не перезаписывая существующие файлы:
 
@@ -66,7 +68,7 @@ repo-guard doctor
 - `.github/PULL_REQUEST_TEMPLATE.md`;
 - `.github/ISSUE_TEMPLATE/change-contract.yml`.
 
-Сгенерированный рабочий процесс закрепляет действие за версией выпуска, а не за изменяемой веткой.
+Сгенерированный рабочий процесс закрепляет действие ровно за переданным immutable SHA или явным version tag. Существование официального release tag проверяется отдельно через `npm run verify:release-ref`.
 
 ## Команды
 
@@ -77,7 +79,7 @@ repo-guard doctor
 | `repo-guard check-diff` | проверить локальное изменение |
 | `repo-guard check-diff --base main --head feature` | проверить диапазон ссылок Git |
 | `repo-guard check-pr` | проверить PR в CI |
-| `repo-guard init` | создать начальную конфигурацию |
+| `repo-guard init --action-ref <ref>` | создать начальную конфигурацию с явным Action ref |
 | `repo-guard doctor` | проверить окружение и подключение |
 | `repo-guard validate-integration` | проверить декларативный слой `integration` |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,17 +12,16 @@
 
 ## Инвариант выпуска
 
-`package.json.version` определяет ссылку на `Action`, которую создаёт `repo-guard init`: `netkeep80/repo-guard@v<version>`.
-
-Для каждой публикуемой версии пакета заранее должны существовать соответствующие тег и выпуск на `GitHub`:
+`package.json.version` определяет официальный тег выпуска `v<version>`. Публикуемый пакет считается согласованным только если соответствующие Git tag и GitHub release уже существуют:
 
 ```text
 package.json.version = X.Y.Z
-Git tag/release       = vX.Y.Z
-Generated Action ref  = netkeep80/repo-guard@vX.Y.Z
+Expected tag/release  = vX.Y.Z
 ```
 
-До публикации проверьте инвариант:
+`repo-guard init` **не выводит Action ref из версии автоматически**. Пользователь обязан явно передать `--action-ref`: полный 40-символьный commit SHA либо строгий `vX.Y.Z`, совпадающий с текущей `package.json.version`. Поэтому отсутствие опубликованного релиза не превращается в фиктивный workflow ref.
+
+Для официального version tag перед публикацией проверьте инвариант:
 
 ```bash
 npm run verify:release-ref -- --tag vX.Y.Z
@@ -58,6 +57,8 @@ npm run verify:release-ref -- --tag vX.Y.Z
    ```bash
    npm publish
    ```
+
+После этого `repo-guard init --action-ref vX.Y.Z ...` может использовать официальный version tag. Для pre-release/candidate интеграции перед публикацией используйте полный 40-символьный commit SHA.
 
 Поле `files` в `package.json` определяет содержимое публикуемого пакета.
 

--- a/scripts/verify-release-ref.mjs
+++ b/scripts/verify-release-ref.mjs
@@ -3,6 +3,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { expectedTagForVersion } from "../src/init.mjs";
 
 const DEFAULT_REPO = "netkeep80/repo-guard";
 const GITHUB_API = "https://api.github.com";
@@ -58,10 +59,6 @@ function pass(name, message) {
 
 function fail(name, message, hint = null) {
   return { name, status: FAIL, message, hint };
-}
-
-export function expectedTagForVersion(version) {
-  return `v${version}`;
 }
 
 export async function verifyReleaseRef({
@@ -143,7 +140,7 @@ export async function verifyReleaseRef({
 function usage() {
   return `Usage: node scripts/verify-release-ref.mjs [--repo <owner/repo>] [--tag <vX.Y.Z>] [--package-root <path>]
 
-Checks the release invariant used by repo-guard init:
+Checks the release invariant shared with repo-guard init:
   package.json.version <-> published Git tag and GitHub release v<version>
 `;
 }
@@ -171,9 +168,7 @@ function printResult(result) {
   console.log("repo-guard release ref verification\n");
   console.log(`Repository: ${result.repo}`);
   if (result.packageVersion) console.log(`package.json version: ${result.packageVersion}`);
-  if (result.expectedTag) {
-    console.log(`Expected Action ref: ${result.repo}@${result.expectedTag}`);
-  }
+  if (result.expectedTag) console.log(`Expected release ref: ${result.repo}@${result.expectedTag}`);
   console.log("");
 
   for (const check of result.checks) {

--- a/src/init.mjs
+++ b/src/init.mjs
@@ -3,6 +3,8 @@ import { resolve, relative, dirname } from "node:path";
 import { normalizeEnforcementMode } from "./enforcement.mjs";
 
 const ACTION = "netkeep80/repo-guard";
+const FULL_SHA = /^[0-9a-f]{40}$/i;
+const VERSION_TAG = /^v\d+\.\d+\.\d+$/;
 const PRESETS = {
   application: ["application", ["*.bak", "*.log"], ["README.md"], { max_new_docs: 3, max_new_files: 20, max_net_added_lines: 1500 }, []],
   library: ["library", ["*.bak"], ["README.md", "CHANGELOG.md"], { max_new_docs: 2, max_new_files: 15, max_net_added_lines: 1000 }, [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }]],
@@ -13,10 +15,23 @@ function buildPolicy(name, mode) {
   const [repository_kind, forbidden, canonical_docs, diff_rules, cochange_rules] = PRESETS[name];
   return { policy_format_version: "0.3.0", repository_kind, enforcement: { mode }, paths: { forbidden, canonical_docs, governance_paths: ["repo-policy.json"] }, diff_rules, content_rules: [], cochange_rules };
 }
-function actionRef(packageRoot) {
+function packageVersion(packageRoot) {
   const version = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf-8")).version;
-  if (!version) throw new Error("Cannot determine repo-guard package version");
+  if (!version || typeof version !== "string") throw new Error("Cannot determine repo-guard package version");
+  return version;
+}
+export function expectedTagForVersion(version) {
+  if (!version || typeof version !== "string") throw new Error("Cannot determine repo-guard package version");
   return `v${version}`;
+}
+export function validateExplicitActionRef(ref, version) {
+  const candidate = typeof ref === "string" ? ref.trim() : "", expectedTag = expectedTagForVersion(version);
+  if (!candidate) return { ok: false, expectedTag, message: `repo-guard init refuses to invent an Action ref; pass --action-ref <40-char-sha|${expectedTag}>` };
+  if (FULL_SHA.test(candidate)) return { ok: true, ref: candidate, kind: "sha", expectedTag };
+  if (VERSION_TAG.test(candidate)) return candidate === expectedTag
+    ? { ok: true, ref: candidate, kind: "release-tag", expectedTag }
+    : { ok: false, expectedTag, message: `Action ref ${candidate} does not match package.json version ${version}; expected ${expectedTag}` };
+  return { ok: false, expectedTag, message: `Action ref ${candidate} is mutable or ambiguous; use a full 40-character commit SHA or ${expectedTag}` };
 }
 const workflow = (mode, ref) => `name: Проверка политики repo-guard
 on:
@@ -95,27 +110,32 @@ function writeIfAbsent(path, content, created, skipped) {
   if (existsSync(path)) return skipped.push(path);
   mkdirSync(dirname(path), { recursive: true }); writeFileSync(path, content, "utf-8"); created.push(path);
 }
-const usage = `Usage: repo-guard init [--preset <preset>] [--mode <mode>]\nPresets: application, library, tooling, documentation`;
+const usage = `Usage: repo-guard init --action-ref <40-char-sha|vX.Y.Z> [--preset <preset>] [--mode <mode>]\nPresets: application, library, tooling, documentation`;
 
 export function runInit(roots, args = []) {
-  let preset = "application", mode = roots.enforcementMode || "enforce";
+  let preset = "application", mode = roots.enforcementMode || "enforce", actionRef = null;
   for (let i = 0; i < args.length; i++) {
-    if (["--preset", "--mode", "--enforcement"].includes(args[i]) && args[i + 1]) {
-      const value = args[++i]; if (args[i - 1] === "--preset") preset = value; else mode = value;
+    if (["--preset", "--mode", "--enforcement", "--action-ref"].includes(args[i]) && args[i + 1]) {
+      const option = args[i], value = args[++i];
+      if (option === "--preset") preset = value; else if (option === "--action-ref") actionRef = value; else mode = value;
     } else if (args[i] === "--help") { console.log(usage); return 0; }
     else { console.error(`Unknown option for init: ${args[i]}\n${usage}`); return 1; }
   }
   if (!PRESETS[preset]) { console.error(`Unknown preset: ${preset}\n${usage}`); return 1; }
   const enforcement = normalizeEnforcementMode(mode, "mode");
   if (!enforcement.ok) { console.error(enforcement.message); return 1; }
+  let refCheck;
+  try { refCheck = validateExplicitActionRef(actionRef, packageVersion(roots.packageRoot)); }
+  catch (error) { console.error(error.message); return 1; }
+  if (!refCheck.ok) { console.error(refCheck.message); return 1; }
 
   const created = [], skipped = [], root = roots.repoRoot;
   writeIfAbsent(resolve(root, "repo-policy.json"), `${JSON.stringify(buildPolicy(preset, enforcement.mode), null, 2)}\n`, created, skipped);
-  writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), workflow(enforcement.mode, actionRef(roots.packageRoot)), created, skipped);
+  writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), workflow(enforcement.mode, refCheck.ref), created, skipped);
   writeIfAbsent(resolve(root, ".github/PULL_REQUEST_TEMPLATE.md"), prTemplate(), created, skipped);
   writeIfAbsent(resolve(root, ".github/ISSUE_TEMPLATE/change-contract.yml"), issueTemplate(), created, skipped);
 
-  console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcement.mode})`);
+  console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcement.mode}, action-ref: ${refCheck.ref})`);
   if (created.length) console.log(`Created:\n${created.map((path) => `  ${relative(root, path)}`).join("\n")}`);
   if (skipped.length) console.log(`Skipped (already exist):\n${skipped.map((path) => `  ${relative(root, path)}`).join("\n")}`);
   return 0;

--- a/tests/test-init.mjs
+++ b/tests/test-init.mjs
@@ -9,13 +9,15 @@ import Ajv from "ajv";
 const root = resolve(new URL("..", import.meta.url).pathname), cli = resolve(root, "src/repo-guard.mjs");
 const schema = JSON.parse(readFileSync(resolve(root, "schemas/repo-policy.schema.json"), "utf-8"));
 const version = JSON.parse(readFileSync(resolve(root, "package.json"), "utf-8")).version;
+const immutableSha = "0123456789abcdef0123456789abcdef01234567";
 const validate = new Ajv({ allErrors: true }).compile(schema);
 const temp = () => mkdtempSync(join(tmpdir(), "repo-guard-init-"));
 const run = (args, cwd = root) => spawnSync(process.execPath, [cli, ...args], { cwd, encoding: "utf-8" });
+const runInit = (dir, args = [], ref = immutableSha) => run(["--repo-root", dir, "init", "--action-ref", ref, ...args]);
 
 describe("repo-guard init", () => {
-  it("creates a valid default scaffold", () => {
-    const dir = temp(), result = run(["--repo-root", dir, "init"]);
+  it("creates a valid default scaffold with an explicit immutable Action ref", () => {
+    const dir = temp(), result = runInit(dir);
     assert.equal(result.status, 0);
     for (const path of ["repo-policy.json", ".github/workflows/repo-guard.yml", ".github/PULL_REQUEST_TEMPLATE.md", ".github/ISSUE_TEMPLATE/change-contract.yml"]) assert.equal(existsSync(join(dir, path)), true, path);
     const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
@@ -23,16 +25,16 @@ describe("repo-guard init", () => {
   });
 
   for (const preset of ["application", "library", "tooling", "documentation"]) it(`generates valid ${preset} preset`, () => {
-    const dir = temp(), result = run(["--repo-root", dir, "init", "--preset", preset, "--mode", "advisory"]);
+    const dir = temp(), result = runInit(dir, ["--preset", preset, "--mode", "advisory"]);
     assert.equal(result.status, 0);
     const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
     assert.equal(policy.repository_kind, preset); assert.equal(policy.enforcement.mode, "advisory"); assert.equal(validate(policy), true);
   });
 
-  it("generates pinned workflow and separate intent/grant templates", () => {
-    const dir = temp(); run(["--repo-root", dir, "init"]);
+  it("pins the generated workflow to the explicit SHA and keeps intent/grant templates separate", () => {
+    const dir = temp(); runInit(dir);
     const workflow = readFileSync(join(dir, ".github/workflows/repo-guard.yml"), "utf-8");
-    assert.match(workflow, new RegExp(`netkeep80/repo-guard@v${version.replaceAll(".", "\\.")}`));
+    assert.match(workflow, new RegExp(`netkeep80/repo-guard@${immutableSha}`));
     assert.match(workflow, /fetch-depth: 0/); assert.match(workflow, /mode: check-pr/); assert.match(workflow, /GH_TOKEN/);
     const pr = readFileSync(join(dir, ".github/PULL_REQUEST_TEMPLATE.md"), "utf-8");
     assert.match(pr, /Намерение изменения/); assert.match(pr, /repo-guard-yaml/); assert.doesNotMatch(pr, /repo-guard-grant/);
@@ -40,20 +42,42 @@ describe("repo-guard init", () => {
     assert.match(issue, /label: ChangeIntent/); assert.match(issue, /repo-guard-grant/); assert.match(issue, /GovernanceGrant/);
   });
 
+  it("accepts only the package-matching version tag as an explicit release ref", () => {
+    const dir = temp(), tag = `v${version}`, result = runInit(dir, [], tag);
+    assert.equal(result.status, 0);
+    assert.match(readFileSync(join(dir, ".github/workflows/repo-guard.yml"), "utf-8"), new RegExp(`repo-guard@${tag.replaceAll(".", "\\.")}`));
+  });
+
+  it("fails closed without an explicit Action ref before writing any scaffold files", () => {
+    const dir = temp(), result = run(["--repo-root", dir, "init"]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /refuses to invent an Action ref/i);
+    assert.equal(existsSync(join(dir, "repo-policy.json")), false);
+    assert.equal(existsSync(join(dir, ".github/workflows/repo-guard.yml")), false);
+  });
+
+  it("rejects mutable or package-mismatched Action refs", () => {
+    for (const ref of ["main", "master", "latest", "v2", "v999.0.0"]) {
+      const dir = temp(), result = runInit(dir, [], ref);
+      assert.equal(result.status, 1, ref);
+      assert.equal(existsSync(join(dir, "repo-policy.json")), false, ref);
+    }
+  });
+
   it("does not overwrite existing files", () => {
     const dir = temp(), path = join(dir, "repo-policy.json"); writeFileSync(path, '{"custom":true}');
-    assert.equal(run(["--repo-root", dir, "init"]).status, 0); assert.match(readFileSync(path, "utf-8"), /custom/);
+    assert.equal(runInit(dir).status, 0); assert.match(readFileSync(path, "utf-8"), /custom/);
   });
   it("is idempotent", () => {
-    const dir = temp(); assert.equal(run(["--repo-root", dir, "init"]).status, 0);
-    const second = run(["--repo-root", dir, "init"]); assert.equal(second.status, 0); assert.match(second.stdout, /Skipped/);
+    const dir = temp(); assert.equal(runInit(dir).status, 0);
+    const second = runInit(dir); assert.equal(second.status, 0); assert.match(second.stdout, /Skipped/);
   });
   it("returns errors instead of terminating imported runtime", () => {
-    for (const args of [["init", "--preset", "unknown"], ["init", "--mode", "wrong"], ["init", "--bad-flag"]]) assert.equal(run(args).status, 1);
+    for (const args of [["--preset", "unknown"], ["--mode", "wrong"], ["--bad-flag"]]) assert.equal(runInit(temp(), args).status, 1);
     const help = run(["init", "--help"]); assert.equal(help.status, 0); assert.match(help.stdout, /Usage: repo-guard init/);
   });
   it("generated policy is immediately validatable", () => {
-    const dir = temp(); run(["--repo-root", dir, "init", "--preset", "tooling"]);
+    const dir = temp(); runInit(dir, ["--preset", "tooling"]);
     const result = run(["--repo-root", dir]); assert.equal(result.status, 0); assert.match(result.stdout, /OK: repo-policy.json/);
   });
 });


### PR DESCRIPTION
Fixes #165.
Refs #166, #164, #158.

`init` must not invent `v<package.version>` when no published release has been established. This PR makes the Action ref explicit and fail-closed; no mutable branch fallback is introduced.

```repo-guard-yaml
change_type: bugfix
scope:
  - src/init.mjs
  - scripts/verify-release-ref.mjs
  - tests/test-init.mjs
  - tests/test-release-ref.mjs
  - README.md
  - RELEASING.md
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 500
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/init.mjs
  - tests/test-init.mjs
must_not_touch:
  - repo-policy.json
  - schemas/**
  - action.yml
  - .github/**
expected_effects:
  - init refuses to invent an Action ref
  - explicit full SHA or package-matching vX.Y.Z is required
  - no scaffold files are written before Action ref validation succeeds
  - verify-release-ref and init share the release tag naming rule
```