### PR TITLE
Governance: classify generated TypeScript artifacts

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -97,6 +97,7 @@
   },
   "surfaces": {
     "source": ["src/**"],
+    "generated": ["dist/**"],
     "tests": ["tests/**"],
     "schemas": ["schemas/**"],
     "docs": ["docs/**", "README.md", "RELEASING.md", "PORTFOLIO.md"],
@@ -108,6 +109,7 @@
       "action.yml",
       "package.json",
       "package-lock.json",
+      "tsconfig.json",
       ".github/PULL_REQUEST_TEMPLATE.md",
       ".github/ISSUE_TEMPLATE/**"
     ],
@@ -115,6 +117,7 @@
   },
   "new_file_classes": {
     "source": ["src/**"],
+    "generated": ["dist/**"],
     "test": ["tests/**"],
     "doc": ["docs/**", "README.md", "RELEASING.md", "PORTFOLIO.md"],
     "example": ["examples/**"],
@@ -126,6 +129,7 @@
       "action.yml",
       "package.json",
       "package-lock.json",
+      "tsconfig.json",
       ".github/PULL_REQUEST_TEMPLATE.md",
       ".github/ISSUE_TEMPLATE/**"
     ],
@@ -137,6 +141,7 @@
       "new_files": {
         "allow_classes": [
           "source",
+          "generated",
           "test",
           "doc",
           "example",


### PR DESCRIPTION
Fixes #185.
Refs #158, #183.

Classifies the first checked TypeScript build artifacts without mixing policy authority into the feature PR:

- `dist/**` becomes an explicit generated surface and new-file class;
- root `tsconfig.json` joins existing build-governance configuration;
- only the feature profile gains the generated class;
- generated files remain fully visible to diff, scope, governance and freshness checks.

Exact scope: one governance file, five added JSON lines, no runtime/schema/source changes.

Validation: JSON/schema load, all 26 discovered tests, and strictness comparison; the single expected incomparable policy delta is `/`, covered by the linked trusted GovernanceGrant.