### PR TITLE
Governance: finish neutral ChangeIntent bridge

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "repo-guard"
-description: "Enforce repository policy and change contracts on pull requests"
+description: "Enforce repository policy and ChangeIntent on pull requests"
 author: "netkeep80"
 
 branding:
@@ -10,7 +10,7 @@ inputs:
   mode:
     description: >
       Command mode. Use `check-pr` to validate a pull request against policy
-      and change contract (requires GitHub Actions PR event context). Use `check-diff`
+      and ChangeIntent (requires GitHub Actions PR event context). Use `check-diff`
       to validate a local diff between two refs.
     required: false
     default: "check-pr"
@@ -44,9 +44,9 @@ inputs:
     required: false
     default: ""
 
-  contract:
+  change-intent:
     description: >
-      Path to a change contract JSON file (used with `mode: check-diff`).
+      Path to a ChangeIntent JSON file (used with `mode: check-diff`).
       Path is relative to `repo-root`.
     required: false
     default: ""
@@ -121,8 +121,8 @@ runs:
           if [ -n "${{ inputs.head }}" ]; then
             CMD="$CMD --head ${{ inputs.head }}"
           fi
-          if [ -n "${{ inputs.contract }}" ]; then
-            CMD="$CMD --contract ${{ inputs.contract }}"
+          if [ -n "${{ inputs.change-intent }}" ]; then
+            CMD="$CMD --change-intent ${{ inputs.change-intent }}"
           fi
         fi
 

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -36,7 +36,6 @@
         "id": "pull-request-template",
         "kind": "markdown",
         "path": ".github/PULL_REQUEST_TEMPLATE.md",
-        "requires_contract_block": false,
         "required_block_kind": "repo-guard-yaml"
       },
       {
@@ -44,7 +43,6 @@
         "kind": "github_issue_form",
         "path": ".github/ISSUE_TEMPLATE/change-contract.yml",
         "optional": true,
-        "requires_contract_block": false,
         "required_block_kind": "repo-guard-yaml"
       }
     ],

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -516,7 +516,7 @@
     },
     "integration_template": {
       "type": "object",
-      "required": ["id", "kind", "path", "requires_contract_block"],
+      "required": ["id", "kind", "path"],
       "additionalProperties": false,
       "properties": {
         "id": { "$ref": "#/definitions/non_empty_string" },


### PR DESCRIPTION
Fixes #177.
Refs #163, #160.

Governance-only bridge with exactly three files:

- removes the inert legacy `requires_contract_block: false` values from trusted self-policy;
- makes that legacy field optional in the current schema so BASE remains valid during the subsequent new-only cutover;
- renames the broken Action input to `change-intent` and invokes only `--change-intent`.

No future DSL aliases are added. Source, tests, docs, examples, templates, and GitHub configuration are untouched.

Local verification: all 26 discovered test files, policy/schema validation, self integration, and doctor passed. Draft CI must still prove the packaged smoke path.