### PR TITLE
TypeScript: establish deterministic dist runtime boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
 
       - run: npm ci
 
+      - name: Verify generated dist freshness
+        run: npm run check:dist
+
       - name: Report architecture compression metrics
         run: npm run compression:metrics -- --compare 94f702271f6fe27672102f5271046151b023f94c
 
@@ -67,7 +70,7 @@ jobs:
 
           printf '\n%s: advisory fixture\n' "TO""DO" >> README.md
           git add README.md
-          OUTPUT="$(node src/repo-guard.mjs --enforcement advisory check-diff 2>&1)"
+          OUTPUT="$(node dist/repo-guard.mjs --enforcement advisory check-diff 2>&1)"
           STATUS=$?
           printf '%s\n' "$OUTPUT"
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ npx repo-guard
 
 ```bash
 npm ci
+npm run check:dist
 npm test
-node src/repo-guard.mjs
+node dist/repo-guard.mjs
 ```
 
 ## Быстрый старт

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       run: |
         # Install runtime dependencies for the checked-out Action source.
         cd "${GITHUB_ACTION_PATH}"
-        npm install --production --silent
+        npm install --omit=dev --silent
 
     - name: Run repo-guard
       id: run-repo-guard
@@ -91,8 +91,8 @@ runs:
       run: |
         set +e
 
-        # Always run the CLI from the checked-out Action source.
-        BIN="node ${GITHUB_ACTION_PATH}/src/repo-guard.mjs"
+        # Always run the checked, generated runtime shipped with the Action.
+        BIN="node ${GITHUB_ACTION_PATH}/dist/repo-guard.mjs"
 
         # Build the command
         CMD="$BIN"

--- a/dist/change-intent.mjs
+++ b/dist/change-intent.mjs
@@ -1,0 +1,51 @@
+import { parseJson, parseMarkdown, parseYaml } from "./document-facts.mjs";
+const CHANGE_INTENT_FORMATS = { "repo-guard-json": "JSON", "repo-guard-yaml": "YAML" };
+function parseBlock(block, formats, field, errorPrefix = field) {
+    try {
+        const value = block.language.endsWith("json") ? parseJson(block.content) : parseYaml(block.content);
+        return { ok: true, [field]: value };
+    }
+    catch (error) {
+        const format = formats[block.language] || "YAML";
+        return { ok: false, error: `${errorPrefix}_malformed_${format.toLowerCase()}`, message: `Invalid ${format} in ${block.language} block: ${error.message}` };
+    }
+}
+export function extractChangeIntent(markdown) {
+    if (!markdown || typeof markdown !== "string")
+        return { ok: false, error: "change_intent_not_found", message: "No markdown text provided" };
+    const blocks = parseMarkdown(markdown).codeBlocks.filter((block) => CHANGE_INTENT_FORMATS[block.language]);
+    if (!blocks.length)
+        return { ok: false, error: "change_intent_not_found", message: "No repo-guard-json or repo-guard-yaml ChangeIntent block found in markdown" };
+    if (blocks.length > 1)
+        return { ok: false, error: "multiple_change_intents", message: `Found ${blocks.length} repo-guard ChangeIntent blocks; expected exactly one` };
+    return parseBlock(blocks[0], CHANGE_INTENT_FORMATS, "changeIntent", "change_intent");
+}
+export function extractGovernanceGrant(markdown) {
+    if (!markdown || typeof markdown !== "string")
+        return { ok: true, grant: null };
+    const blocks = parseMarkdown(markdown).codeBlocks.filter((block) => block.language === "repo-guard-grant");
+    if (!blocks.length)
+        return { ok: true, grant: null };
+    if (blocks.length > 1)
+        return { ok: false, error: "multiple_governance_grants", message: `Found ${blocks.length} repo-guard-grant blocks; expected at most one` };
+    return parseBlock(blocks[0], { "repo-guard-grant": "YAML" }, "grant");
+}
+const ISSUE_LINK_RE = /(?:Fixes|Closes|Resolves)\s+(?:[\w.-]+\/[\w.-]+)?#(\d+)/gi;
+export function extractLinkedIssueNumbers(text) {
+    if (!text || typeof text !== "string")
+        return [];
+    return [...new Set([...text.matchAll(ISSUE_LINK_RE)].map((match) => Number(match[1])))];
+}
+export function resolveChangeIntent(prBody, issueBody) {
+    const direct = extractChangeIntent(prBody);
+    if (direct.ok || direct.error !== "change_intent_not_found")
+        return direct;
+    if (!issueBody)
+        return { ok: false, error: "change_intent_not_found", message: "No ChangeIntent in PR body and no linked issue body available" };
+    const fallback = extractChangeIntent(issueBody);
+    if (fallback.ok)
+        return fallback;
+    return fallback.error === "change_intent_not_found"
+        ? { ok: false, error: "fallback_missing", message: "No ChangeIntent found in PR body or linked issue body" }
+        : fallback;
+}

--- a/dist/check-diff.mjs
+++ b/dist/check-diff.mjs
@@ -1,0 +1,52 @@
+import { resolve } from "node:path";
+import { getDiff } from "./git.mjs";
+import { resolveEnforcementMode } from "./enforcement.mjs";
+import { renderAnalysisReport } from "./reporting/renderers.mjs";
+import { loadJSON, loadPolicyRuntime, validationCheck } from "./runtime/validation.mjs";
+import { runPolicyPipeline } from "./runtime/pipeline.mjs";
+const value = (args, name) => { const i = args.indexOf(name); return i < 0 ? null : args[i + 1]; };
+export function runCheckDiff(roots, args = []) {
+    const base = value(args, "--base"), head = value(args, "--head"), changeIntentArg = value(args, "--change-intent");
+    const changeIntentPath = changeIntentArg ? resolve(roots.repoRoot, changeIntentArg) : null, format = value(args, "--format") || "text";
+    if (!["text", "json", "summary"].includes(format)) {
+        console.error(`Unknown check-diff format: ${format}`);
+        return 1;
+    }
+    const quiet = format !== "text", runtime = loadPolicyRuntime(roots, { quiet });
+    const { ajv, policy, changeIntentSchema } = runtime;
+    if (!runtime.ok) {
+        if (!quiet)
+            console.error("\nPolicy compilation failed; aborting enforcement.");
+        return 1;
+    }
+    const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
+    if (!enforcement.ok) {
+        console.error(`ERROR: ${enforcement.message}`);
+        return 1;
+    }
+    let changeIntent = null;
+    const initialChecks = [];
+    if (changeIntentPath)
+        try {
+            const loaded = loadJSON(changeIntentPath), check = validationCheck(ajv, changeIntentSchema, loaded, changeIntentPath);
+            initialChecks.push({ name: "change-intent", check });
+            if (check.ok)
+                changeIntent = loaded;
+        }
+        catch (error) {
+            initialChecks.push({ name: "change-intent", check: { ok: false, message: `Cannot read ${changeIntentPath}: ${error.message}` } });
+        }
+    let diffText;
+    try {
+        diffText = getDiff(base, head, roots.repoRoot);
+    }
+    catch (error) {
+        console.error(`Error: ${error.message}`);
+        return 1;
+    }
+    const report = runPolicyPipeline({ mode: "check-diff", repositoryRoot: roots.repoRoot, policy, changeIntent, changeIntentSource: changeIntentPath ? "cli file" : "none", enforcement, diffText, initialChecks }, { quiet });
+    const output = renderAnalysisReport(report, { format });
+    if (output)
+        console.log(output);
+    return report.exitCode;
+}

--- a/dist/checks/constraint-program.mjs
+++ b/dist/checks/constraint-program.mjs
@@ -1,0 +1,171 @@
+const RANKS = {
+    enforcement: { advisory: 0, blocking: 1 },
+    count: { changed_only: 0, all_tracked: 1 },
+};
+const array = (value) => Array.isArray(value) ? value : [];
+const compare = (relation, value, metadata = {}) => ({ relation, value, ...metadata });
+const scalar = (relation, value, metadata) => compare(relation, value, metadata);
+const set = (relation, value, metadata) => compare(relation, array(value), metadata);
+const exact = (value, metadata) => compare("equal_or_incomparable", value, metadata);
+const entity = (metadata) => compare("required_entity", true, metadata);
+export function compileConstraintProgram(policy = {}, changeIntent = null) {
+    const program = [], diff = policy.diff_rules || {}, budgets = changeIntent?.budgets || {};
+    const add = (key, runtime = null, strictness = null) => program.push({ key, runtime, strictness });
+    add("paths:forbidden", { kind: "forbid_paths", name: "forbidden-paths", patterns: policy.paths?.forbidden || [] }, set("superset_stricter", policy.paths?.forbidden, { pointer: "/paths/forbidden", weakenKind: "forbidden_path_removed", itemField: "pattern", message: (item) => `paths.forbidden removed: ${item}` }));
+    for (const [field, metric, name] of [
+        ["max_new_docs", "new_docs", "canonical-docs-budget"], ["max_new_files", "new_files", "max-new-files"], ["max_net_added_lines", "net_added_lines", "max-net-added-lines"],
+    ]) {
+        const value = diff[field];
+        add(`diff:${field}`, { kind: "max_metric", name, metric, max: budgets[field] ?? value }, typeof value === "number" ? scalar("lower_stricter", value, {
+            pointer: `/diff_rules/${field}`, weakenKind: "diff_rule_budget_increased", removeKind: "diff_rule_budget_removed", field,
+            message: (before, after) => `diff_rules.${field}: ${before} -> ${after}`, removeMessage: `diff_rules.${field} removed (was ${value})`,
+        }) : null);
+    }
+    for (const [key, field, relation, kind, message] of [
+        ["paths:governance", "governance_paths", "superset_stricter", "governance_path_removed", (item) => `paths.governance_paths removed: ${item}`],
+        ["paths:operational", "operational_paths", "subset_stricter", "operational_path_added", (item) => `paths.operational_paths added exclusion: ${item}`],
+        ["paths:canonical_docs", "canonical_docs", "subset_stricter", "canonical_doc_added", (item) => `paths.canonical_docs added exemption: ${item}`],
+    ])
+        add(key, null, set(relation, policy.paths?.[field], { pointer: `/paths/${field}`, weakenKind: kind, itemField: "pattern", message }));
+    const mode = policy.enforcement?.mode;
+    if (mode)
+        add("enforcement", null, scalar("higher_stricter", RANKS.enforcement[mode], {
+            raw: mode, pointer: "/enforcement/mode", weakenKind: "enforcement_weakened", removeKind: "enforcement_removed",
+            message: (before, after) => `enforcement.mode: ${before} -> ${after}`, removeMessage: `enforcement.mode removed (was ${mode})`,
+        }));
+    for (const rule of array(policy.size_rules)) {
+        const owner = `size:${rule.id}`, pointer = `/size_rules/${rule.id}`;
+        add(owner, null, entity({ owner, pointer, removeKind: "size_rule_removed", rule_id: rule.id,
+            removeBefore: { present: true, glob: rule.glob, max: rule.max }, removeAfter: { present: false }, removeMessage: `size_rules entry "${rule.id}" removed (glob: ${rule.glob ?? "?"}, max: ${rule.max ?? "?"})` }));
+        add(`${owner}:shape`, null, exact({ scope: rule.scope, metric: rule.metric, glob: rule.glob, applies_to_change_types: rule.applies_to_change_types }, { owner, pointer, incomparableMessage: `size_rules[${rule.id}] changed selector/scope semantics` }));
+        add(`${owner}:max`, null, scalar("lower_stricter", rule.max, { owner, pointer: `${pointer}/max`, weakenKind: "size_rule_max_increased", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].max: ${a} -> ${b}` }));
+        add(`${owner}:level`, null, scalar("higher_stricter", RANKS.enforcement[rule.level || "blocking"], { owner, raw: rule.level || "blocking", pointer: `${pointer}/level`, weakenKind: "size_rule_level_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].level: ${a} -> ${b}` }));
+        add(`${owner}:count`, null, scalar("higher_stricter", RANKS.count[rule.count || "all_tracked"], { owner, raw: rule.count || "all_tracked", pointer: `${pointer}/count`, weakenKind: "size_rule_count_weakened", rule_id: rule.id, message: (a, b) => `size_rules[${rule.id}].count: ${a} -> ${b}` }));
+        add(`${owner}:ignore`, null, set("subset_stricter", rule.ignore, { owner, pointer: `${pointer}/ignore`, weakenKind: "size_rule_ignore_added", itemField: "pattern", message: (item) => `size_rules[${rule.id}].ignore added: ${item}` }));
+        if (rule.max_growth !== undefined)
+            add(`${owner}:max_growth`, null, scalar("lower_stricter", rule.max_growth, {
+                owner, pointer: `${pointer}/max_growth`, weakenKind: "size_rule_max_growth_increased", removeKind: "size_rule_max_growth_removed", rule_id: rule.id,
+                message: (a, b) => `size_rules[${rule.id}].max_growth: ${a} -> ${b}`, removeMessage: `size_rules[${rule.id}].max_growth removed (was ${rule.max_growth})`,
+            }));
+    }
+    for (const workflow of array(policy.integration?.workflows)) {
+        const owner = `workflow:${workflow.id}`, pointer = `/integration/workflows/${workflow.id}`;
+        add(owner, null, entity({ owner, pointer, removeKind: "integration_workflow_removed", workflow_id: workflow.id,
+            removeBefore: { present: true, role: workflow.role, path: workflow.path }, removeAfter: { present: false }, removeMessage: `integration.workflows entry "${workflow.id}" removed` }));
+        const { enforcement, ...otherExpect } = workflow.expect || {};
+        add(`${owner}:shape`, null, exact({ kind: workflow.kind, path: workflow.path, role: workflow.role, profiles: workflow.profiles, expect: otherExpect }, { owner, pointer, incomparableMessage: `integration.workflows[${workflow.id}] changed non-monotonic wiring semantics` }));
+        if (enforcement)
+            add(`${owner}:enforcement`, null, scalar("higher_stricter", RANKS.enforcement[enforcement], {
+                owner, raw: enforcement, pointer: `${pointer}/expect/enforcement`, weakenKind: "integration_workflow_expectation_weakened", removeKind: "integration_workflow_expectation_removed", workflow_id: workflow.id,
+                message: (a, b) => `integration.workflows[${workflow.id}].expect.enforcement: ${a} -> ${b}`, removeMessage: `integration.workflows[${workflow.id}].expect.enforcement removed (was ${enforcement})`,
+            }));
+    }
+    if (array(policy.size_rules).length)
+        add("runtime:size-rules", { kind: "size_rules", name: "size-rules", rules: policy.size_rules });
+    if (array(policy.registry_rules).length)
+        add("runtime:registry-rules", { kind: "registry_rules", name: "registry-rules", rules: policy.registry_rules });
+    if (array(policy.trace_rules).length)
+        add("runtime:trace-rules", { kind: "trace_rules", name: "trace-rules" });
+    if (policy.change_profiles)
+        add("runtime:change-profile", { kind: "change_profile", name: "change-profiles" });
+    if (policy.integration)
+        add("runtime:integration", { kind: "integration", name: "integration" });
+    add("surface-debt", { kind: "surface_debt", name: "surface-debt", debt: changeIntent?.surface_debt });
+    array(policy.cochange_rules).forEach((rule, index) => add(`cochange:${index}`, { kind: "implies_nonempty", name: "cochange", ...rule }));
+    if (changeIntent) {
+        add("change-intent:scope", { kind: "scope_paths", name: "change-intent-scope", patterns: changeIntent.scope });
+        add("change-intent:must-touch", { kind: "require_paths", name: "must-touch", patterns: changeIntent.must_touch });
+        add("change-intent:must-not-touch", { kind: "forbid_paths", name: "must-not-touch", patterns: changeIntent.must_not_touch, changeIntent: true });
+    }
+    return program;
+}
+export const runtimeConstraints = (program) => program.flatMap((entry) => entry.runtime ? [{ key: entry.key, ...entry.runtime }] : []);
+const comparisonConstraints = (policy) => compileConstraintProgram(policy).flatMap((entry) => entry.strictness ? [{ key: entry.key, ...entry.strictness }] : []);
+function canonical(value) { if (Array.isArray(value))
+    return value.map(canonical); if (value && typeof value === "object")
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, canonical(value[key])])); return value; }
+const same = (a, b) => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
+const clone = (value) => value === undefined ? undefined : structuredClone(value);
+function unknownProjection(policy = {}) {
+    const copy = clone(policy) || {};
+    delete copy.enforcement;
+    delete copy.diff_rules;
+    delete copy.size_rules;
+    if (copy.paths) {
+        for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"])
+            delete copy.paths[field];
+        if (!Object.keys(copy.paths).length)
+            delete copy.paths;
+    }
+    if (copy.integration) {
+        delete copy.integration.workflows;
+        if (!Object.keys(copy.integration).length)
+            delete copy.integration;
+    }
+    return copy;
+}
+const relaxation = (entry, before, after = null, kind = entry.weakenKind, message = null, extra = {}) => ({
+    kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}), ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
+    message: message || entry.message?.(before, after) || entry.removeMessage, ...extra,
+});
+const incomparable = (entry, before, after) => ({ kind: "policy_incomparable", pointer: entry.pointer, before, after, message: entry.incomparableMessage || `policy constraint ${entry.key} changed with no proven monotonic ordering` });
+export function compareConstraintPrograms(basePolicy, headPolicy) {
+    if (!basePolicy || !headPolicy)
+        return { relation: "equal", relaxations: [], incomparable: [] };
+    const base = comparisonConstraints(basePolicy), head = new Map(comparisonConstraints(headPolicy).map((item) => [item.key, item]));
+    const relaxations = [], incomparableChanges = [], removedOwners = new Set();
+    let tightened = false, changed = false;
+    for (const entry of base) {
+        if (entry.owner && removedOwners.has(entry.owner))
+            continue;
+        const next = head.get(entry.key);
+        if (!next) {
+            if (entry.removeKind) {
+                relaxations.push(relaxation(entry, entry.removeBefore ?? entry.raw ?? entry.value, entry.removeAfter ?? null, entry.removeKind, entry.removeMessage));
+                changed = true;
+                if (entry.relation === "required_entity")
+                    removedOwners.add(entry.key);
+            }
+            continue;
+        }
+        if (entry.relation === "lower_stricter" || entry.relation === "higher_stricter") {
+            const weaker = entry.relation === "lower_stricter" ? next.value > entry.value : next.value < entry.value;
+            const stricter = entry.relation === "lower_stricter" ? next.value < entry.value : next.value > entry.value;
+            if (weaker)
+                relaxations.push(relaxation(entry, entry.raw ?? entry.value, next.raw ?? next.value));
+            tightened ||= stricter;
+            changed ||= next.value !== entry.value;
+        }
+        else if (["superset_stricter", "subset_stricter"].includes(entry.relation)) {
+            const before = new Set(entry.value), after = new Set(next.value), removed = entry.value.filter((item) => !after.has(item)), added = next.value.filter((item) => !before.has(item));
+            const weaker = entry.relation === "superset_stricter" ? removed : added;
+            for (const item of weaker)
+                relaxations.push(relaxation(entry, item, null, entry.weakenKind, entry.message(item), { [entry.itemField]: item }));
+            tightened ||= (entry.relation === "superset_stricter" ? added : removed).length > 0;
+            changed ||= removed.length > 0 || added.length > 0;
+        }
+        else if (entry.relation === "equal_or_incomparable" && !same(entry.value, next.value)) {
+            incomparableChanges.push(incomparable(entry, entry.value, next.value));
+            changed = true;
+        }
+    }
+    const baseKeys = new Set(base.map((entry) => entry.key));
+    for (const item of head.values())
+        if (!baseKeys.has(item.key)) {
+            changed = true;
+            if (["required_entity", "lower_stricter", "higher_stricter"].includes(item.relation))
+                tightened = true;
+            else if (item.relation === "subset_stricter" && item.value.length)
+                for (const added of item.value)
+                    incomparableChanges.push(incomparable(item, [], [added]));
+            else if (item.relation === "equal_or_incomparable" && !item.owner)
+                incomparableChanges.push(incomparable(item, null, item.value));
+        }
+    const beforeUnknown = unknownProjection(basePolicy), afterUnknown = unknownProjection(headPolicy);
+    if (!same(beforeUnknown, afterUnknown)) {
+        incomparableChanges.push({ kind: "policy_incomparable", pointer: "/", before: beforeUnknown, after: afterUnknown, message: "policy sections outside the Constraint Program changed and require explicit governance review" });
+        changed = true;
+    }
+    const relation = relaxations.length ? "weaker" : incomparableChanges.length ? "incomparable" : tightened || changed ? "stricter" : "equal";
+    return { relation, relaxations, incomparable: incomparableChanges };
+}

--- a/dist/checks/default-rule-families.mjs
+++ b/dist/checks/default-rule-families.mjs
@@ -1,0 +1,21 @@
+import { advisoryTextRuleFamily } from "./rules/advisory-text-rules.mjs";
+import { anchorExtractionRuleFamily } from "./rules/anchor-rules.mjs";
+import { constraintRuleFamily } from "./rules/constraints.mjs";
+import { contentRuleFamily } from "./rules/content-rules.mjs";
+import { governancePathsRuleFamily } from "./rules/governance-paths.mjs";
+import { policyRelaxationRuleFamily } from "./rules/policy-delta-rules.mjs";
+import { createRuleRegistry } from "./rule-registry.mjs";
+export const defaultRuleFamilies = [
+    constraintRuleFamily,
+    governancePathsRuleFamily,
+    policyRelaxationRuleFamily,
+    advisoryTextRuleFamily,
+    anchorExtractionRuleFamily,
+    contentRuleFamily,
+];
+export function createDefaultRuleRegistry() {
+    const registry = createRuleRegistry();
+    for (const family of defaultRuleFamilies)
+        registry.register(family);
+    return registry;
+}

--- a/dist/checks/integration-constraints.mjs
+++ b/dist/checks/integration-constraints.mjs
@@ -1,0 +1,157 @@
+import { compareSets } from "./relation-kernel.mjs";
+const object = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
+const array = (value) => Array.isArray(value) ? value : [];
+const lower = (value) => String(value || "").toLowerCase();
+const localUse = (uses) => { const value = String(uses || ""); return value === "./" || value.startsWith("./") || value.startsWith("../"); };
+function actionUse(uses) {
+    const raw = String(uses || "").trim();
+    if (localUse(raw))
+        return { raw, target: raw, ref: "", local: true };
+    const at = raw.lastIndexOf("@");
+    return at < 0 ? { raw, target: raw, ref: "", local: false } : { raw, target: raw.slice(0, at), ref: raw.slice(at + 1), local: false };
+}
+const repoGuardUse = (uses) => { const parsed = actionUse(uses); return parsed.local || lower(parsed.target).includes("repo-guard"); };
+const semver = (ref) => /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(String(ref || ""));
+const sha = (ref) => /^[0-9a-f]{40}$/i.test(String(ref || ""));
+const branch = (ref) => /^(main|master|develop|dev|trunk|head)$/i.test(String(ref || ""));
+function pinned(use, strategy = "ref") {
+    if (strategy === "any")
+        return true;
+    if (strategy === "local")
+        return use.local;
+    if (use.local)
+        return true;
+    if (strategy === "sha")
+        return sha(use.ref);
+    if (strategy === "semver")
+        return semver(use.ref);
+    if (strategy === "tag")
+        return use.ref.length > 0 && !sha(use.ref) && !branch(use.ref);
+    return use.ref.length > 0;
+}
+const stepInputs = (workflow, action) => workflow.stepInputs.find((fact) => fact.jobId === action.jobId && fact.stepIndex === action.stepIndex && fact.uses === action.uses)?.inputs || {};
+const repoGuardActions = (workflow, expected = {}) => workflow.actionUses.map((fact) => ({ ...fact, parsed: actionUse(fact.uses) })).filter((fact) => expected.uses ? fact.parsed.target === expected.uses || fact.uses === expected.uses : repoGuardUse(fact.uses));
+const referencesRepoGuard = (workflow) => workflow.actionUses.some((fact) => repoGuardUse(fact.uses)) || workflow.runCommands.some((fact) => /repo-guard|src\/repo-guard\.mjs/i.test(String(fact.run || "")));
+const hasFetchDepthZero = (workflow) => workflow.stepInputs.some((fact) => lower(fact.uses).startsWith("actions/checkout") && fact.inputs?.["fetch-depth"] === "0");
+const hasEnv = (workflow, names) => { const actual = new Set(workflow.envVars.map((fact) => fact.name)); return names.some((name) => actual.has(name)); };
+const hasAllEnv = (workflow, names) => { const actual = new Set(workflow.envVars.map((fact) => fact.name)); return names.every((name) => actual.has(name)); };
+function hasPermission(workflow, name, expected) {
+    const matches = (value) => value && lower(value) === lower(expected);
+    if (matches(object(workflow.permissions.workflow)[name]))
+        return true;
+    return workflow.permissions.jobs.some((job) => matches(object(job.permissions)[name]));
+}
+const location = (workflow, fact = {}) => {
+    const parts = [];
+    if (fact.jobId)
+        parts.push(`job ${fact.jobId}`);
+    if (fact.stepIndex)
+        parts.push(`step ${fact.stepIndex}${fact.stepName ? ` "${fact.stepName}"` : ""}`);
+    return parts.length ? `${workflow.path}: ${parts.join(" ")}` : workflow.path;
+};
+const detail = (workflow, fact, message) => `${location(workflow, fact)}: ${message}`;
+const truthy = (value) => !["", "false", "0", "null"].includes(lower(value).trim());
+const manualClone = (run) => /\bgit\s+clone\b/i.test(String(run || "")) && /repo-guard/i.test(String(run || ""));
+const tempCli = (run) => String(run || "").split(/\r?\n/).some((line) => /RUNNER_TEMP|TMPDIR|\/tmp|\btemp\b/i.test(line) && /src\/repo-guard\.mjs|repo-guard\.mjs/i.test(line));
+function workflowDetails(workflow) {
+    const details = [], expect = workflow.expect || {};
+    if (workflow.role !== "repo_guard_pr_gate") {
+        if (!referencesRepoGuard(workflow))
+            details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
+        return details;
+    }
+    const events = expect.events?.length ? expect.events : ["pull_request"];
+    for (const event of compareSets(events, workflow.triggerEvents, "left_subset").missing)
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required event ${event}`);
+    if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target")) {
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow must run on pull_request or pull_request_target`);
+    }
+    if (expect.event_types?.length) {
+        const event = workflow.triggerEvents.includes("pull_request") ? "pull_request" : "pull_request_target";
+        const actual = workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
+        for (const type of compareSets(expect.event_types, actual, "left_subset").missing)
+            details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required ${event} type ${type}`);
+    }
+    if (!hasFetchDepthZero(workflow))
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
+    const actions = repoGuardActions(workflow, expect.action || {});
+    if (expect.action && !actions.length)
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow must use ${expect.action.uses || "a repo-guard action"} via uses`);
+    if (!expect.action && !referencesRepoGuard(workflow))
+        details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
+    if (actions.length && expect.action) {
+        const strategy = expect.action.ref_pinning || "ref";
+        if (!actions.some((fact) => (!expect.action.ref || fact.parsed.ref === expect.action.ref) && pinned(fact.parsed, strategy))) {
+            details.push(`${workflow.path}: repo_guard_pr_gate action must satisfy ref_pinning ${strategy}${expect.action.ref ? ` at ref ${expect.action.ref}` : ""}; actual uses: ${actions.map((fact) => fact.uses).join(", ")}`);
+        }
+    }
+    const mode = expect.mode || "check-pr";
+    for (const [field, wanted] of [["mode", mode], ["enforcement", expect.enforcement]]) {
+        if (wanted && actions.length && !actions.some((fact) => stepInputs(workflow, fact)[field] === wanted))
+            details.push(detail(workflow, actions[0], `repo_guard_pr_gate action must set ${field}: ${wanted}`));
+    }
+    if (!actions.length && mode === "check-pr" && !workflow.runCommands.some((fact) => String(fact.run || "").includes("check-pr")))
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow must run check-pr`);
+    for (const [permission, wanted] of Object.entries(expect.permissions || {}))
+        if (!hasPermission(workflow, permission, wanted))
+            details.push(`${workflow.path}: repo_guard_pr_gate workflow must declare permission ${permission}: ${wanted}`);
+    const tokenEnv = expect.token_env || (mode === "check-pr" ? ["GH_TOKEN", "GITHUB_TOKEN"] : []);
+    if (tokenEnv.length && !hasEnv(workflow, tokenEnv))
+        details.push(`${workflow.path}: check-pr workflow should provide one of ${tokenEnv.join(", ")}`);
+    if (expect.required_env?.length && !hasAllEnv(workflow, expect.required_env)) {
+        const actual = new Set(workflow.envVars.map((fact) => fact.name));
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required env ${expect.required_env.filter((name) => !actual.has(name)).join(", ")}`);
+    }
+    if (expect.summary === true && !workflow.summaryPublishing.length)
+        details.push(`${workflow.path}: repo_guard_pr_gate workflow must publish to GITHUB_STEP_SUMMARY`);
+    const disallow = new Set(expect.disallow || ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]);
+    if (disallow.has("continue_on_error"))
+        for (const fact of workflow.continueOnError || [])
+            if (truthy(fact.value))
+                details.push(detail(workflow, fact, "repo_guard_pr_gate step must not set continue-on-error"));
+    if (disallow.has("manual_clone"))
+        for (const fact of workflow.runCommands)
+            if (manualClone(fact.run))
+                details.push(detail(workflow, fact, "repo_guard_pr_gate workflow must not clone repo-guard manually"));
+    if (disallow.has("direct_temp_cli_execution"))
+        for (const fact of workflow.runCommands)
+            if (tempCli(fact.run))
+                details.push(detail(workflow, fact, "repo_guard_pr_gate workflow must not run repo-guard directly from a temporary clone"));
+    return details;
+}
+function templateDetails(template) {
+    if (template.present === false && template.optional)
+        return [];
+    const details = [], blocks = template.changeIntentBlocks || [];
+    const selected = template.requiredBlockKind ? blocks.filter((block) => block.format === template.requiredBlockKind) : blocks;
+    if (template.requiredBlockKind && !selected.length)
+        details.push(`${template.path}: ${template.id} requires a ${template.requiredBlockKind} fenced ChangeIntent block`);
+    else if (template.requiresChangeIntentBlock && !template.hasRepoGuardYamlBlock && !template.hasRepoGuardJsonBlock)
+        details.push(`${template.path}: ${template.id} requires a repo-guard ChangeIntent block`);
+    const fields = new Set(selected.flatMap((block) => block.fieldPaths || []));
+    for (const field of template.requiredChangeIntentFields || [])
+        if (!fields.has(field))
+            details.push(`${template.path}: ${template.id} ChangeIntent block missing required field "${field}"`);
+    return details;
+}
+function missingMentions(doc, facts, label) {
+    return (facts || []).filter((mention) => !mention.present).map((mention) => `${doc.path}: missing required ${label} "${mention.term}"`);
+}
+export function integrationConstraintEntries(integration = {}) {
+    const artifacts = array(integration.errors).map((error) => `${error.section}${error.id ? `:${error.id}` : ""}${error.path ? ` (${error.path})` : ""}: ${error.message}`);
+    const workflows = array(integration.workflows).flatMap(workflowDetails);
+    const templates = array(integration.templates).flatMap(templateDetails);
+    const docs = array(integration.docs).flatMap((doc) => [
+        ...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"),
+        ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention"),
+    ]);
+    const profiles = array(integration.profiles).flatMap((profile) => profile.profileNameReferences?.length ? [] : [`${profile.docPath}: profile "${profile.id}" is not mentioned`]);
+    const entry = (name, details, pass, fail, hint) => ({ name, check: details.length ? { ok: false, message: fail, details, hint } : { ok: true, message: pass } });
+    return [
+        entry("integration-artifacts", artifacts, "All declared integration artifacts were read and parsed", "Integration artifact extraction failed", "Fix missing files, malformed workflow YAML, malformed ChangeIntent blocks, or Markdown fences"),
+        entry("integration-workflows", workflows, "Workflow integration wiring is valid", "Workflow integration wiring has issues", "Compare declared repo-guard workflows with templates/example-workflow.yml"),
+        entry("integration-templates", templates, "Template integration wiring is valid", "Template integration wiring has issues", "Add repo-guard-yaml or repo-guard-json fenced ChangeIntent blocks to required templates"),
+        entry("integration-docs", docs, "Documentation integration wiring is valid", "Documentation integration wiring has issues", "Update declared docs so every must_mention term appears"),
+        entry("integration-profiles", profiles, "Profile documentation wiring is valid", "Profile documentation wiring has issues", "Mention each integration profile id in its declared profile document"),
+    ];
+}

--- a/dist/checks/orchestrator.mjs
+++ b/dist/checks/orchestrator.mjs
@@ -1,0 +1,7 @@
+import { createDefaultRuleRegistry } from "./default-rule-families.mjs";
+export function runPolicyChecks(facts, reporter, options = {}) {
+    const registry = options.registry || createDefaultRuleRegistry();
+    for (const entry of registry.evaluate(facts, options)) {
+        reporter.report(entry.name, entry.check);
+    }
+}

--- a/dist/checks/relation-kernel.mjs
+++ b/dist/checks/relation-kernel.mjs
@@ -1,0 +1,12 @@
+const set = (values = []) => new Set(values);
+export function compareSets(left = [], right = [], relation = "equal") {
+    const l = set(left), r = set(right);
+    const missing = left.filter((value) => !r.has(value));
+    const extra = right.filter((value) => !l.has(value));
+    const ok = relation === "left_subset" ? !missing.length
+        : relation === "right_subset" ? !extra.length
+            : !missing.length && !extra.length;
+    return { ok, missing, extra };
+}
+export const implies = (trigger, evidence) => !trigger || Boolean(evidence);
+export const maxBound = (actual, max) => max === undefined || actual <= max;

--- a/dist/checks/rule-registry.mjs
+++ b/dist/checks/rule-registry.mjs
@@ -1,0 +1,51 @@
+function assertRuleFamily(family) {
+    if (!family || typeof family !== "object") {
+        throw new TypeError("rule family must be an object");
+    }
+    if (!family.id || typeof family.id !== "string") {
+        throw new TypeError("rule family requires a string id");
+    }
+    if (typeof family.evaluate !== "function") {
+        throw new TypeError(`rule family "${family.id}" requires an evaluate function`);
+    }
+}
+function normalizeRuleEntries(family, entries) {
+    const list = Array.isArray(entries) ? entries : [entries];
+    return list
+        .filter(Boolean)
+        .map((entry) => {
+        if (!entry.name || !entry.check) {
+            throw new TypeError(`rule family "${family.id}" returned an invalid rule entry`);
+        }
+        return {
+            family: family.id,
+            name: entry.name,
+            check: entry.check,
+        };
+    });
+}
+export function createRuleRegistry() {
+    const families = [];
+    const ids = new Set();
+    return {
+        register(family) {
+            assertRuleFamily(family);
+            if (ids.has(family.id)) {
+                throw new Error(`rule family "${family.id}" is already registered`);
+            }
+            families.push(family);
+            ids.add(family.id);
+            return this;
+        },
+        list() {
+            return families.map((family) => family.id);
+        },
+        evaluate(facts, context = {}) {
+            return families.flatMap((family) => {
+                if (family.applies && !family.applies(facts, context))
+                    return [];
+                return normalizeRuleEntries(family, family.evaluate(facts, context));
+            });
+        },
+    };
+}

--- a/dist/checks/rules/advisory-text-rules.mjs
+++ b/dist/checks/rules/advisory-text-rules.mjs
@@ -1,0 +1,136 @@
+import { uniqueSorted } from "../../utils/collections.mjs";
+import { matchesAny } from "../../utils/path-patterns.mjs";
+import { readRepositoryTextFile } from "../../utils/repository-files.mjs";
+function stripMarkdownNoise(content) {
+    return content
+        .replace(/```[\s\S]*?```/g, " ")
+        .replace(/`[^`]*`/g, " ")
+        .replace(/!\[[^\]]*\]\([^)]+\)/g, " ")
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        .replace(/<[^>]+>/g, " ");
+}
+function markdownTokens(content) {
+    const normalized = stripMarkdownNoise(content)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, " ");
+    return normalized.split(/\s+/).filter((token) => token.length >= 3);
+}
+function tokenSet(content) {
+    return new Set(markdownTokens(content));
+}
+function jaccardScore(left, right) {
+    if (left.size === 0 || right.size === 0)
+        return 0;
+    let intersection = 0;
+    for (const token of left) {
+        if (right.has(token))
+            intersection++;
+    }
+    const union = left.size + right.size - intersection;
+    return union === 0 ? 0 : intersection / union;
+}
+function markdownHeadings(content) {
+    const headings = [];
+    for (const line of content.split(/\r?\n/)) {
+        const match = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+        if (match) {
+            headings.push({
+                level: match[1].length,
+                title: match[2].trim(),
+                normalized: match[2].trim().toLowerCase().replace(/\s+/g, " "),
+            });
+        }
+    }
+    return headings;
+}
+export function checkAdvisoryTextRules(files, rules, options = {}) {
+    if (!rules)
+        return { ok: true, matches: [] };
+    const canonicalPatterns = rules.canonical_files || [];
+    const changedMarkdown = files.filter((file) => file.status !== "deleted" && file.path.match(/\.md$/i));
+    if (changedMarkdown.length === 0 || canonicalPatterns.length === 0) {
+        return { ok: true, matches: [] };
+    }
+    const threshold = rules.warn_on_similarity_above ?? 0.7;
+    const maxReported = rules.max_reported_matches ?? 3;
+    const canonicalFiles = uniqueSorted(options.allFiles || []);
+    const results = [];
+    const readErrors = [];
+    for (const changed of changedMarkdown) {
+        let changedContent;
+        try {
+            changedContent = readRepositoryTextFile(changed.path, options);
+        }
+        catch (error) {
+            readErrors.push(`${changed.path}: ${error.message}`);
+            continue;
+        }
+        const changedTokens = tokenSet(changedContent);
+        const changedHeadings = markdownHeadings(changedContent);
+        const changedHeadingSet = new Set(changedHeadings.map((heading) => heading.normalized));
+        for (const canonicalPath of canonicalFiles) {
+            if (canonicalPath === changed.path)
+                continue;
+            if (!canonicalPath.match(/\.md$/i))
+                continue;
+            if (!matchesAny(canonicalPath, canonicalPatterns))
+                continue;
+            let canonicalContent;
+            try {
+                canonicalContent = readRepositoryTextFile(canonicalPath, options);
+            }
+            catch (error) {
+                readErrors.push(`${canonicalPath}: ${error.message}`);
+                continue;
+            }
+            const score = jaccardScore(changedTokens, tokenSet(canonicalContent));
+            const canonicalHeadings = markdownHeadings(canonicalContent);
+            const duplicateHeadings = uniqueSorted(canonicalHeadings
+                .filter((heading) => changedHeadingSet.has(heading.normalized))
+                .map((heading) => heading.title));
+            if (score >= threshold || duplicateHeadings.length > 0) {
+                results.push({
+                    changed_file: changed.path,
+                    canonical_file: canonicalPath,
+                    score: Number(score.toFixed(3)),
+                    threshold,
+                    duplicate_section_titles: duplicateHeadings,
+                    reason: score >= threshold ? "text_similarity" : "duplicate_section_title",
+                });
+            }
+        }
+    }
+    results.sort((left, right) => right.score - left.score ||
+        left.changed_file.localeCompare(right.changed_file) ||
+        left.canonical_file.localeCompare(right.canonical_file));
+    const matches = results.slice(0, maxReported);
+    const details = matches.map((match) => {
+        const sections = match.duplicate_section_titles.length > 0
+            ? `; duplicate sections: ${match.duplicate_section_titles.join(", ")}`
+            : "";
+        return `${match.changed_file} overlaps ${match.canonical_file} (score ${match.score}, threshold ${match.threshold}${sections})`;
+    });
+    return {
+        ok: matches.length === 0,
+        advisory: true,
+        message: matches.length > 0 ? "heuristic markdown duplication advisory" : undefined,
+        matches,
+        details: [...details, ...readErrors.map((error) => `read warning: ${error}`)],
+        hint: matches.length > 0
+            ? "Review whether the changed markdown should update the canonical source instead of duplicating policy prose."
+            : undefined,
+    };
+}
+export const advisoryTextRuleFamily = {
+    id: "advisory-text-rules",
+    evaluate(facts) {
+        return {
+            name: "advisory-text-rules",
+            check: checkAdvisoryTextRules(facts.diff.files.checked, facts.policy.advisory_text_rules, {
+                repoRoot: facts.repositoryRoot,
+                allFiles: facts.trackedFiles,
+                readFile: facts.readFile,
+            }),
+        };
+    },
+};

--- a/dist/checks/rules/anchor-rules.mjs
+++ b/dist/checks/rules/anchor-rules.mjs
@@ -1,0 +1,6 @@
+import { checkAnchorExtraction } from "../../extractors/anchors.mjs";
+export const anchorExtractionRuleFamily = {
+    id: "anchor-extraction",
+    applies: (facts) => Boolean(facts.policy.anchors),
+    evaluate: (facts) => ({ name: "anchor-extraction", check: checkAnchorExtraction(facts.anchors) }),
+};

--- a/dist/checks/rules/change-profiles.mjs
+++ b/dist/checks/rules/change-profiles.mjs
@@ -1,0 +1,86 @@
+import { classifyNewFiles, detectTouchedSurfaces } from "../../diff/classification.mjs";
+import { formatList, uniqueSorted } from "../../utils/collections.mjs";
+import { maxBound } from "../relation-kernel.mjs";
+function budget(actual, max, files = undefined) { return max === undefined ? { ok: true } : { ok: maxBound(actual, max), actual, limit: max, ...(files ? { files } : {}) }; }
+function profileBudgets(files, canonicalDocs, limits = {}) {
+    const added = files.filter((file) => file.status === "added");
+    const docs = added.filter((file) => /\.md$/i.test(file.path) && !canonicalDocs.includes(file.path));
+    const net = files.reduce((sum, file) => sum + (file.addedLines?.length || 0) - (file.deletedLines?.length || 0), 0);
+    return { docs: budget(docs.length, limits.max_new_docs, docs.map((file) => file.path)), files: budget(added.length, limits.max_new_files, added.map((file) => file.path)), lines: budget(net, limits.max_net_added_lines) };
+}
+function checkProfileNewFiles(files, classes, rule, changeType, detected = null) {
+    if (!rule)
+        return { ok: true };
+    detected ||= classifyNewFiles(files, classes || {});
+    const newFiles = detected.new_files;
+    if (!newFiles.length)
+        return { ok: true, change_type: changeType, new_files: [], files_by_class: detected.files_by_class, unclassified_files: detected.unclassified_files };
+    const allowedClasses = uniqueSorted(rule.allow_classes || []), allowed = new Set(allowedClasses);
+    const touchedClasses = uniqueSorted(Object.keys(detected.files_by_class));
+    const violatingClasses = allowedClasses.length ? touchedClasses.filter((name) => !allowed.has(name)) : touchedClasses;
+    const unclassifiedFiles = detected.unclassified_files;
+    const classBudgetViolations = Object.entries(rule.max_per_class || {}).flatMap(([fileClass, limit]) => {
+        const selected = detected.files_by_class[fileClass] || [];
+        return maxBound(selected.length, limit) ? [] : [{ class: fileClass, actual: selected.length, limit, files: selected }];
+    });
+    const exceedsMax = !maxBound(newFiles.length, rule.max_new_files);
+    const details = [
+        ...violatingClasses.map((name) => `class ${name} is not allowed by change_profiles["${changeType}"].new_files.allow_classes; files: ${detected.files_by_class[name].join(", ")}`),
+        ...unclassifiedFiles.map((file) => `file ${file} detected class: unclassified; violated rule: change_profiles["${changeType}"].new_files.allow_classes`),
+        ...classBudgetViolations.map((v) => `class ${v.class} has ${v.actual} new file(s), limit ${v.limit}; files: ${v.files.join(", ")}`),
+    ];
+    if (exceedsMax)
+        details.push(`new files ${newFiles.length} exceeds change_profiles["${changeType}"].new_files.max_new_files ${rule.max_new_files}`);
+    const ok = !violatingClasses.length && !unclassifiedFiles.length && !classBudgetViolations.length && !exceedsMax;
+    return {
+        ok, message: violatingClasses.length ? `change_type "${changeType}" cannot add new-file classes: ${violatingClasses.join(", ")}`
+            : unclassifiedFiles.length ? `change_profiles["${changeType}"].new_files found added files that match no declared new_file_class: ${unclassifiedFiles.join(", ")}`
+                : !ok ? `change_type "${changeType}" exceeds change_profiles["${changeType}"].new_files budget` : undefined,
+        change_type: changeType, new_files: newFiles, actual: exceedsMax ? newFiles.length : undefined, limit: exceedsMax ? rule.max_new_files : undefined,
+        allowed_classes: allowedClasses, touched_classes: touchedClasses, violating_classes: violatingClasses, class_budget_violations: classBudgetViolations,
+        files_by_class: detected.files_by_class, unclassified_files: unclassifiedFiles, details,
+        hint: unclassifiedFiles.length ? "Add matching new_file_classes globs or update the change_profile.new_files.allow_classes." : undefined,
+    };
+}
+export function checkChangeProfile(files, policy, changeType, derived = {}) {
+    const profiles = policy.change_profiles || {};
+    if (changeType === "governance")
+        return { ok: true, change_type: changeType, delegated_to: "governance-change-authorization" };
+    if (!Object.keys(profiles).length)
+        return { ok: true };
+    if (!changeType)
+        return { ok: false, message: "change_profiles requires a declared change_type", change_type: null, hint: "Set change_type in the ChangeIntent." };
+    const profile = profiles[changeType];
+    if (!profile)
+        return { ok: false, message: `change_type "${changeType}" is not defined in change_profiles`, change_type: changeType, details: [`known change types: ${formatList(Object.keys(profiles).sort())}`], hint: "Define the change type in change_profiles or use one of the configured types." };
+    const detected = derived.touchedSurfaces || detectTouchedSurfaces(files, policy.surfaces);
+    const touched = detected.touched_surfaces, required = uniqueSorted(profile.require_surfaces || []), allowed = uniqueSorted(profile.allow_surfaces || []), forbidden = uniqueSorted(profile.forbid_surfaces || []);
+    const touchedSet = new Set(touched), usesConstraints = required.length + allowed.length + forbidden.length > 0;
+    const hasUnclassified = usesConstraints && detected.unclassified_files.length > 0 && !profile.allow_unclassified_surfaces;
+    const missing = required.filter((surface) => !touchedSet.has(surface));
+    const violating = uniqueSorted([...(allowed.length ? touched.filter((surface) => !allowed.includes(surface)) : []), ...touched.filter((surface) => forbidden.includes(surface))]);
+    const newFiles = checkProfileNewFiles(files, policy.new_file_classes, profile.new_files, changeType, derived.newFileClasses);
+    const budgets = profileBudgets(files, policy.paths.canonical_docs, profile.budgets);
+    const details = [
+        ...missing.map((surface) => `required surface ${surface} was not touched by change_profiles["${changeType}"].require_surfaces`),
+        ...violating.map((surface) => `surface ${surface} violated change_profiles["${changeType}"] surface constraints; files: ${detected.files_by_surface[surface].join(", ")}`),
+    ];
+    if (hasUnclassified)
+        details.push(`changed files matched no declared surface: ${detected.unclassified_files.join(", ")}`);
+    if (!budgets.docs.ok)
+        details.push(`new docs ${budgets.docs.actual} exceeds change_profiles["${changeType}"].budgets.max_new_docs ${budgets.docs.limit}; files: ${budgets.docs.files.join(", ")}`);
+    if (!budgets.files.ok)
+        details.push(`new files ${budgets.files.actual} exceeds change_profiles["${changeType}"].budgets.max_new_files ${budgets.files.limit}; files: ${budgets.files.files.join(", ")}`);
+    if (!budgets.lines.ok)
+        details.push(`net added lines ${budgets.lines.actual} exceeds change_profiles["${changeType}"].budgets.max_net_added_lines ${budgets.lines.limit}`);
+    if (!newFiles.ok)
+        details.push(...(newFiles.details || [newFiles.message]).filter(Boolean));
+    const ok = !missing.length && !violating.length && !hasUnclassified && budgets.docs.ok && budgets.files.ok && budgets.lines.ok && newFiles.ok;
+    return {
+        ok, message: ok ? undefined : `change_type "${changeType}" violated change_profiles`, change_type: changeType,
+        touched_surfaces: touched, required_surfaces: required, allowed_surfaces: allowed, forbidden_surfaces: forbidden,
+        missing_required_surfaces: missing, violating_surfaces: violating, files_by_surface: detected.files_by_surface, unclassified_files: detected.unclassified_files,
+        docs_budget: budgets.docs, new_files_budget: budgets.files, net_added_lines_budget: budgets.lines, new_files: newFiles, details,
+        hint: hasUnclassified ? "Add matching surface globs or set change_profiles[change_type].allow_unclassified_surfaces: true." : undefined,
+    };
+}

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -1,0 +1,123 @@
+import { calculateDiffGrowth } from "../../diff/growth.mjs";
+import { selectPaths } from "../../diff/classification.mjs";
+import { matchesAny } from "../../utils/path-patterns.mjs";
+import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
+import { integrationConstraintEntries } from "../integration-constraints.mjs";
+import { checkTraceRuleResult } from "../trace-rules.mjs";
+import { checkChangeProfile } from "./change-profiles.mjs";
+import { checkRegistryRules } from "./registry-rules.mjs";
+import { checkSizeRules } from "./size-rules.mjs";
+function budget(selected, max) {
+    if (max === undefined)
+        return { ok: true };
+    return { ok: selected.length <= max, actual: selected.length, limit: max, files: selected.map((file) => file.path) };
+}
+export const checkCanonicalDocsBudget = (files, canonicalDocs = [], max) => budget(files.filter((file) => file.status === "added" && /\.md$/i.test(file.path) && !canonicalDocs.includes(file.path)), max);
+export const checkNewFilesBudget = (files, max) => budget(files.filter((file) => file.status === "added"), max);
+export function checkNetAddedLinesBudget(files, max) {
+    if (max === undefined)
+        return { ok: true };
+    const actual = files.reduce((sum, file) => sum + (file.addedLines?.length || 0) - (file.deletedLines?.length || 0), 0);
+    return { ok: actual <= max, actual, limit: max };
+}
+export function checkSurfaceDebt(files, debt) {
+    const growth = calculateDiffGrowth(files);
+    if (growth.new_files <= 0 && growth.net_added_lines <= 0)
+        return { ok: true, status: "not_needed", growth };
+    if (!debt)
+        return { ok: true, status: "undeclared", growth, details: [`new files: ${growth.new_files}`, `net added lines: ${growth.net_added_lines}`] };
+    if (!debt.repayment_issue)
+        return { ok: false, status: "missing_repayment_target", message: "declared surface debt is missing repayment target: repayment_issue", growth, surface_debt: debt, details: ["missing repayment_issue"], hint: "Set repayment_issue to the issue number where the temporary growth will be repaid." };
+    const expected = debt.expected_delta || {}, exceeded = [];
+    if (expected.max_new_files !== undefined && growth.new_files > expected.max_new_files)
+        exceeded.push(`new files ${growth.new_files} exceeds declared debt ${expected.max_new_files}`);
+    if (expected.max_net_added_lines !== undefined && growth.net_added_lines > expected.max_net_added_lines)
+        exceeded.push(`net added lines ${growth.net_added_lines} exceeds declared debt ${expected.max_net_added_lines}`);
+    return { ok: !exceeded.length, status: exceeded.length ? "declared_debt_exceeded" : "declared", message: exceeded.length ? "declared surface debt is smaller than actual diff growth" : undefined, growth, surface_debt: debt, details: exceeded, hint: exceeded.length ? "Update expected_delta to match intentional temporary growth or reduce the diff." : undefined };
+}
+export const checkForbiddenPaths = (files, patterns) => selectPaths(files, patterns, { excludeStatuses: ["deleted"] });
+export function checkScope(files, patterns) {
+    if (!patterns?.length)
+        return { ok: true };
+    const out = files.filter((file) => !matchesAny(file.path, patterns)).map((file) => file.path).sort();
+    return { ok: !out.length, declared_scope: patterns, out_of_scope_paths: out, message: out.length ? "changed files fall outside declared ChangeIntent scope" : undefined, details: out.map((path) => `out of scope: ${path}`) };
+}
+export function checkMustTouch(files, patterns) {
+    if (!patterns?.length)
+        return { ok: true };
+    const ok = selectPaths(files, patterns).length > 0;
+    return { ok, must_touch: patterns, changed: files.map((file) => file.path), hint: ok ? undefined : "must_touch uses any-of semantics: at least one pattern must match a changed file" };
+}
+export function checkMustNotTouch(files, patterns) {
+    if (!patterns?.length)
+        return { ok: true };
+    const touched = selectPaths(files, patterns);
+    return { ok: !touched.length, touched, must_not_touch: patterns };
+}
+export const checkCochangeRules = (files, rules = []) => rules.flatMap((rule) => selectPaths(files, rule.if_changed).length && !selectPaths(files, rule.must_change_any).length ? [{ if_changed: rule.if_changed, must_change_any: rule.must_change_any }] : []);
+export function compileConstraintIR(facts) {
+    return { files: facts.diff.files.checked, constraints: runtimeConstraints(compileConstraintProgram(facts.policy, facts.changeIntent)) };
+}
+function evaluateMetric(files, constraint, policy) {
+    if (constraint.metric === "new_docs")
+        return checkCanonicalDocsBudget(files, policy.paths.canonical_docs, constraint.max);
+    if (constraint.metric === "new_files")
+        return checkNewFilesBudget(files, constraint.max);
+    return checkNetAddedLinesBudget(files, constraint.max);
+}
+export function evaluateConstraintIR(facts, context = {}) {
+    const { files, constraints } = compileConstraintIR(facts), results = [], cochange = [];
+    for (const constraint of constraints) {
+        let check;
+        if (constraint.kind === "max_metric")
+            check = evaluateMetric(files, constraint, facts.policy);
+        else if (constraint.kind === "surface_debt")
+            check = checkSurfaceDebt(files, constraint.debt);
+        else if (constraint.kind === "scope_paths")
+            check = checkScope(files, constraint.patterns);
+        else if (constraint.kind === "require_paths")
+            check = checkMustTouch(files, constraint.patterns);
+        else if (constraint.kind === "forbid_paths") {
+            if (constraint.changeIntent)
+                check = checkMustNotTouch(files, constraint.patterns);
+            else {
+                const found = checkForbiddenPaths(files, constraint.patterns);
+                check = { ok: !found.length, files: found };
+            }
+        }
+        else if (constraint.kind === "implies_nonempty") {
+            if (selectPaths(files, constraint.if_changed).length && !selectPaths(files, constraint.must_change_any).length)
+                cochange.push(constraint);
+            continue;
+        }
+        else if (constraint.kind === "size_rules") {
+            const result = checkSizeRules(files, constraint.rules, {
+                repoRoot: facts.repositoryRoot, trackedFiles: facts.trackedFiles, readFile: facts.readFile,
+                ignorePatterns: facts.policy.paths.operational_paths, changeType: facts.changeIntent?.change_type,
+            });
+            results.push({ name: constraint.name, check: result });
+            if (result.advisory_violations.length)
+                results.push({ name: "size-rules-advisory", check: { ok: false, advisory: true, size_violations: result.advisory_violations, details: result.advisory_details, growth: result.growth } });
+            continue;
+        }
+        else if (constraint.kind === "registry_rules")
+            check = checkRegistryRules(constraint.rules, { repoRoot: facts.repositoryRoot, readFile: facts.readFile, documents: facts.documents });
+        else if (constraint.kind === "change_profile")
+            check = checkChangeProfile(files, facts.policy, facts.changeIntent?.change_type, facts.derived);
+        else if (constraint.kind === "trace_rules") {
+            for (const trace of context.anchorDiagnostics?.traceRuleResults || [])
+                results.push({ name: `trace-rule: ${trace.id}`, check: checkTraceRuleResult(trace) });
+            continue;
+        }
+        else if (constraint.kind === "integration") {
+            results.push(...integrationConstraintEntries(facts.integration));
+            continue;
+        }
+        else
+            continue;
+        results.push({ name: constraint.name, check });
+    }
+    results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed.join(",")} -> ${item.must_change_any.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));
+    return results;
+}
+export const constraintRuleFamily = { id: "constraints", evaluate: (facts, context) => evaluateConstraintIR(facts, context) };

--- a/dist/checks/rules/content-rules.mjs
+++ b/dist/checks/rules/content-rules.mjs
@@ -1,0 +1,69 @@
+import { createDocumentReader, stripMarkdownInline } from "../../document-facts.mjs";
+import { matchesAny } from "../../utils/path-patterns.mjs";
+function checkRegexRule(files, rule) {
+    const violations = [];
+    const regexes = rule.forbid_regex.map((pattern) => new RegExp(pattern));
+    for (const file of files) {
+        if (!matchesAny(file.path, [rule.glob || "**"]))
+            continue;
+        for (const line of file.addedLines || []) {
+            regexes.forEach((regex, index) => {
+                if (regex.test(line))
+                    violations.push({
+                        kind: "regex", rule_id: rule.id, file: file.path, line: line.trim(), matched_regex: rule.forbid_regex[index],
+                    });
+            });
+        }
+    }
+    return violations;
+}
+function markdownLanguageViolations(file, rule, documents) {
+    const allowed = new Set(rule.allow_words || []);
+    const maxLatin = rule.max_unapproved_latin_words_per_line ?? 1;
+    const violations = [];
+    for (const prose of documents.markdown(file.path).proseLines) {
+        const line = stripMarkdownInline(prose.text);
+        const latin = [...line.matchAll(/(?<![\w])([A-Za-z][A-Za-z-]{2,})(?![\w])/g)]
+            .map((match) => match[1]).filter((word) => !allowed.has(word));
+        const hasCyrillic = /[А-Яа-яЁё]{3,}/.test(line);
+        if (latin.length > maxLatin || (latin.length > 0 && !hasCyrillic)) {
+            violations.push({
+                kind: "language", rule_id: rule.id, file: file.path, line_number: prose.line,
+                line: prose.text.trim(), language: rule.language, unapproved_words: latin,
+            });
+        }
+    }
+    return violations;
+}
+export function checkContentRules(files, rules = [], options = {}) {
+    const violations = [];
+    const documents = options.documents || createDocumentReader(options);
+    for (const rule of rules) {
+        if (rule.mode === "added_lines" && rule.forbid_regex)
+            violations.push(...checkRegexRule(files, rule));
+        else if (rule.mode === "markdown_language") {
+            for (const file of files) {
+                if (file.status !== "deleted" && matchesAny(file.path, [rule.glob || "**/*.md"])) {
+                    violations.push(...markdownLanguageViolations(file, rule, documents));
+                }
+            }
+        }
+    }
+    return violations;
+}
+function formatViolation(violation) {
+    return violation.kind === "language"
+        ? `[${violation.rule_id}] ${violation.file}:${violation.line_number}: unapproved ${violation.language} prose words: ${violation.unapproved_words.join(", ")}`
+        : `[${violation.rule_id}] ${violation.file}: "${violation.line}" matched /${violation.matched_regex}/`;
+}
+export const contentRuleFamily = {
+    id: "content-rules",
+    evaluate(facts) {
+        const violations = checkContentRules(facts.diff.files.checked, facts.policy.content_rules, {
+            repoRoot: facts.repositoryRoot, readFile: facts.readFile, documents: facts.documents,
+        });
+        return violations.length
+            ? { name: "content-rules", check: { ok: false, violations, details: violations.map(formatViolation) } }
+            : { name: "content-rules", check: { ok: true } };
+    },
+};

--- a/dist/checks/rules/governance-paths.mjs
+++ b/dist/checks/rules/governance-paths.mjs
@@ -1,0 +1,53 @@
+import { matchesAny } from "../../utils/path-patterns.mjs";
+const expand = (pattern) => typeof pattern !== "string" || !pattern ? [] : [pattern.endsWith("/") ? `${pattern}**` : pattern];
+export function expandGovernancePatterns(patterns = []) {
+    return [...new Set(patterns.flatMap(expand))];
+}
+const trusted = (authorizer) => Boolean(authorizer && (authorizer.issue_author_permission_trusted || authorizer.governance_approved_label || authorizer.codeowner_approved || authorizer.trusted_team_approval));
+export function checkGovernanceChangeAuthorization({ files, governancePaths, governanceGrant, trustedAuthorizer, changeIntentType = null }) {
+    const patterns = expandGovernancePatterns(governancePaths || []), governanceChange = changeIntentType === "governance";
+    const matchesBoundary = (path) => matchesAny(path, patterns);
+    if (!patterns.length && !governanceChange)
+        return { ok: true };
+    const touched = files.filter((file) => matchesBoundary(file.path)).map((file) => file.path);
+    const nonGovernance = governanceChange ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path) : [];
+    if (!governanceChange && !touched.length)
+        return { ok: true, touched_governance_paths: [] };
+    const declared = Array.isArray(governanceGrant?.authorized_governance_paths) ? governanceGrant.authorized_governance_paths : [];
+    const sourceTrusted = trusted(trustedAuthorizer), authorized = sourceTrusted ? declared : [];
+    const unauthorized = touched.filter((path) => !matchesAny(path, expandGovernancePatterns(authorized)));
+    const details = [
+        ...nonGovernance.map((path) => `governance ChangeIntent cannot change non-governance path ${path}`),
+        ...unauthorized.map((path) => `governance path ${path} changed without matching GovernanceGrant authorization`),
+    ];
+    if (declared.length && !sourceTrusted)
+        details.push("GovernanceGrant is ignored because no trusted authorizer was detected");
+    const ok = !nonGovernance.length && !unauthorized.length;
+    return {
+        ok,
+        message: ok ? undefined : governanceChange && nonGovernance.length
+            ? "governance ChangeIntent includes files outside trusted governance paths"
+            : "governance paths changed without trusted GovernanceGrant",
+        touched_governance_paths: touched,
+        non_governance_paths: nonGovernance,
+        trusted_authorized_governance_paths: authorized,
+        unauthorized_paths: unauthorized,
+        untrusted_governance_grant_ignored: declared.length > 0 && !sourceTrusted,
+        details,
+        hint: ok ? undefined : "Use a dedicated governance-only diff and authorize every touched governance path from a trusted linked-issue GovernanceGrant.",
+    };
+}
+export const governancePathsRuleFamily = {
+    id: "governance-paths",
+    applies(facts) {
+        const paths = Array.isArray(facts.trustedGovernancePaths) ? facts.trustedGovernancePaths : facts.policy.paths?.governance_paths;
+        return Boolean(paths?.length) || facts.changeIntent?.change_type === "governance";
+    },
+    evaluate(facts) {
+        const governancePaths = Array.isArray(facts.trustedGovernancePaths) ? facts.trustedGovernancePaths : facts.policy.paths?.governance_paths;
+        return { name: "governance-change-authorization", check: checkGovernanceChangeAuthorization({
+                files: facts.diff.files.checked, governancePaths, governanceGrant: facts.governanceGrant, trustedAuthorizer: facts.trustedAuthorizer,
+                changeIntentType: facts.changeIntent?.change_type,
+            }) };
+    },
+};

--- a/dist/checks/rules/policy-delta-rules.mjs
+++ b/dist/checks/rules/policy-delta-rules.mjs
@@ -1,0 +1,99 @@
+import { matchesAny } from "../../utils/path-patterns.mjs";
+import { compareConstraintPrograms } from "../constraint-program.mjs";
+import { expandGovernancePatterns } from "./governance-paths.mjs";
+const array = (value) => Array.isArray(value) ? value : [];
+export const comparePolicyStrictness = compareConstraintPrograms;
+export function computePolicyDelta(basePolicy, headPolicy) {
+    if (!basePolicy || !headPolicy)
+        return { relaxations: [] };
+    const compared = compareConstraintPrograms(basePolicy, headPolicy);
+    return { relaxations: [...compared.relaxations, ...compared.incomparable] };
+}
+const DEFAULT_PROTECTED_SURFACES = ["source", "tests", "schemas"];
+function protectedPatterns(policy, configured) {
+    return [...new Set((configured?.length ? configured : DEFAULT_PROTECTED_SURFACES).flatMap((name) => array(policy?.surfaces?.[name])))];
+}
+const governanceFile = (path, policy) => path === "repo-policy.json" || matchesAny(path, expandGovernancePatterns(array(policy?.paths?.governance_paths)));
+export function classifyChangedFiles(files, basePolicy, configured = null) {
+    const patterns = protectedPatterns(basePolicy, configured), protectedFiles = [], governanceFiles = [], otherFiles = [];
+    for (const file of files) {
+        if (governanceFile(file.path, basePolicy))
+            governanceFiles.push(file.path);
+        else if (patterns.length && matchesAny(file.path, patterns))
+            protectedFiles.push(file.path);
+        else
+            otherFiles.push(file.path);
+    }
+    return { protectedFiles, governanceFiles, otherFiles, protectedPatterns: patterns };
+}
+function pointerCovers(grant, delta) {
+    if (typeof grant !== "string" || typeof delta !== "string")
+        return false;
+    if (grant === delta || delta.startsWith(`${grant}/`))
+        return true;
+    if (!grant.endsWith("/*"))
+        return false;
+    const prefix = grant.slice(0, -2), remainder = delta.startsWith(`${prefix}/`) ? delta.slice(prefix.length + 1) : null;
+    return remainder !== null && remainder.split("/").length <= 2;
+}
+function grantCoversRelaxation(governanceGrant, relaxations) {
+    if (!governanceGrant)
+        return { ok: false, reason: "governance_grant_missing" };
+    const allowed = array(governanceGrant.allow_policy_relaxation);
+    if (!allowed.length)
+        return { ok: false, reason: "governance_grant_missing_allow_policy_relaxation" };
+    const uncovered = relaxations.map((item) => item.pointer).filter((pointer) => !allowed.some((entry) => pointerCovers(entry, pointer)));
+    return uncovered.length
+        ? { ok: false, reason: "governance_grant_does_not_cover_all_relaxations", uncovered_pointers: uncovered, allowed_pointers: allowed }
+        : { ok: true, allowed_pointers: allowed };
+}
+function trust(authorizer) {
+    if (!authorizer)
+        return { trusted: false, reasons: ["trusted_authorizer_missing"] };
+    const sources = [
+        authorizer.issue_author_permission_trusted && "issue_author_permission",
+        authorizer.governance_approved_label && "governance_approved_label",
+        authorizer.codeowner_approved && "codeowner_approval",
+        authorizer.trusted_team_approval && "trusted_team_approval",
+    ].filter(Boolean);
+    return sources.length ? { trusted: true, reasons: [], detected_sources: sources } : { trusted: false, reasons: ["no_trusted_authorization_source"], detected_sources: [] };
+}
+export function checkPolicyRelaxation({ basePolicy, headPolicy, changedFiles, trustedAuthorizer, governanceGrant, changeIntentType, configuredProtectedSurfaces = null, }) {
+    if (!basePolicy || !headPolicy)
+        return { ok: true };
+    const { relaxations } = computePolicyDelta(basePolicy, headPolicy);
+    if (!relaxations.length)
+        return { ok: true, policy_relaxations: [] };
+    const classified = classifyChangedFiles(changedFiles, basePolicy, configuredProtectedSurfaces);
+    const authorizer = trust(trustedAuthorizer), grant = grantCoversRelaxation(governanceGrant, relaxations);
+    const reasons = [...authorizer.reasons];
+    if (!grant.ok)
+        reasons.push(grant.reason);
+    const governanceOnly = !classified.protectedFiles.length && !classified.otherFiles.length && classified.governanceFiles.length > 0;
+    if (!governanceOnly)
+        reasons.push("policy_relaxation_mixed_with_non_governance_changes");
+    if (changeIntentType && changeIntentType !== "governance")
+        reasons.push("change_intent_type_is_not_governance");
+    const details = relaxations.map((item) => `- ${item.pointer}: ${item.message}`);
+    if (!governanceOnly && classified.protectedFiles.length)
+        details.push(`Mixed with protected-surface changes: ${classified.protectedFiles.slice(0, 10).join(", ")}`);
+    if (authorizer.reasons.length)
+        details.push(`trusted_authorizer: ${authorizer.reasons.join(", ")}`);
+    const ok = !reasons.length;
+    return {
+        ok, message: ok ? undefined : "PR attempts to relax trusted repository policy", policy_relaxations: relaxations,
+        details, blocked_reasons: reasons, governance_only: governanceOnly, protected_files: classified.protectedFiles,
+        governance_files: classified.governanceFiles, other_files: classified.otherFiles, protected_patterns: classified.protectedPatterns,
+        trusted_authorizer: authorizer,
+        hint: ok ? undefined : "Policy relaxation requires a dedicated governance change and a trusted linked-issue GovernanceGrant covering every relaxed pointer.",
+    };
+}
+export const policyRelaxationRuleFamily = {
+    id: "policy-delta",
+    applies: (facts) => Boolean(facts.basePolicy && facts.headPolicy),
+    evaluate: (facts) => ({ name: "policy-relaxation", check: checkPolicyRelaxation({
+            basePolicy: facts.basePolicy, headPolicy: facts.headPolicy, changedFiles: facts.diff.files.checked,
+            trustedAuthorizer: facts.trustedAuthorizer, governanceGrant: facts.governanceGrant,
+            changeIntentType: facts.changeIntent?.change_type, configuredProtectedSurfaces: facts.basePolicy?.policy_delta_rules?.protected_surfaces,
+        }) }),
+};

--- a/dist/checks/rules/registry-rules.mjs
+++ b/dist/checks/rules/registry-rules.mjs
@@ -1,0 +1,74 @@
+import { createDocumentReader, markdownSection } from "../../document-facts.mjs";
+import { compareSets } from "../relation-kernel.mjs";
+import { formatList, uniqueSorted } from "../../utils/collections.mjs";
+import { normalizePathEntry } from "../../utils/path-patterns.mjs";
+const normalizeAll = (values) => uniqueSorted(values.map(normalizePathEntry).filter(Boolean));
+function resolveJsonPointer(data, pointer) {
+    if (pointer === "")
+        return data;
+    if (!pointer?.startsWith("/"))
+        throw new Error(`invalid json_pointer "${pointer}"`);
+    let current = data;
+    for (const raw of pointer.slice(1).split("/")) {
+        const part = raw.replace(/~1/g, "/").replace(/~0/g, "~");
+        if (current == null || !Object.hasOwn(current, part))
+            throw new Error(`json_pointer "${pointer}" does not exist`);
+        current = current[part];
+    }
+    return current;
+}
+function normalizeMarkdownLinkTarget(target, source) {
+    const clean = normalizePathEntry(target.split("#")[0].split("?")[0]);
+    if (!clean || /^[a-z][a-z0-9+.-]*:/i.test(clean) || clean.startsWith("#"))
+        return "";
+    const sourceDir = source.file.includes("/") ? source.file.split("/").slice(0, -1).join("/") : "";
+    const candidate = clean.startsWith("/") ? clean.slice(1) : normalizePathEntry(`${sourceDir}/${clean}`), parts = [];
+    for (const part of candidate.split("/")) {
+        if (!part || part === ".")
+            continue;
+        if (part === "..")
+            parts.pop();
+        else
+            parts.push(part);
+    }
+    let result = parts.join("/");
+    if (source.prefix) {
+        const prefix = normalizePathEntry(source.prefix);
+        if (!result.startsWith(prefix) && sourceDir && result.startsWith(`${sourceDir}/`))
+            result = normalizePathEntry(`${prefix}${result.slice(sourceDir.length + 1)}`);
+    }
+    return result;
+}
+function readRegistrySource(source, documents) {
+    if (source.type === "json_array") {
+        const value = resolveJsonPointer(documents.json(source.file), source.json_pointer);
+        if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))
+            throw new Error(`${source.file}${source.json_pointer} must be an array of strings`);
+        return normalizeAll(value);
+    }
+    if (source.type === "markdown_section_links")
+        return normalizeAll(markdownSection(documents.markdown(source.file), source.section).links.map((link) => normalizeMarkdownLinkTarget(link.target, source)).filter(Boolean));
+    throw new Error(`unsupported registry source type "${source.type}"`);
+}
+export function checkRegistryRules(rules = [], options = {}) {
+    if (!rules?.length)
+        return { ok: true, results: [] };
+    const documents = options.documents || createDocumentReader(options);
+    const results = rules.map((rule) => {
+        try {
+            const leftEntries = readRegistrySource(rule.left, documents), rightEntries = readRegistrySource(rule.right, documents);
+            const relation = rule.kind === "left_subset_of_right" ? "left_subset" : rule.kind === "right_subset_of_left" ? "right_subset" : "equal";
+            const compared = compareSets(leftEntries, rightEntries, relation);
+            return { ok: compared.ok, rule_id: rule.id, kind: rule.kind, left_entries: leftEntries, right_entries: rightEntries,
+                missing_from_right: compared.missing, extra_in_right: compared.extra, message: compared.ok ? undefined : `registry rule "${rule.id}" failed ${rule.kind}` };
+        }
+        catch (error) {
+            return { ok: false, rule_id: rule.id, kind: rule.kind, left_entries: [], right_entries: [], missing_from_right: [], extra_in_right: [], message: `registry rule "${rule.id}" could not be evaluated`, details: [error.message] };
+        }
+    });
+    const failed = results.filter((result) => !result.ok);
+    return { ok: !failed.length, results, failed_rules: failed.map((result) => result.rule_id), details: failed.flatMap((result) => [
+            `[${result.rule_id}] ${result.message}`, `left entries: ${formatList(result.left_entries)}`, `right entries: ${formatList(result.right_entries)}`,
+            `missing from right: ${formatList(result.missing_from_right)}`, `extra in right: ${formatList(result.extra_in_right)}`, ...(result.details || []),
+        ]) };
+}

--- a/dist/checks/rules/size-rules.mjs
+++ b/dist/checks/rules/size-rules.mjs
@@ -1,0 +1,102 @@
+import { uniqueSorted } from "../../utils/collections.mjs";
+import { matchesAny, normalizePathEntry, normalizePathList } from "../../utils/path-patterns.mjs";
+import { readRepositoryBufferFile } from "../../utils/repository-files.mjs";
+import { maxBound } from "../relation-kernel.mjs";
+const changedPaths = (files, { includeDeleted = false } = {}) => normalizePathList((files || []).filter((file) => includeDeleted || file.status !== "deleted").map((file) => file.path));
+const allKnownPaths = (files, options = {}) => normalizePathList([...(options.trackedFiles || options.allFiles || []), ...changedPaths(files)]);
+function matchesRule(path, rule, options = {}) {
+    const ignored = [...(options.ignorePatterns || []), ...(rule.ignore || [])];
+    return matchesAny(path, [rule.glob || "**"]) && !(ignored.length && matchesAny(path, ignored));
+}
+const matchingPaths = (paths, rule, options) => normalizePathList(paths).filter((path) => matchesRule(path, rule, options));
+const applies = (rule, options) => !rule.applies_to_change_types || rule.applies_to_change_types.includes(options.changeType || null);
+export function countTextLines(content) {
+    if (!content.length)
+        return 0;
+    const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    const lines = (normalized.match(/\n/g) || []).length + 1;
+    return normalized.endsWith("\n") ? lines - 1 : lines;
+}
+function measureFile(path, metric, options) {
+    if (metric === "files")
+        return { skipped: false, actual: 1 };
+    const content = readRepositoryBufferFile(path, options);
+    if (content === null)
+        return { skipped: true, actual: 0 };
+    return { skipped: false, actual: metric === "bytes" ? content.length : countTextLines(content.toString("utf-8")) };
+}
+function measureDirectory(paths, rule, options) {
+    if (rule.metric === "files")
+        return paths.length;
+    return paths.reduce((sum, path) => { const measured = measureFile(path, rule.metric, options); return sum + (measured.skipped ? 0 : measured.actual); }, 0);
+}
+function directoryPath(glob) {
+    const normalized = normalizePathEntry(glob).replace(/\\/g, "/"), stable = [];
+    for (const part of normalized.split("/").filter(Boolean)) {
+        if (/[*?[\]{}()]/.test(part))
+            break;
+        stable.push(part);
+    }
+    return stable.length ? stable.join("/") : (normalized || ".");
+}
+function growth(files, rule, options) {
+    if (rule.max_growth === undefined)
+        return null;
+    if (rule.scope !== "directory")
+        throw new Error("max_growth is supported only for directory size rules");
+    if (rule.metric === "bytes")
+        throw new Error("max_growth for bytes is not supported; use an absolute byte max together with line/file growth");
+    return (files || []).reduce((delta, file) => {
+        if (!matchesRule(file.path, rule, options))
+            return delta;
+        if (rule.metric === "files")
+            return delta + (file.status === "added" ? 1 : file.status === "deleted" ? -1 : 0);
+        return delta + (file.addedLines?.length || 0) - (file.deletedLines?.length || 0);
+    }, 0);
+}
+function formatViolation(v) {
+    return v.kind === "growth"
+        ? `[${v.ruleId}] ${v.path} changed ${v.metric}: ${v.before} -> ${v.after} (delta ${v.delta}, max growth ${v.maxGrowth})`
+        : `[${v.ruleId}] ${v.path} has ${v.actual} ${v.metric} (max ${v.max})`;
+}
+export function checkSizeRules(files, rules = [], options = {}) {
+    const blocking = [], advisory = [], errors = [], growthReports = [];
+    const allPaths = allKnownPaths(files, options), changed = changedPaths(files), changedAll = changedPaths(files, { includeDeleted: true });
+    for (const rule of rules || []) {
+        if (!applies(rule, options))
+            continue;
+        const count = rule.count || "all_tracked", level = rule.level || "blocking";
+        const fail = (violation) => (level === "advisory" ? advisory : blocking).push(violation);
+        try {
+            if (rule.scope === "file") {
+                if (rule.metric === "files")
+                    throw new Error("metric=files is supported only for directory size rules");
+                for (const path of matchingPaths(count === "changed_only" ? changed : allPaths, rule, options)) {
+                    const measured = measureFile(path, rule.metric, options);
+                    if (!measured.skipped && !maxBound(measured.actual, rule.max))
+                        fail({ ruleId: rule.id, rule_id: rule.id, kind: "absolute", scope: "file", path, metric: rule.metric, actual: measured.actual, max: rule.max, count, level });
+                }
+            }
+            else if (rule.scope === "directory") {
+                if (count === "changed_only" && !matchingPaths(changedAll, rule, options).length)
+                    continue;
+                const paths = matchingPaths(allPaths, rule, options), actual = measureDirectory(paths, rule, options), path = directoryPath(rule.glob);
+                if (!maxBound(actual, rule.max))
+                    fail({ ruleId: rule.id, rule_id: rule.id, kind: "absolute", scope: "directory", path, metric: rule.metric, actual, max: rule.max, count, level, files: paths });
+                const delta = growth(files, rule, options);
+                if (delta !== null) {
+                    const report = { ruleId: rule.id, rule_id: rule.id, scope: "directory", path, metric: rule.metric, before: actual - delta, after: actual, delta, maxGrowth: rule.max_growth, max_growth: rule.max_growth, level };
+                    growthReports.push(report);
+                    if (!maxBound(delta, rule.max_growth))
+                        fail({ ...report, kind: "growth" });
+                }
+            }
+        }
+        catch (error) {
+            errors.push(`[${rule.id}] ${error.message}`);
+        }
+    }
+    const failedRules = uniqueSorted([...blocking.map((v) => v.ruleId), ...(errors.length ? ["read-errors"] : [])]);
+    return { ok: !blocking.length && !errors.length, size_violations: blocking, advisory_violations: advisory, failed_rules: failedRules,
+        details: blocking.map(formatViolation), advisory_details: advisory.map(formatViolation), errors, growth: growthReports };
+}

--- a/dist/checks/trace-rules.mjs
+++ b/dist/checks/trace-rules.mjs
@@ -1,0 +1,84 @@
+import { uniqueSorted } from "../utils/collections.mjs";
+import { matchesAny } from "../utils/path-patterns.mjs";
+import { compareSets, implies } from "./relation-kernel.mjs";
+const CHANGE_INTENT_ANCHOR_FIELDS = new Map([
+    ["anchors.affects", ["anchors", "affects"]], ["anchors.implements", ["anchors", "implements"]], ["anchors.verifies", ["anchors", "verifies"]],
+]);
+const location = (instance) => `${instance.file}${instance.line ? `:${instance.line}` : ""}${instance.column ? `:${instance.column}` : ""}`;
+function group(instances = []) {
+    const grouped = new Map();
+    for (const instance of instances)
+        (grouped.get(instance.value) || grouped.set(instance.value, []).get(instance.value)).push({ ...instance });
+    return grouped;
+}
+const changedPaths = (facts) => (facts.diff?.files?.checked || []).map((file) => file.path);
+const matchingPaths = (paths, patterns) => uniqueSorted(paths.filter((path) => matchesAny(path, patterns || [])));
+function changeIntentValues(changeIntent, field) {
+    const path = CHANGE_INTENT_ANCHOR_FIELDS.get(field);
+    if (!path)
+        return [];
+    let value = changeIntent || {};
+    for (const segment of path)
+        value = value?.[segment];
+    return Array.isArray(value) ? uniqueSorted(value.map(String)) : [];
+}
+function mustResolve(rule, anchors) {
+    const fromInstances = anchors.byType?.[rule.from_anchor_type] || [], toInstances = anchors.byType?.[rule.to_anchor_type] || [];
+    const from = group(fromInstances), to = group(toInstances), values = [...from.keys()].sort();
+    const relation = compareSets(values, [...to.keys()], "left_subset");
+    const unresolved = relation.missing.map((value) => ({ value, instances: from.get(value) }));
+    const resolved = values.filter((value) => !relation.missing.includes(value)).map((value) => ({ value, from: from.get(value), to: to.get(value) || [] }));
+    return { id: rule.id, kind: rule.kind, fromAnchorType: rule.from_anchor_type, toAnchorType: rule.to_anchor_type, ok: relation.ok, resolved, unresolved,
+        stats: { fromInstances: fromInstances.length, fromValues: from.size, toInstances: toInstances.length, toValues: to.size, resolved: resolved.length, unresolved: unresolved.length } };
+}
+function evidence(rule, facts, declared = null) {
+    const paths = changedPaths(facts), evidenceFiles = matchingPaths(paths, rule.must_touch_any);
+    const trigger = declared ?? matchingPaths(paths, rule.if_changed);
+    const common = { id: rule.id, kind: rule.kind, ok: implies(trigger.length, evidenceFiles.length), mustTouchAny: [...(rule.must_touch_any || [])], evidenceFiles };
+    return declared === null
+        ? { ...common, ifChanged: [...(rule.if_changed || [])], changedFiles: trigger, stats: { changedFiles: trigger.length, evidenceFiles: evidenceFiles.length } }
+        : { ...common, changeIntentField: rule.change_intent_field, declaredAnchors: trigger, stats: { declaredAnchors: trigger.length, evidenceFiles: evidenceFiles.length } };
+}
+export function buildTraceRuleDiagnostics(facts) {
+    return (facts.policy.trace_rules || []).map((rule) => {
+        if (rule.kind === "must_resolve")
+            return mustResolve(rule, facts.anchors || {});
+        if (rule.kind === "changed_files_require_evidence")
+            return evidence(rule, facts);
+        if (rule.kind === "declared_anchors_require_evidence")
+            return evidence(rule, facts, changeIntentValues(facts.changeIntent, rule.change_intent_field));
+        return { id: rule.id, kind: rule.kind, ok: true, stats: {} };
+    });
+}
+function checkMustResolve(result) {
+    const unresolved = (result.unresolved || []).map((item) => ({
+        value: item.value, fromAnchorType: result.fromAnchorType, toAnchorType: result.toAnchorType,
+        locations: (item.instances || []).map(location), instances: item.instances || [],
+    }));
+    return {
+        ok: !unresolved.length, message: unresolved.length ? `unresolved anchor reference(s) for trace rule "${result.id}"` : undefined,
+        trace_rule: result.id, trace_kind: result.kind, from_anchor_type: result.fromAnchorType, to_anchor_type: result.toAnchorType,
+        unresolved_anchors: unresolved, files: uniqueSorted(unresolved.flatMap((anchor) => anchor.instances.map((instance) => instance.file))),
+        details: unresolved.flatMap((anchor) => anchor.locations.map((where) => `${anchor.value} (${anchor.fromAnchorType} -> ${anchor.toAnchorType}) at ${where}`)),
+    };
+}
+function checkEvidence(result) {
+    const details = [];
+    if (result.changedFiles)
+        details.push(`changed_files: ${result.changedFiles.join(", ")}`);
+    if (result.changeIntentField)
+        details.push(`change_intent_field: ${result.changeIntentField}`);
+    if (result.declaredAnchors)
+        details.push(`declared_anchors: ${result.declaredAnchors.join(", ")}`);
+    details.push(`must_touch_any: ${result.mustTouchAny.join(", ")}`, `evidence_files: ${result.evidenceFiles.length ? result.evidenceFiles.join(", ") : "(none)"}`);
+    return { ok: result.ok, message: result.ok ? undefined : `missing evidence for trace rule "${result.id}"`, trace_rule: result.id, trace_kind: result.kind,
+        if_changed: result.ifChanged, must_touch_any: result.mustTouchAny, changed_files: result.changedFiles, change_intent_field: result.changeIntentField,
+        declared_anchors: result.declaredAnchors, evidence_files: result.evidenceFiles, files: uniqueSorted([...(result.changedFiles || []), ...(result.evidenceFiles || [])]), details };
+}
+export function checkTraceRuleResult(result) {
+    if (result.kind === "must_resolve")
+        return checkMustResolve(result);
+    if (["changed_files_require_evidence", "declared_anchors_require_evidence"].includes(result.kind))
+        return checkEvidence(result);
+    return { ok: true, trace_rule: result.id, trace_kind: result.kind, details: [] };
+}

--- a/dist/diff/classification.mjs
+++ b/dist/diff/classification.mjs
@@ -1,0 +1,52 @@
+import { uniqueSorted } from "../utils/collections.mjs";
+import { matchesAny } from "../utils/path-patterns.mjs";
+function statusAllowed(file, statuses) {
+    return !statuses || statuses.includes(file.status);
+}
+export function selectPaths(files, patterns = [], options = {}) {
+    const { statuses = null, excludeStatuses = [] } = options;
+    return uniqueSorted(files
+        .filter((file) => statusAllowed(file, statuses) && !excludeStatuses.includes(file.status))
+        .filter((file) => matchesAny(file.path, patterns || []))
+        .map((file) => file.path));
+}
+export function classifyPathSets(files, selectors = {}, options = {}) {
+    const candidates = files.filter((file) => statusAllowed(file, options.statuses || null) && !(options.excludeStatuses || []).includes(file.status));
+    const selectedPaths = uniqueSorted(candidates.map((file) => file.path));
+    const filesBySelector = {};
+    const selectorsByFile = {};
+    for (const [name, patterns] of Object.entries(selectors || {})) {
+        const matched = selectPaths(candidates, patterns);
+        if (matched.length === 0)
+            continue;
+        filesBySelector[name] = matched;
+        for (const path of matched)
+            (selectorsByFile[path] ||= []).push(name);
+    }
+    for (const names of Object.values(selectorsByFile))
+        names.sort();
+    return {
+        selected_paths: selectedPaths,
+        touched_selectors: Object.keys(filesBySelector).sort(),
+        files_by_selector: filesBySelector,
+        selectors_by_file: selectorsByFile,
+        unclassified_files: selectedPaths.filter((path) => !selectorsByFile[path]),
+    };
+}
+export function detectTouchedSurfaces(files, surfaces = {}) {
+    const selected = classifyPathSets(files, surfaces);
+    return {
+        touched_surfaces: selected.touched_selectors,
+        files_by_surface: selected.files_by_selector,
+        unclassified_files: selected.unclassified_files,
+    };
+}
+export function classifyNewFiles(files, classes = {}) {
+    const selected = classifyPathSets(files, classes, { statuses: ["added"] });
+    return {
+        new_files: selected.selected_paths,
+        files_by_class: selected.files_by_selector,
+        class_by_file: selected.selectors_by_file,
+        unclassified_files: selected.unclassified_files,
+    };
+}

--- a/dist/diff/filters.mjs
+++ b/dist/diff/filters.mjs
@@ -1,0 +1,6 @@
+import { matchesAny } from "../utils/path-patterns.mjs";
+export function filterOperationalPaths(files, operationalPaths) {
+    if (!operationalPaths || operationalPaths.length === 0)
+        return files;
+    return files.filter((file) => !matchesAny(file.path, operationalPaths));
+}

--- a/dist/diff/growth.mjs
+++ b/dist/diff/growth.mjs
@@ -1,0 +1,12 @@
+export function calculateDiffGrowth(files) {
+    const newFiles = files.filter((file) => file.status === "added").map((file) => file.path);
+    let netAddedLines = 0;
+    for (const file of files) {
+        netAddedLines += file.addedLines.length - (file.deletedLines ? file.deletedLines.length : 0);
+    }
+    return {
+        new_files: newFiles.length,
+        new_files_list: newFiles,
+        net_added_lines: netAddedLines,
+    };
+}

--- a/dist/diff/parser.mjs
+++ b/dist/diff/parser.mjs
@@ -1,0 +1,30 @@
+export function parseDiff(diffText) {
+    const files = [];
+    let current = null;
+    for (const line of diffText.split("\n")) {
+        if (line.startsWith("diff --git")) {
+            if (current)
+                files.push(current);
+            const match = line.match(/diff --git a\/.+ b\/(.+)/);
+            current = { path: match ? match[1] : "", addedLines: [], deletedLines: [], status: "modified" };
+            continue;
+        }
+        if (!current)
+            continue;
+        if (line.startsWith("new file")) {
+            current.status = "added";
+        }
+        else if (line.startsWith("deleted file")) {
+            current.status = "deleted";
+        }
+        else if (line.startsWith("+") && !line.startsWith("+++")) {
+            current.addedLines.push(line.slice(1));
+        }
+        else if (line.startsWith("-") && !line.startsWith("---")) {
+            current.deletedLines.push(line.slice(1));
+        }
+    }
+    if (current)
+        files.push(current);
+    return files;
+}

--- a/dist/doctor.mjs
+++ b/dist/doctor.mjs
@@ -1,0 +1,239 @@
+import { readFileSync, existsSync, statSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import Ajv from "ajv";
+import { compileAnchorPolicy, compileForbidRegex, compileIntegrationPolicy } from "./policy-compiler.mjs";
+import { resolvePolicyProfile } from "./policy-profiles.mjs";
+const PASS = "PASS";
+const WARN = "WARN";
+const FAIL = "FAIL";
+function check(name, fn) {
+    try {
+        return fn();
+    }
+    catch (e) {
+        return { name, status: FAIL, message: e.message, hint: "Unexpected error during check" };
+    }
+}
+function checkRepoRoot(repoRoot) {
+    return check("repository-root", () => {
+        if (!existsSync(repoRoot)) {
+            return { name: "repository-root", status: FAIL, message: `Path does not exist: ${repoRoot}`, hint: "Pass a valid path via --repo-root or run from inside a repository" };
+        }
+        const stat = statSync(repoRoot);
+        if (!stat.isDirectory()) {
+            return { name: "repository-root", status: FAIL, message: `Not a directory: ${repoRoot}`, hint: "Pass a directory path via --repo-root" };
+        }
+        return { name: "repository-root", status: PASS, message: repoRoot };
+    });
+}
+function checkGit(repoRoot) {
+    return check("git-available", () => {
+        try {
+            const version = execFileSync("git", ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim();
+            const isRepo = existsSync(resolve(repoRoot, ".git"));
+            if (!isRepo) {
+                return { name: "git-available", status: WARN, message: `${version} (not a git repository at ${repoRoot})`, hint: "Run 'git init' or check --repo-root points to a git repository" };
+            }
+            return { name: "git-available", status: PASS, message: version };
+        }
+        catch {
+            return { name: "git-available", status: FAIL, message: "git CLI not found", hint: "Install git: https://git-scm.com/downloads" };
+        }
+    });
+}
+function checkFetchDepth(repoRoot) {
+    return check("fetch-depth", () => {
+        try {
+            const isShallow = execFileSync("git", ["rev-parse", "--is-shallow-repository"], { encoding: "utf-8", cwd: repoRoot, stdio: "pipe" }).trim();
+            if (isShallow === "true") {
+                let count;
+                try {
+                    count = execFileSync("git", ["rev-list", "--count", "HEAD"], { encoding: "utf-8", cwd: repoRoot, stdio: "pipe" }).trim();
+                }
+                catch {
+                    count = "unknown";
+                }
+                return { name: "fetch-depth", status: WARN, message: `Shallow clone detected (${count} commit(s) available)`, hint: "Use 'fetch-depth: 0' in actions/checkout to enable full diff analysis" };
+            }
+            return { name: "fetch-depth", status: PASS, message: "Full history available" };
+        }
+        catch {
+            return { name: "fetch-depth", status: WARN, message: "Unable to determine fetch depth (not a git repository?)", hint: "Ensure this is a git repository with at least one commit" };
+        }
+    });
+}
+function checkPolicyDiscovery(repoRoot, packageRoot) {
+    return check("repo-policy.json", () => {
+        const policyPath = resolve(repoRoot, "repo-policy.json");
+        if (!existsSync(policyPath)) {
+            return { name: "repo-policy.json", status: FAIL, message: `Not found at ${policyPath}`, hint: "Create repo-policy.json or run 'repo-guard init' to scaffold one" };
+        }
+        let policy;
+        try {
+            policy = JSON.parse(readFileSync(policyPath, "utf-8"));
+        }
+        catch (e) {
+            return { name: "repo-policy.json", status: FAIL, message: `Parse error: ${e.message}`, hint: "Fix JSON syntax in repo-policy.json" };
+        }
+        const schemaPath = resolve(packageRoot, "schemas/repo-policy.schema.json");
+        if (!existsSync(schemaPath)) {
+            return { name: "repo-policy.json", status: FAIL, message: "Policy schema not found at package root", hint: "Reinstall repo-guard — schema files are missing" };
+        }
+        const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
+        const ajv = new Ajv({ allErrors: true });
+        const valid = ajv.validate(schema, policy);
+        if (!valid) {
+            const errors = ajv.errors.map(e => `${e.instancePath || "/"} ${e.message}`).join("; ");
+            const integrationErrors = compileIntegrationPolicy(policy);
+            const integrationDetails = integrationErrors.length > 0
+                ? `; Invalid integration policy: ${integrationErrors.map(e => e.message).join("; ")}`
+                : "";
+            return { name: "repo-policy.json", status: FAIL, message: `Schema validation failed: ${errors}${integrationDetails}`, hint: "Fix the policy to match the schema — see schemas/repo-policy.schema.json" };
+        }
+        const profileResult = resolvePolicyProfile(policy);
+        if (!profileResult.ok) {
+            const details = profileResult.errors.map(e => e.message).join("; ");
+            return { name: "repo-policy.json", status: FAIL, message: `Invalid profile policy: ${details}`, hint: "Fix profile and profile_overrides in repo-policy.json" };
+        }
+        const effectivePolicy = profileResult.policy;
+        const regexErrors = compileForbidRegex(effectivePolicy.content_rules || []);
+        if (regexErrors.length > 0) {
+            const details = regexErrors.map(e => `[${e.rule_id}] /${e.pattern}/: ${e.message}`).join("; ");
+            return { name: "repo-policy.json", status: FAIL, message: `Invalid forbid_regex: ${details}`, hint: "Fix the regular expressions in content_rules" };
+        }
+        const anchorErrors = compileAnchorPolicy(effectivePolicy);
+        if (anchorErrors.length > 0) {
+            const details = anchorErrors.map(e => e.message).join("; ");
+            return { name: "repo-policy.json", status: FAIL, message: `Invalid anchor policy: ${details}`, hint: "Fix anchors and trace_rules references in repo-policy.json" };
+        }
+        const integrationErrors = compileIntegrationPolicy(effectivePolicy);
+        if (integrationErrors.length > 0) {
+            const details = integrationErrors.map(e => e.message).join("; ");
+            return { name: "repo-policy.json", status: FAIL, message: `Invalid integration policy: ${details}`, hint: "Fix integration ids, kinds, roles, required fields, and profile references in repo-policy.json" };
+        }
+        const profileSuffix = effectivePolicy.profile ? `, profile ${effectivePolicy.profile}` : "";
+        return { name: "repo-policy.json", status: PASS, message: `Valid (${effectivePolicy.repository_kind}, format ${effectivePolicy.policy_format_version}${profileSuffix})` };
+    });
+}
+function checkEventContext() {
+    return check("event-context", () => {
+        const eventPath = process.env.GITHUB_EVENT_PATH;
+        if (!eventPath) {
+            return { name: "event-context", status: WARN, message: "GITHUB_EVENT_PATH not set (not in GitHub Actions)", hint: "This is expected when running locally; check-pr requires GitHub Actions context" };
+        }
+        if (!existsSync(eventPath)) {
+            return { name: "event-context", status: FAIL, message: `GITHUB_EVENT_PATH set but file not found: ${eventPath}`, hint: "The event file should be created by GitHub Actions — check runner configuration" };
+        }
+        let event;
+        try {
+            event = JSON.parse(readFileSync(eventPath, "utf-8"));
+        }
+        catch (e) {
+            return { name: "event-context", status: FAIL, message: `Event file parse error: ${e.message}`, hint: "The event file is corrupt — check runner configuration" };
+        }
+        if (!event.pull_request) {
+            return { name: "event-context", status: WARN, message: "Event file present but not a pull_request event", hint: "check-pr requires a pull_request trigger; other triggers are fine for check-diff" };
+        }
+        const pr = event.pull_request;
+        const hasSHAs = pr.base?.sha && pr.head?.sha;
+        if (!hasSHAs) {
+            return { name: "event-context", status: FAIL, message: "pull_request event missing base/head SHA", hint: "Ensure the workflow trigger includes the pull_request event with SHA context" };
+        }
+        return { name: "event-context", status: PASS, message: `PR #${pr.number} (${pr.base.sha.slice(0, 7)}..${pr.head.sha.slice(0, 7)})` };
+    });
+}
+function checkAuth() {
+    return check("auth-token", () => {
+        const ghToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+        if (!ghToken) {
+            try {
+                execFileSync("gh", ["auth", "status"], { encoding: "utf-8", stdio: "pipe" });
+                return { name: "auth-token", status: PASS, message: "gh CLI authenticated (no explicit token)" };
+            }
+            catch {
+                return { name: "auth-token", status: WARN, message: "No GH_TOKEN/GITHUB_TOKEN and gh CLI not authenticated", hint: "Set GH_TOKEN or GITHUB_TOKEN, or run 'gh auth login'. Auth is only required when check-pr falls back to linked-issue ChangeIntent" };
+            }
+        }
+        return { name: "auth-token", status: PASS, message: "Token present via environment" };
+    });
+}
+function checkGhCli() {
+    return check("gh-cli", () => {
+        try {
+            const version = execFileSync("gh", ["--version"], { encoding: "utf-8", stdio: "pipe" }).trim().split("\n")[0];
+            return { name: "gh-cli", status: PASS, message: version };
+        }
+        catch {
+            return { name: "gh-cli", status: WARN, message: "gh CLI not found", hint: "Install gh CLI if check-pr must fall back to a linked issue: https://cli.github.com/" };
+        }
+    });
+}
+function checkWorkflowConfig(repoRoot) {
+    return check("workflow-config", () => {
+        const workflowDir = resolve(repoRoot, ".github/workflows");
+        if (!existsSync(workflowDir)) {
+            return { name: "workflow-config", status: WARN, message: "No .github/workflows/ directory found", hint: "Run 'repo-guard init' to generate a workflow, or create one manually" };
+        }
+        const files = readdirSync(workflowDir).filter(f => f.endsWith(".yml") || f.endsWith(".yaml"));
+        if (files.length === 0) {
+            return { name: "workflow-config", status: WARN, message: "No YAML workflow files in .github/workflows/", hint: "Run 'repo-guard init' to generate a workflow" };
+        }
+        let repoGuardFound = false;
+        let fetchDepthOk = false;
+        let ghTokenOk = false;
+        for (const file of files) {
+            const content = readFileSync(resolve(workflowDir, file), "utf-8");
+            if (content.includes("repo-guard") || content.includes("check-pr")) {
+                repoGuardFound = true;
+                if (/fetch-depth\s*:\s*0/.test(content))
+                    fetchDepthOk = true;
+                if (/GH_TOKEN|GITHUB_TOKEN/.test(content))
+                    ghTokenOk = true;
+            }
+        }
+        if (!repoGuardFound) {
+            return { name: "workflow-config", status: WARN, message: "No workflow references repo-guard or check-pr", hint: "Add a repo-guard workflow — run 'repo-guard init' or see templates/example-workflow.yml" };
+        }
+        const issues = [];
+        if (!fetchDepthOk)
+            issues.push("missing 'fetch-depth: 0' (required for full diff)");
+        if (!ghTokenOk)
+            issues.push("missing GH_TOKEN/GITHUB_TOKEN env (required for issue fallback)");
+        if (issues.length > 0) {
+            return { name: "workflow-config", status: WARN, message: `Workflow found but: ${issues.join("; ")}`, hint: "Compare your workflow with templates/example-workflow.yml" };
+        }
+        return { name: "workflow-config", status: PASS, message: "Workflow configured with fetch-depth: 0 and token" };
+    });
+}
+export function runDoctor(roots) {
+    console.log("repo-guard doctor\n");
+    const results = [];
+    results.push(checkRepoRoot(roots.repoRoot));
+    results.push(checkGit(roots.repoRoot));
+    results.push(checkFetchDepth(roots.repoRoot));
+    results.push(checkPolicyDiscovery(roots.repoRoot, roots.packageRoot));
+    results.push(checkEventContext());
+    results.push(checkAuth());
+    results.push(checkGhCli());
+    results.push(checkWorkflowConfig(roots.repoRoot));
+    let passes = 0;
+    let warns = 0;
+    let fails = 0;
+    for (const r of results) {
+        const icon = r.status === PASS ? PASS : r.status === WARN ? WARN : FAIL;
+        console.log(`  ${icon}: ${r.name}`);
+        console.log(`    ${r.message}`);
+        if (r.hint) {
+            console.log(`    hint: ${r.hint}`);
+        }
+        if (r.status === PASS)
+            passes++;
+        else if (r.status === WARN)
+            warns++;
+        else
+            fails++;
+    }
+    console.log(`\nSummary: ${passes} passed, ${warns} warnings, ${fails} failed`);
+    return { results, passes, warns, fails };
+}

--- a/dist/document-facts.mjs
+++ b/dist/document-facts.mjs
@@ -1,0 +1,93 @@
+import { parseDocument } from "yaml";
+import { readRepositoryTextFile } from "./utils/repository-files.mjs";
+function collapseMessage(message) {
+    return String(message || "").replace(/\s+/g, " ").trim();
+}
+export function parseYaml(content) {
+    const doc = parseDocument(content, { prettyErrors: false });
+    if (doc.errors.length)
+        throw new Error(`invalid YAML: ${doc.errors.map((e) => collapseMessage(e.message)).join("; ")}`);
+    return doc.toJSON();
+}
+export function parseJson(content) {
+    return JSON.parse(content);
+}
+export function stripMarkdownInline(line) {
+    return line.replace(/`[^`]*`/g, "").replace(/\]\([^)]*\)/g, "]").replace(/https?:\/\/\S+/g, "");
+}
+export function parseMarkdown(content) {
+    const lines = String(content || "").split(/\r?\n/);
+    const headings = [];
+    const codeBlocks = [];
+    const proseLines = [];
+    const links = [];
+    const errors = [];
+    let fence = null;
+    for (const [offset, line] of lines.entries()) {
+        const lineNumber = offset + 1;
+        if (!fence) {
+            const opening = line.match(/^([ \t]*)(`{3,}|~{3,})(.*)$/);
+            if (opening) {
+                fence = {
+                    indent: opening[1], marker: opening[2][0], length: opening[2].length,
+                    infoString: opening[3].trim(), startLine: lineNumber, contentLines: [],
+                };
+                continue;
+            }
+            const heading = line.match(/^[ \t]{0,3}(#{1,6})(?:[ \t]+|$)(.*)$/);
+            if (heading) {
+                const text = heading[2].replace(/[ \t]+#+[ \t]*$/, "").trim();
+                if (text)
+                    headings.push({ level: heading[1].length, text, line: lineNumber });
+            }
+            for (const match of line.matchAll(/\[[^\]]+\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)) {
+                links.push({ target: match[1], line: lineNumber, column: match.index + 1 });
+            }
+            proseLines.push({ line: lineNumber, text: line });
+            continue;
+        }
+        const closing = line.match(/^[ \t]*(`{3,}|~{3,})[ \t]*$/);
+        if (closing && closing[1][0] === fence.marker && closing[1].length >= fence.length) {
+            const language = fence.infoString.split(/\s+/).filter(Boolean)[0] || "";
+            codeBlocks.push({ language, infoString: fence.infoString, startLine: fence.startLine, endLine: lineNumber, content: fence.contentLines.join("\n") });
+            fence = null;
+        }
+        else {
+            fence.contentLines.push(fence.indent && line.startsWith(fence.indent) ? line.slice(fence.indent.length) : line);
+        }
+    }
+    if (fence)
+        errors.push({ message: `unclosed Markdown fence starting at line ${fence.startLine}` });
+    return { lines, headings, codeBlocks, proseLines, links, errors };
+}
+export function markdownSection(markdown, section) {
+    const heading = markdown.headings.find((item) => item.text.toLowerCase() === section.trim().toLowerCase());
+    if (!heading)
+        throw new Error(`markdown section "${section}" not found`);
+    const end = markdown.headings.find((item) => item.line > heading.line && item.level <= heading.level)?.line || markdown.lines.length + 1;
+    return {
+        startLine: heading.line + 1, endLine: end - 1,
+        lines: markdown.lines.slice(heading.line, end - 1),
+        links: markdown.links.filter((link) => link.line > heading.line && link.line < end),
+    };
+}
+export function createDocumentReader(options = {}) {
+    const textCache = new Map();
+    const parsed = { markdown: new Map(), json: new Map(), yaml: new Map() };
+    const text = (path) => {
+        if (!textCache.has(path))
+            textCache.set(path, readRepositoryTextFile(path, options));
+        return textCache.get(path);
+    };
+    const cached = (kind, path, parser) => {
+        if (!parsed[kind].has(path))
+            parsed[kind].set(path, parser(text(path)));
+        return parsed[kind].get(path);
+    };
+    return {
+        text,
+        markdown: (path) => cached("markdown", path, parseMarkdown),
+        json: (path) => cached("json", path, parseJson),
+        yaml: (path) => cached("yaml", path, parseYaml),
+    };
+}

--- a/dist/enforcement.mjs
+++ b/dist/enforcement.mjs
@@ -1,0 +1,26 @@
+const MODE_ALIASES = new Map([
+    ["advisory", "advisory"],
+    ["warn", "advisory"],
+    ["blocking", "blocking"],
+    ["enforce", "blocking"],
+]);
+export function normalizeEnforcementMode(value, label = "enforcement") {
+    const raw = String(value || "").trim().toLowerCase();
+    const mode = MODE_ALIASES.get(raw);
+    if (!mode) {
+        return {
+            ok: false,
+            message: `Unknown ${label}: ${value}. Must be one of: advisory, warn, blocking, enforce.`,
+        };
+    }
+    return { ok: true, mode };
+}
+export function resolveEnforcementMode({ cliValue, policy }) {
+    const policyValue = policy?.enforcement?.mode;
+    const raw = cliValue || policyValue || "blocking";
+    const source = cliValue ? "cli" : policyValue ? "policy" : "default";
+    const result = normalizeEnforcementMode(raw, "enforcement mode");
+    if (!result.ok)
+        return result;
+    return { ok: true, mode: result.mode, source, requested: raw };
+}

--- a/dist/extractors/anchors.mjs
+++ b/dist/extractors/anchors.mjs
@@ -1,0 +1,115 @@
+import { parseJson } from "../document-facts.mjs";
+import { uniqueSorted } from "../utils/collections.mjs";
+import { matchesAny } from "../utils/path-patterns.mjs";
+import { readRepositoryTextFile } from "../utils/repository-files.mjs";
+function candidateAnchorFiles(options) {
+    const changed = (options.changedFiles || []).filter((file) => file.status !== "deleted").map((file) => file.path);
+    return uniqueSorted([...(options.trackedFiles || []), ...changed].filter(Boolean));
+}
+function buildLineStarts(content) {
+    const starts = [0];
+    for (let i = 0; i < content.length; i++)
+        if (content[i] === "\n")
+            starts.push(i + 1);
+    return starts;
+}
+function positionAt(starts, index) {
+    let low = 0;
+    let high = starts.length - 1;
+    while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        if (starts[mid] <= index)
+            low = mid + 1;
+        else
+            high = mid - 1;
+    }
+    const lineIndex = Math.max(0, high);
+    return { line: lineIndex + 1, column: index - starts[lineIndex] + 1 };
+}
+function makeRegex(pattern) {
+    const compiled = new RegExp(pattern);
+    let flags = compiled.flags;
+    for (const flag of ["g", "d"])
+        if (!flags.includes(flag))
+            flags += flag;
+    return new RegExp(compiled.source, flags);
+}
+function extractRegexAnchors(anchorType, source, file, content) {
+    const instances = [];
+    const starts = buildLineStarts(content);
+    for (const match of content.matchAll(makeRegex(source.pattern))) {
+        let captureGroup = null;
+        for (let i = 1; i < match.length; i++)
+            if (match[i] !== undefined) {
+                captureGroup = i;
+                break;
+            }
+        const value = captureGroup ? match[captureGroup] : match[0];
+        const index = captureGroup && match.indices?.[captureGroup] ? match.indices[captureGroup][0] : match.index;
+        const position = positionAt(starts, index);
+        const instance = { anchorType, value: String(value), file, sourceKind: "regex", ...position, raw: match[0] };
+        if (captureGroup)
+            instance.captureGroup = captureGroup;
+        instances.push(instance);
+    }
+    return instances;
+}
+function extractJsonFieldAnchor(anchorType, source, file, content) {
+    let data;
+    try {
+        data = parseJson(content);
+    }
+    catch (error) {
+        throw new Error(`invalid JSON: ${error.message}`);
+    }
+    if (data === null || Array.isArray(data) || typeof data !== "object")
+        throw new Error("json_field extractor requires a top-level JSON object");
+    if (!Object.hasOwn(data, source.field))
+        throw new Error(`field "${source.field}" not found`);
+    const value = data[source.field];
+    if (value === null || typeof value === "object")
+        throw new Error(`field "${source.field}" must be a string, number, or boolean`);
+    return [{ anchorType, value: String(value), file, sourceKind: "json_field", raw: String(value) }];
+}
+function compareInstances(a, b) {
+    return a.file.localeCompare(b.file) || (a.line || 0) - (b.line || 0) || (a.column || 0) - (b.column || 0) ||
+        a.anchorType.localeCompare(b.anchorType) || a.value.localeCompare(b.value);
+}
+export function extractAnchors(policy, options = {}) {
+    const anchorTypes = policy.anchors?.types || {};
+    const files = candidateAnchorFiles(options);
+    const instances = [];
+    const errors = [];
+    const text = (file) => options.documents?.text(file) ?? readRepositoryTextFile(file, options);
+    for (const [anchorType, config] of Object.entries(anchorTypes)) {
+        for (const [sourceIndex, source] of (config.sources || []).entries()) {
+            for (const file of files.filter((path) => matchesAny(path, [source.glob]))) {
+                try {
+                    const content = text(file);
+                    if (source.kind === "regex")
+                        instances.push(...extractRegexAnchors(anchorType, source, file, content));
+                    else if (source.kind === "json_field")
+                        instances.push(...extractJsonFieldAnchor(anchorType, source, file, content));
+                    else
+                        throw new Error(`unsupported anchor source kind "${source.kind}"`);
+                }
+                catch (error) {
+                    errors.push({ anchorType, sourceKind: source.kind, sourceIndex, file, message: error.message });
+                }
+            }
+        }
+    }
+    instances.sort(compareInstances);
+    errors.sort((a, b) => (a.file || "").localeCompare(b.file || "") || a.anchorType.localeCompare(b.anchorType) || a.sourceIndex - b.sourceIndex || a.message.localeCompare(b.message));
+    const byType = Object.fromEntries(Object.keys(anchorTypes).sort().map((type) => [type, []]));
+    for (const instance of instances)
+        (byType[instance.anchorType] ||= []).push(instance);
+    return { instances, byType, errors };
+}
+export function formatAnchorExtractionError(error) {
+    return `[${error.anchorType} ${error.sourceKind} source ${error.sourceIndex}] ${error.file ? `${error.file}: ` : ""}${error.message}`;
+}
+export function checkAnchorExtraction(anchorExtraction) {
+    const errors = anchorExtraction?.errors || [];
+    return { ok: errors.length === 0, message: errors.length ? "anchor extraction failed" : undefined, errors: errors.map(formatAnchorExtractionError) };
+}

--- a/dist/extractors/integration.mjs
+++ b/dist/extractors/integration.mjs
@@ -1,0 +1,357 @@
+import { createDocumentReader, parseJson, parseMarkdown, parseYaml } from "../document-facts.mjs";
+import { uniqueSorted } from "../utils/collections.mjs";
+function isPlainObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function normalizeValue(value) {
+    if (value === undefined)
+        return "";
+    if (value === null)
+        return "null";
+    if (typeof value === "string")
+        return value;
+    if (["number", "boolean", "bigint"].includes(typeof value))
+        return String(value);
+    return JSON.stringify(value);
+}
+function normalizeMap(value) {
+    if (!isPlainObject(value))
+        return null;
+    return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a.localeCompare(b)).map(([key, item]) => [key, normalizeValue(item)]));
+}
+function extractTriggerEvents(onValue) {
+    if (typeof onValue === "string")
+        return [onValue];
+    if (Array.isArray(onValue))
+        return onValue.filter((item) => item != null).map(normalizeValue);
+    return isPlainObject(onValue) ? Object.keys(onValue) : [];
+}
+function extractTriggerEventTypes(onValue) {
+    if (!isPlainObject(onValue))
+        return [];
+    return Object.entries(onValue).flatMap(([event, config]) => {
+        if (!isPlainObject(config) || !Object.hasOwn(config, "types"))
+            return [];
+        const types = (Array.isArray(config.types) ? config.types : [config.types]).filter((item) => item != null).map(normalizeValue);
+        return types.length ? [{ event, types }] : [];
+    });
+}
+function collectEnvVars(value, scope, extra = {}) {
+    const env = normalizeMap(value);
+    return env ? Object.entries(env).map(([name, item]) => ({ scope, ...extra, name, value: item })) : [];
+}
+function detectSummaryPublishingMode(run) {
+    if (run == null || !String(run).includes("GITHUB_STEP_SUMMARY"))
+        return null;
+    const text = String(run);
+    const target = String.raw `["']?\$?\{?GITHUB_STEP_SUMMARY\}?["']?`;
+    if (new RegExp(`>>\\s*${target}`).test(text) || new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*>>`).test(text))
+        return "append";
+    if (new RegExp(`(^|[^>])>\\s*${target}`).test(text) || new RegExp(`GITHUB_STEP_SUMMARY[^\\n]*(^|[^>])>`).test(text))
+        return "write";
+    return "mentions";
+}
+function collectWorkflowFacts(entry, content) {
+    const data = parseYaml(content);
+    if (!isPlainObject(data))
+        throw new Error("workflow YAML must be a mapping");
+    const jobs = isPlainObject(data.jobs) ? data.jobs : {};
+    const actionUses = [];
+    const stepInputs = [];
+    const envVars = collectEnvVars(data.env, "workflow");
+    const ifConditions = [];
+    const runCommands = [];
+    const summaryPublishing = [];
+    const continueOnError = [];
+    const jobPermissions = [];
+    for (const [jobId, job] of Object.entries(jobs)) {
+        if (!isPlainObject(job))
+            continue;
+        const permission = normalizeMap(job.permissions);
+        if (permission || typeof job.permissions === "string")
+            jobPermissions.push({ jobId, permissions: permission || job.permissions });
+        envVars.push(...collectEnvVars(job.env, "job", { jobId }));
+        if (job.if !== undefined)
+            ifConditions.push({ scope: "job", jobId, condition: normalizeValue(job.if) });
+        if (job["continue-on-error"] !== undefined)
+            continueOnError.push({ scope: "job", jobId, value: normalizeValue(job["continue-on-error"]) });
+        if (job.uses !== undefined) {
+            const uses = normalizeValue(job.uses);
+            actionUses.push({ scope: "job", jobId, uses });
+            const inputs = normalizeMap(job.with);
+            if (inputs)
+                stepInputs.push({ scope: "job", jobId, uses, inputs });
+        }
+        if (!Array.isArray(job.steps))
+            continue;
+        for (const [offset, step] of job.steps.entries()) {
+            if (!isPlainObject(step))
+                continue;
+            const base = { jobId, stepIndex: offset + 1 };
+            if (step.name)
+                base.stepName = normalizeValue(step.name);
+            if (step.uses !== undefined) {
+                const uses = normalizeValue(step.uses);
+                actionUses.push({ ...base, uses });
+                const inputs = normalizeMap(step.with);
+                if (inputs)
+                    stepInputs.push({ ...base, uses, inputs });
+            }
+            envVars.push(...collectEnvVars(step.env, "step", base));
+            if (step.if !== undefined)
+                ifConditions.push({ scope: "step", ...base, condition: normalizeValue(step.if) });
+            if (step["continue-on-error"] !== undefined)
+                continueOnError.push({ ...base, value: normalizeValue(step["continue-on-error"]) });
+            if (step.run !== undefined)
+                runCommands.push({ ...base, run: normalizeValue(step.run) });
+            const summary = detectSummaryPublishingMode(step.run);
+            if (summary)
+                summaryPublishing.push({ ...base, mode: summary });
+        }
+    }
+    return {
+        id: entry.id, kind: entry.kind, path: entry.path, role: entry.role, expect: entry.expect || null,
+        triggerEvents: extractTriggerEvents(data.on), triggerEventTypes: extractTriggerEventTypes(data.on),
+        permissions: { workflow: normalizeMap(data.permissions) || (typeof data.permissions === "string" ? data.permissions : null), jobs: jobPermissions },
+        actionUses, stepInputs, envVars, ifConditions, runCommands, summaryPublishing, continueOnError,
+    };
+}
+function publicCodeBlock(block) {
+    return { language: block.language, infoString: block.infoString, startLine: block.startLine, endLine: block.endLine };
+}
+function fieldPathsFromObject(value, prefix = "") {
+    if (!isPlainObject(value))
+        return [];
+    return Object.keys(value).sort().flatMap((key) => {
+        const path = prefix ? `${prefix}.${key}` : key;
+        return [path, ...fieldPathsFromObject(value[key], path)];
+    });
+}
+function parseChangeIntentBlock(block) {
+    try {
+        const data = block.language === "repo-guard-json" ? parseJson(block.content) : parseYaml(block.content);
+        return { ok: true, fieldNames: isPlainObject(data) ? Object.keys(data).sort() : [], fieldPaths: uniqueSorted(fieldPathsFromObject(data)) };
+    }
+    catch (error) {
+        return { ok: false, message: `invalid ${block.language} block at line ${block.startLine}: ${error.message}` };
+    }
+}
+function extractChangeIntentBlocks(markdown) {
+    const blocks = [];
+    const errors = [];
+    for (const block of markdown.codeBlocks.filter((item) => ["repo-guard-yaml", "repo-guard-json"].includes(item.language))) {
+        const parsed = parseChangeIntentBlock(block);
+        blocks.push({
+            format: block.language, startLine: block.startLine, endLine: block.endLine, ok: parsed.ok,
+            fieldNames: parsed.fieldNames || [], fieldPaths: parsed.fieldPaths || [],
+        });
+        if (!parsed.ok)
+            errors.push({ message: parsed.message });
+    }
+    return { blocks, errors };
+}
+function templateFactFromMarkdown(entry, markdown) {
+    const { blocks, errors } = extractChangeIntentBlocks(markdown);
+    return {
+        fact: {
+            id: entry.id, kind: entry.kind, path: entry.path, present: true, optional: Boolean(entry.optional),
+            requiresChangeIntentBlock: Boolean(entry.requires_change_intent_block), requiredBlockKind: entry.required_block_kind || null,
+            requiredChangeIntentFields: entry.required_change_intent_fields || [],
+            hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
+            hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
+            changeIntentBlocks: blocks, changeIntentFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
+            headings: markdown.headings, codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+        }, errors,
+    };
+}
+function collectStringValues(value, sourcePath = "$") {
+    if (typeof value === "string")
+        return [{ sourcePath, value }];
+    if (Array.isArray(value))
+        return value.flatMap((item, index) => collectStringValues(item, `${sourcePath}[${index}]`));
+    return isPlainObject(value) ? Object.entries(value).flatMap(([key, item]) => collectStringValues(item, `${sourcePath}.${key}`)) : [];
+}
+function collectIssueFormTemplateFacts(entry, content) {
+    const blocks = [];
+    const errors = [];
+    for (const source of collectStringValues(parseYaml(content))) {
+        const markdown = parseMarkdown(source.value);
+        errors.push(...markdown.errors.map((error) => ({ message: `${source.sourcePath}: ${error.message}` })));
+        const extracted = extractChangeIntentBlocks(markdown);
+        blocks.push(...extracted.blocks.map((block) => ({ ...block, sourcePath: source.sourcePath })));
+        errors.push(...extracted.errors.map((error) => ({ message: `${source.sourcePath}: ${error.message}` })));
+    }
+    return {
+        fact: {
+            id: entry.id, kind: entry.kind, path: entry.path, present: true, optional: Boolean(entry.optional),
+            requiresChangeIntentBlock: Boolean(entry.requires_change_intent_block), requiredBlockKind: entry.required_block_kind || null,
+            requiredChangeIntentFields: entry.required_change_intent_fields || [],
+            hasRepoGuardYamlBlock: blocks.some((block) => block.format === "repo-guard-yaml"),
+            hasRepoGuardJsonBlock: blocks.some((block) => block.format === "repo-guard-json"),
+            changeIntentBlocks: blocks, changeIntentFieldNames: uniqueSorted(blocks.flatMap((block) => block.fieldPaths)),
+        }, errors,
+    };
+}
+function missingOptionalTemplateFact(entry) {
+    return {
+        id: entry.id, kind: entry.kind, path: entry.path, present: false, optional: true,
+        requiresChangeIntentBlock: Boolean(entry.requires_change_intent_block), requiredBlockKind: entry.required_block_kind || null,
+        requiredChangeIntentFields: entry.required_change_intent_fields || [], hasRepoGuardYamlBlock: false, hasRepoGuardJsonBlock: false,
+        changeIntentBlocks: [], changeIntentFieldNames: [], headings: [], codeBlocks: [],
+    };
+}
+function collectTemplateFacts(entry, content, markdown = null) {
+    if (entry.kind === "github_issue_form")
+        return collectIssueFormTemplateFacts(entry, content);
+    const parsed = markdown || parseMarkdown(content);
+    const result = templateFactFromMarkdown(entry, parsed);
+    result.errors.push(...parsed.errors);
+    return result;
+}
+function findLiteralOccurrences(content, term) {
+    if (!term)
+        return [];
+    const needle = String(term).toLowerCase();
+    const locations = [];
+    for (const [offset, line] of String(content || "").split(/\r?\n/).entries()) {
+        const haystack = line.toLowerCase();
+        let index = 0;
+        while ((index = haystack.indexOf(needle, index)) !== -1) {
+            locations.push({ line: offset + 1, column: index + 1 });
+            index += Math.max(needle.length, 1);
+        }
+    }
+    return locations;
+}
+function mentionFact(content, term) {
+    const locations = findLiteralOccurrences(content, term);
+    return { term, present: locations.length > 0, count: locations.length, locations };
+}
+function collectDocFacts(entry, content, markdown) {
+    return {
+        fact: {
+            id: entry.id, path: entry.path, headings: markdown.headings, codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+            hasCodeBlocks: markdown.codeBlocks.length > 0,
+            mentions: (entry.must_mention || []).map((term) => mentionFact(content, term)),
+            fileReferences: (entry.must_reference_files || []).map((term) => mentionFact(content, term)),
+            profileMentions: (entry.must_mention_profiles || []).map((term) => mentionFact(content, term)),
+            changeIntentFieldMentions: (entry.must_mention_change_intent_fields || []).map((term) => mentionFact(content, term)),
+        }, errors: markdown.errors,
+    };
+}
+function collectRegexFacts(content, regexes) {
+    const facts = [];
+    const seen = new Set();
+    for (const [offset, line] of String(content || "").split(/\r?\n/).entries()) {
+        for (const source of regexes) {
+            const regex = new RegExp(source.source, source.flags.includes("g") ? source.flags : `${source.flags}g`);
+            let match;
+            while ((match = regex.exec(line)) !== null) {
+                const value = match[1];
+                if (!value)
+                    continue;
+                const column = match.index + match[0].lastIndexOf(value) + 1;
+                const key = `${value}:${offset + 1}:${column}`;
+                if (!seen.has(key)) {
+                    seen.add(key);
+                    facts.push({ value, line: offset + 1, column });
+                }
+            }
+        }
+    }
+    return facts;
+}
+function profileReferenceFacts(content, profileId) {
+    const values = uniqueSorted([profileId, String(profileId || "").replace(/[-_.]+/g, " ").trim()].filter(Boolean));
+    const facts = [];
+    const seen = new Set();
+    for (const value of values) {
+        for (const location of findLiteralOccurrences(content, value)) {
+            const key = `${profileId}:${location.line}:${location.column}`;
+            if (!seen.has(key)) {
+                seen.add(key);
+                facts.push({ value: profileId, ...location });
+            }
+        }
+    }
+    return facts.sort((a, b) => a.line - b.line || a.column - b.column || a.value.localeCompare(b.value));
+}
+function collectProfileFacts(entry, content, markdown) {
+    return {
+        fact: {
+            id: entry.id, docPath: entry.doc_path, headings: markdown.headings, codeBlocks: markdown.codeBlocks.map(publicCodeBlock),
+            identifiers: collectRegexFacts(content, [
+                /\bprofile[ _-]?id\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+                /\bprofile\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+            ]),
+            migrationTargets: collectRegexFacts(content, [
+                /\bmigration[ _-]?target\b\s*[:=]\s*`?([A-Za-z0-9_.-]+)/i,
+                /\bmigrat(?:e|es|ed|ing)\s+to\s+`?([A-Za-z0-9_.-]+)/i,
+            ]),
+            profileNameReferences: profileReferenceFacts(content, entry.id),
+        }, errors: markdown.errors,
+    };
+}
+function compareErrors(a, b) {
+    return a.section.localeCompare(b.section) || (a.path || "").localeCompare(b.path || "") ||
+        (a.id || "").localeCompare(b.id || "") || a.message.localeCompare(b.message);
+}
+function withErrorContext(section, entry, message) {
+    return { section, id: entry.id, kind: entry.kind, path: entry.path || entry.doc_path, message };
+}
+function isMissingRepositoryFileError(error, entry) {
+    const message = String(error?.message || "");
+    return error?.code === "ENOENT" || message.includes("ENOENT") || message.includes("no such file or directory") ||
+        message === `cannot read ${entry.path}` || message.includes(`missing fixture ${entry.path}`);
+}
+export function extractIntegration(policy, options = {}) {
+    const integration = policy.integration;
+    const result = { workflows: [], templates: [], docs: [], profiles: [], errors: [] };
+    if (!integration)
+        return result;
+    const documents = options.documents || createDocumentReader(options);
+    for (const entry of integration.workflows || []) {
+        try {
+            result.workflows.push(collectWorkflowFacts(entry, documents.text(entry.path)));
+        }
+        catch (error) {
+            result.errors.push(withErrorContext("workflows", entry, error.message));
+        }
+    }
+    for (const entry of integration.templates || []) {
+        try {
+            const content = documents.text(entry.path);
+            const extracted = collectTemplateFacts(entry, content, entry.kind === "markdown" ? documents.markdown(entry.path) : null);
+            result.templates.push(extracted.fact);
+            result.errors.push(...extracted.errors.map((error) => withErrorContext("templates", entry, error.message)));
+        }
+        catch (error) {
+            if (entry.optional === true && isMissingRepositoryFileError(error, entry))
+                result.templates.push(missingOptionalTemplateFact(entry));
+            else
+                result.errors.push(withErrorContext("templates", entry, error.message));
+        }
+    }
+    for (const entry of integration.docs || []) {
+        try {
+            const extracted = collectDocFacts(entry, documents.text(entry.path), documents.markdown(entry.path));
+            result.docs.push(extracted.fact);
+            result.errors.push(...extracted.errors.map((error) => withErrorContext("docs", entry, error.message)));
+        }
+        catch (error) {
+            result.errors.push(withErrorContext("docs", entry, error.message));
+        }
+    }
+    for (const entry of integration.profiles || []) {
+        try {
+            const extracted = collectProfileFacts(entry, documents.text(entry.doc_path), documents.markdown(entry.doc_path));
+            result.profiles.push(extracted.fact);
+            result.errors.push(...extracted.errors.map((error) => withErrorContext("profiles", entry, error.message)));
+        }
+        catch (error) {
+            result.errors.push(withErrorContext("profiles", entry, error.message));
+        }
+    }
+    result.errors.sort(compareErrors);
+    return result;
+}

--- a/dist/facts/input.mjs
+++ b/dist/facts/input.mjs
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process";
+import { createDocumentReader } from "../document-facts.mjs";
+import { classifyNewFiles, detectTouchedSurfaces } from "../diff/classification.mjs";
+import { filterOperationalPaths } from "../diff/filters.mjs";
+import { parseDiff } from "../diff/parser.mjs";
+import { extractAnchors } from "../extractors/anchors.mjs";
+import { extractIntegration } from "../extractors/integration.mjs";
+import { readRepositoryBufferFile } from "../utils/repository-files.mjs";
+export const listTrackedFiles = (repoRoot) => execFileSync("git", ["ls-files"], { encoding: "utf-8", cwd: repoRoot }).split(/\r?\n/).filter(Boolean);
+export function buildPolicyFacts(input) {
+    const { mode = "check-diff", repositoryRoot, policy, basePolicy = null, headPolicy = null, changeIntent = null, changeIntentSource = "none", governanceGrant = null, trustedGovernancePaths = null, trustedAuthorizer = null, enforcement, diffText, trackedFiles = null, diagnostics = {}, readFile = null, } = input;
+    const allFiles = parseDiff(diffText);
+    const checkedFiles = filterOperationalPaths(allFiles, policy.paths.operational_paths);
+    const resolvedTrackedFiles = trackedFiles || listTrackedFiles(repositoryRoot), cache = new Map();
+    const cachedReadFile = (path) => {
+        if (!cache.has(path))
+            cache.set(path, readRepositoryBufferFile(path, { repoRoot: repositoryRoot, readFile }));
+        return cache.get(path);
+    };
+    const documents = createDocumentReader({ repoRoot: repositoryRoot, readFile: cachedReadFile });
+    const options = { repoRoot: repositoryRoot, trackedFiles: resolvedTrackedFiles, changedFiles: checkedFiles, readFile: cachedReadFile, documents };
+    return {
+        mode, repositoryRoot, policy, basePolicy, headPolicy, changeIntent, changeIntentSource, governanceGrant,
+        trustedGovernancePaths, trustedAuthorizer, readFile: cachedReadFile, documents,
+        enforcementMode: enforcement.mode, enforcement,
+        diff: { files: { all: allFiles, checked: checkedFiles, skippedOperational: allFiles.filter((file) => !checkedFiles.includes(file)) } },
+        anchors: extractAnchors(policy, options), integration: extractIntegration(policy, options), trackedFiles: resolvedTrackedFiles,
+        derived: {
+            changedPaths: checkedFiles.map((file) => file.path),
+            touchedSurfaces: policy.surfaces ? detectTouchedSurfaces(checkedFiles, policy.surfaces) : null,
+            newFileClasses: policy.new_file_classes ? classifyNewFiles(checkedFiles, policy.new_file_classes) : null,
+        },
+        diagnostics: { ...diagnostics, skippedOperationalFiles: allFiles.length - checkedFiles.length },
+    };
+}

--- a/dist/git.mjs
+++ b/dist/git.mjs
@@ -1,0 +1,93 @@
+import { execFileSync } from "node:child_process";
+function childProcessMessage(error) {
+    const stderr = error?.stderr?.toString?.().trim();
+    if (stderr)
+        return stderr;
+    const stdout = error?.stdout?.toString?.().trim();
+    if (stdout)
+        return stdout;
+    return error?.message || "command failed";
+}
+function gitSubcommand(args) {
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === "-c") {
+            i++;
+            continue;
+        }
+        if (!args[i].startsWith("-"))
+            return args[i];
+    }
+    return "";
+}
+export function runGit(args, options = {}) {
+    try {
+        return execFileSync("git", args, {
+            encoding: "utf-8",
+            cwd: options.cwd,
+            stdio: options.stdio || "pipe",
+        });
+    }
+    catch (error) {
+        const command = gitSubcommand(args);
+        const subcommand = command ? ` ${command}` : "";
+        throw new Error(`git${subcommand} failed: ${childProcessMessage(error)}`);
+    }
+}
+export function resolveRemoteBaseRef(baseRef, cwd, remote = "origin") {
+    if (typeof baseRef !== "string" || baseRef.length === 0) {
+        throw new Error("missing PR base ref");
+    }
+    const ref = `refs/remotes/${remote}/${baseRef}`;
+    const sha = runGit(["rev-parse", "--verify", `${ref}^{commit}`], { cwd }).trim();
+    if (!sha) {
+        throw new Error(`current base ref ${ref} resolved to an empty object id`);
+    }
+    return sha;
+}
+function diffArgs(...args) {
+    return ["-c", "core.quotepath=false", "diff", ...args];
+}
+export function getDiff(base, head, cwd) {
+    if (base && head) {
+        return runGit(diffArgs(`${base}...${head}`), { cwd });
+    }
+    const staged = runGit(diffArgs("--cached"), { cwd });
+    if (staged.trim())
+        return staged;
+    return runGit(diffArgs("HEAD"), { cwd });
+}
+export function readFileAtRef(ref, path, cwd) {
+    if (!ref || !path)
+        return null;
+    return runGit(["show", `${ref}:${path}`], { cwd });
+}
+export function readBasePolicy(base, cwd, policyPath = "repo-policy.json") {
+    if (!base)
+        return { policy: null, error: "no_base_ref" };
+    let raw;
+    try {
+        raw = readFileAtRef(base, policyPath, cwd);
+    }
+    catch (e) {
+        return { policy: null, error: `git_show_failed: ${e.message}` };
+    }
+    if (raw == null)
+        return { policy: null, error: "empty_base_policy" };
+    let parsed;
+    try {
+        parsed = JSON.parse(raw);
+    }
+    catch (e) {
+        return { policy: null, error: `base_policy_parse_error: ${e.message}` };
+    }
+    return { policy: parsed, error: null };
+}
+export function readBaseGovernancePaths(base, cwd, policyPath = "repo-policy.json") {
+    const result = readBasePolicy(base, cwd, policyPath);
+    if (result.error)
+        return { governancePaths: null, error: result.error };
+    const list = result.policy?.paths?.governance_paths;
+    if (!Array.isArray(list))
+        return { governancePaths: [], error: null };
+    return { governancePaths: list, error: null };
+}

--- a/dist/github-pr.mjs
+++ b/dist/github-pr.mjs
@@ -1,0 +1,191 @@
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { getDiff, readBasePolicy, resolveRemoteBaseRef } from "./git.mjs";
+import { extractChangeIntent, extractGovernanceGrant, extractLinkedIssueNumbers, resolveChangeIntent } from "./change-intent.mjs";
+import { resolveEnforcementMode } from "./enforcement.mjs";
+import { loadPolicyRuntime, loadPolicyRuntimeFromObject, validationCheck } from "./runtime/validation.mjs";
+import { runPolicyPipeline } from "./runtime/pipeline.mjs";
+import { resolveTrustedAuthorizer } from "./trusted-authorizer.mjs";
+const REPO = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, ISSUE = /^[1-9][0-9]*$/;
+export function loadGitHubEvent() {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath)
+        return { ok: false, error: "no_event", message: "GITHUB_EVENT_PATH not set; not running in GitHub Actions" };
+    try {
+        const event = JSON.parse(readFileSync(eventPath, "utf-8")), pr = event.pull_request;
+        if (!pr)
+            return { ok: false, error: "not_pr_event", message: "GitHub event does not contain pull_request data" };
+        return { ok: true, base: pr.base?.sha, baseRef: pr.base?.ref, head: pr.head?.sha, prBody: pr.body || "", prNumber: pr.number, repoFullName: event.repository?.full_name || process.env.GITHUB_REPOSITORY || "" };
+    }
+    catch (error) {
+        return { ok: false, error: "event_read_error", message: `Cannot read event file: ${error.message}` };
+    }
+}
+export function fetchIssueBody(repo, number) {
+    if (!REPO.test(repo) || !ISSUE.test(String(number)))
+        return null;
+    try {
+        return execFileSync("gh", ["api", `repos/${repo}/issues/${number}`, "--jq", ".body"], { encoding: "utf-8", timeout: 30000 }).trim() || null;
+    }
+    catch {
+        return null;
+    }
+}
+function cliAvailable(command) { try {
+    execFileSync(command, ["--version"], { encoding: "utf-8", stdio: "pipe" });
+    return true;
+}
+catch {
+    return false;
+} }
+export function checkPrerequisites() {
+    return [!process.env.GITHUB_EVENT_PATH && "GITHUB_EVENT_PATH env var (set automatically by GitHub Actions)", !cliAvailable("git") && "git CLI (required for diff analysis)"].filter(Boolean);
+}
+export const checkIssueFallbackPrerequisites = () => cliAvailable("gh") ? [] : ["gh CLI (required for linked issue fallback)"];
+export function resolvePRChangeIntentFacts({ prBody, issueBody = null, linkedIssueCount = null }) {
+    const linkedIssues = extractLinkedIssueNumbers(prBody), grantResult = extractGovernanceGrant(issueBody);
+    const prResult = extractChangeIntent(prBody);
+    const common = { linkedIssues, grantResult };
+    if (prResult.ok)
+        return { ok: true, changeIntent: prResult.changeIntent, changeIntentSource: "pr body", ...common };
+    if (prResult.error !== "change_intent_not_found")
+        return { ok: false, error: prResult.error, message: prResult.message, changeIntentSource: "pr body", ...common };
+    const count = linkedIssueCount ?? linkedIssues.length;
+    if (count > 1)
+        return { ok: false, error: "issue_link_ambiguous", message: `PR body references ${count} issues (${linkedIssues.map((n) => `#${n}`).join(", ")}); expected exactly one`, changeIntentSource: "none", ...common };
+    const issueResult = resolveChangeIntent(prBody, issueBody);
+    return issueResult.ok
+        ? { ok: true, changeIntent: issueResult.changeIntent, changeIntentSource: "linked issue", ...common }
+        : { ok: false, error: issueResult.error, message: issueResult.message, changeIntentSource: "none", ...common };
+}
+function loadRuntime(load, label, failure) {
+    try {
+        const runtime = load();
+        if (runtime.ok)
+            return runtime;
+    }
+    catch (error) {
+        console.error(`FAIL: ${label}\n  ${error.message}`);
+    }
+    console.error(`\n${failure}`);
+    return null;
+}
+function printMissing(title, missing) { console.error(title); for (const item of missing)
+    console.error(`  - ${item}`); }
+function fetchLinkedIssue({ prBody, repoFullName }) {
+    const linkedIssues = extractLinkedIssueNumbers(prBody), pr = extractChangeIntent(prBody);
+    const hasChangeIntent = pr.ok, needsFallback = !hasChangeIntent && pr.error === "change_intent_not_found" && linkedIssues.length === 1;
+    if (linkedIssues.length !== 1 || (!needsFallback && !hasChangeIntent))
+        return { linkedIssues, issueBody: null, fatal: false };
+    console.log(needsFallback ? `No ChangeIntent in PR body; trying linked issue #${linkedIssues[0]}...` : `Fetching linked issue #${linkedIssues[0]} for GovernanceGrant...`);
+    const missing = checkIssueFallbackPrerequisites();
+    if (missing.length) {
+        if (needsFallback) {
+            printMissing("ERROR: linked issue fallback prerequisites not met:", missing);
+            return { linkedIssues, issueBody: null, fatal: true };
+        }
+        console.warn("WARN: linked issue lookup unavailable; GovernanceGrant cannot be established");
+        return { linkedIssues, issueBody: null, fatal: false };
+    }
+    const issueBody = fetchIssueBody(repoFullName, linkedIssues[0]);
+    if (issueBody === null && hasChangeIntent)
+        console.warn(`WARN: could not fetch linked issue #${linkedIssues[0]}; GovernanceGrant unavailable`);
+    return { linkedIssues, issueBody, fatal: false };
+}
+export function runCheckPR(roots, args = []) {
+    if (args.length) {
+        console.error(`Unexpected argument for check-pr: ${args[0]}`);
+        return 1;
+    }
+    const prereqs = checkPrerequisites();
+    if (prereqs.length) {
+        printMissing("ERROR: check-pr prerequisites not met:", prereqs);
+        return 1;
+    }
+    const event = loadGitHubEvent();
+    if (!event.ok) {
+        console.error(`ERROR: ${event.message}`);
+        return 1;
+    }
+    const { base: eventBase, baseRef, head, prBody, prNumber, repoFullName } = event;
+    if (!eventBase || !head) {
+        console.error("ERROR: pull_request event missing base/head SHA");
+        return 1;
+    }
+    let base = eventBase;
+    if (baseRef) {
+        try {
+            base = resolveRemoteBaseRef(baseRef, roots.repoRoot);
+        }
+        catch (error) {
+            console.error(`ERROR: cannot resolve current PR base ref ${baseRef}: ${error.message}`);
+            return 1;
+        }
+        if (base !== eventBase)
+            console.log(`Base ref ${baseRef} advanced from event snapshot ${eventBase.slice(0, 7)} to ${base.slice(0, 7)}; using current base`);
+    }
+    console.log(`PR #${prNumber}: checking ChangeIntent and diff (${base.slice(0, 7)}..${head.slice(0, 7)})`);
+    const headRuntime = loadRuntime(() => loadPolicyRuntime(roots, { label: "repo-policy.json (PR head)" }), "repo-policy.json (PR head)", "Proposed policy compilation failed");
+    if (!headRuntime)
+        return 1;
+    const initialChecks = [], baseRead = readBasePolicy(base, roots.repoRoot);
+    let runtime = headRuntime, basePolicy = null, trustedGovernancePaths = [];
+    if (baseRead.error)
+        initialChecks.push({ name: "governance-trusted-boundary", check: { ok: false, message: `cannot establish trusted governance boundary: ${baseRead.error}`, details: [`base_ref: ${base}`] } });
+    else {
+        runtime = loadRuntime(() => loadPolicyRuntimeFromObject(roots, baseRead.policy, { label: "repo-policy.json (base)" }), "repo-policy.json (base)", "Base policy compilation failed");
+        if (!runtime)
+            return 1;
+        basePolicy = runtime.policy;
+        trustedGovernancePaths = basePolicy.paths?.governance_paths ?? [];
+    }
+    const { ajv, policy, changeIntentSchema, governanceGrantSchema } = runtime;
+    const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
+    if (!enforcement.ok) {
+        console.error(`ERROR: ${enforcement.message}`);
+        return 1;
+    }
+    const linked = fetchLinkedIssue({ prBody, repoFullName });
+    if (linked.fatal)
+        return 1;
+    const { linkedIssues, issueBody } = linked;
+    let resolved = resolvePRChangeIntentFacts({ prBody, issueBody });
+    if (!resolved.ok && resolved.linkedIssues.length === 1 && issueBody === null && resolved.error !== "issue_link_ambiguous")
+        resolved = { ...resolved, error: "issue_fetch_failed", message: `Could not fetch issue #${resolved.linkedIssues[0]} body` };
+    let changeIntent = null, changeIntentSource = resolved.changeIntentSource || "none";
+    if (!resolved.ok)
+        initialChecks.push({ name: "change-intent", check: { ok: false, message: `[${resolved.error}]: ${resolved.message}` } });
+    else {
+        const check = validationCheck(ajv, changeIntentSchema, resolved.changeIntent, "change-intent (from markdown)");
+        initialChecks.push({ name: "change-intent", check });
+        if (check.ok)
+            changeIntent = resolved.changeIntent;
+    }
+    let governanceGrant = null;
+    if (resolved.grantResult && !resolved.grantResult.ok)
+        initialChecks.push({ name: "governance-grant", check: { ok: false, message: `[${resolved.grantResult.error}]: ${resolved.grantResult.message}` } });
+    else if (resolved.grantResult?.grant) {
+        const check = validationCheck(ajv, governanceGrantSchema, resolved.grantResult.grant, "governance-grant (linked issue)");
+        initialChecks.push({ name: "governance-grant", check });
+        if (check.ok)
+            governanceGrant = resolved.grantResult.grant;
+    }
+    let diffText;
+    try {
+        diffText = getDiff(base, head, roots.repoRoot);
+    }
+    catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        return 1;
+    }
+    let trustedAuthorizer = null;
+    if (basePolicy && repoFullName)
+        try {
+            trustedAuthorizer = resolveTrustedAuthorizer({ repoFullName, issueNumber: linkedIssues.length === 1 ? linkedIssues[0] : null, prNumber });
+        }
+        catch { }
+    return runPolicyPipeline({
+        mode: "check-pr", repositoryRoot: roots.repoRoot, policy, basePolicy, headPolicy: headRuntime.policy,
+        changeIntent, changeIntentSource, governanceGrant, trustedGovernancePaths, trustedAuthorizer, enforcement, diffText, initialChecks,
+    }).exitCode;
+}

--- a/dist/init.mjs
+++ b/dist/init.mjs
@@ -1,0 +1,141 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve, relative, dirname } from "node:path";
+import { normalizeEnforcementMode } from "./enforcement.mjs";
+const ACTION = "netkeep80/repo-guard";
+const PRESETS = {
+    application: ["application", ["*.bak", "*.log"], ["README.md"], { max_new_docs: 3, max_new_files: 20, max_net_added_lines: 1500 }, []],
+    library: ["library", ["*.bak"], ["README.md", "CHANGELOG.md"], { max_new_docs: 2, max_new_files: 15, max_net_added_lines: 1000 }, [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }]],
+    tooling: ["tooling", ["*.bak"], ["README.md"], { max_new_docs: 2, max_new_files: 15, max_net_added_lines: 2000 }, [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }]],
+    documentation: ["documentation", [], ["README.md"], { max_new_docs: 10, max_new_files: 20 }, []],
+};
+function buildPolicy(name, mode) {
+    const [repository_kind, forbidden, canonical_docs, diff_rules, cochange_rules] = PRESETS[name];
+    return { policy_format_version: "0.3.0", repository_kind, enforcement: { mode }, paths: { forbidden, canonical_docs, governance_paths: ["repo-policy.json"] }, diff_rules, content_rules: [], cochange_rules };
+}
+function actionRef(packageRoot) {
+    const version = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf-8")).version;
+    if (!version)
+        throw new Error("Cannot determine repo-guard package version");
+    return `v${version}`;
+}
+const workflow = (mode, ref) => `name: Проверка политики repo-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Проверить политику репозитория
+        uses: ${ACTION}@${ref}
+        with: { mode: check-pr, enforcement: ${mode} }
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`;
+const prTemplate = () => `## Краткое описание
+
+## Намерение изменения
+
+\`\`\`repo-guard-yaml
+change_type: feature
+scope:
+  - src/**
+budgets: {}
+anchors:
+  affects: []
+  implements: []
+  verifies: []
+must_touch: []
+must_not_touch: []
+expected_effects:
+  - Опишите ожидаемый эффект
+\`\`\`
+`;
+const issueTemplate = () => `name: Намерение изменения
+description: Предложить изменение с ChangeIntent и, при необходимости, GovernanceGrant.
+title: "[change] "
+body:
+  - type: textarea
+    id: description
+    attributes: { label: Описание, description: Что меняется и зачем? }
+    validations: { required: true }
+  - type: textarea
+    id: change_intent
+    attributes:
+      label: ChangeIntent
+      description: Обычное намерение изменения; не даёт управляющих разрешений.
+      value: |
+        \`\`\`repo-guard-yaml
+        change_type: feature
+        scope: ["src/**"]
+        budgets: {}
+        anchors: { affects: [], implements: [], verifies: [] }
+        must_touch: []
+        must_not_touch: []
+        expected_effects: ["Опишите ожидаемый эффект"]
+        \`\`\`
+    validations: { required: true }
+  - type: textarea
+    id: governance_grant
+    attributes:
+      label: GovernanceGrant (только для управляющих изменений)
+      description: Оставьте пустым для обычной задачи. Grant доверяется только из связанной задачи.
+      value: |
+        \`\`\`repo-guard-grant
+        authorized_governance_paths:
+          - repo-policy.json
+        allow_policy_relaxation: []
+        \`\`\`
+    validations: { required: false }
+`;
+function writeIfAbsent(path, content, created, skipped) {
+    if (existsSync(path))
+        return skipped.push(path);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, content, "utf-8");
+    created.push(path);
+}
+const usage = `Usage: repo-guard init [--preset <preset>] [--mode <mode>]\nPresets: application, library, tooling, documentation`;
+export function runInit(roots, args = []) {
+    let preset = "application", mode = roots.enforcementMode || "enforce";
+    for (let i = 0; i < args.length; i++) {
+        if (["--preset", "--mode", "--enforcement"].includes(args[i]) && args[i + 1]) {
+            const value = args[++i];
+            if (args[i - 1] === "--preset")
+                preset = value;
+            else
+                mode = value;
+        }
+        else if (args[i] === "--help") {
+            console.log(usage);
+            return 0;
+        }
+        else {
+            console.error(`Unknown option for init: ${args[i]}\n${usage}`);
+            return 1;
+        }
+    }
+    if (!PRESETS[preset]) {
+        console.error(`Unknown preset: ${preset}\n${usage}`);
+        return 1;
+    }
+    const enforcement = normalizeEnforcementMode(mode, "mode");
+    if (!enforcement.ok) {
+        console.error(enforcement.message);
+        return 1;
+    }
+    const created = [], skipped = [], root = roots.repoRoot;
+    writeIfAbsent(resolve(root, "repo-policy.json"), `${JSON.stringify(buildPolicy(preset, enforcement.mode), null, 2)}\n`, created, skipped);
+    writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), workflow(enforcement.mode, actionRef(roots.packageRoot)), created, skipped);
+    writeIfAbsent(resolve(root, ".github/PULL_REQUEST_TEMPLATE.md"), prTemplate(), created, skipped);
+    writeIfAbsent(resolve(root, ".github/ISSUE_TEMPLATE/change-intent.yml"), issueTemplate(), created, skipped);
+    console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcement.mode})`);
+    if (created.length)
+        console.log(`Created:\n${created.map((path) => `  ${relative(root, path)}`).join("\n")}`);
+    if (skipped.length)
+        console.log(`Skipped (already exist):\n${skipped.map((path) => `  ${relative(root, path)}`).join("\n")}`);
+    return 0;
+}

--- a/dist/integration-validator.mjs
+++ b/dist/integration-validator.mjs
@@ -1,0 +1,81 @@
+import { resolve } from "node:path";
+import { integrationConstraintEntries } from "./checks/integration-constraints.mjs";
+import { resolveEnforcementMode } from "./enforcement.mjs";
+import { extractIntegration } from "./extractors/integration.mjs";
+import { compileIntegrationPolicy } from "./policy-compiler.mjs";
+import { createAnalysisTextPresenter, renderAnalysisReport } from "./reporting/renderers.mjs";
+import { createAnalysisCollector } from "./runtime/analysis-report.mjs";
+import { ajvErrors, createAjv, loadJSON } from "./runtime/validation.mjs";
+const emptyFacts = () => ({ workflows: [], templates: [], docs: [], profiles: [], errors: [] });
+const count = (integration = {}) => {
+    const result = Object.fromEntries(["workflows", "templates", "docs", "profiles"].map((key) => [key, Array.isArray(integration[key]) ? integration[key].length : 0]));
+    return { ...result, ...(Array.isArray(integration.errors) ? { errors: integration.errors.length } : {}), total: result.workflows + result.templates + result.docs + result.profiles };
+};
+const option = (args, name, fallback) => { const index = args.indexOf(name); return index < 0 ? fallback : args[index + 1]; };
+export function createIntegrationAnalysisReport(roots, { format = "text" } = {}) {
+    const policyPath = resolve(roots.repoRoot, "repo-policy.json"), schemaPath = resolve(roots.packageRoot, "schemas/repo-policy.schema.json");
+    let policy, schema;
+    try {
+        policy = loadJSON(policyPath);
+    }
+    catch (error) {
+        const enforcement = { mode: roots.enforcementMode || "blocking" };
+        const reporter = createAnalysisCollector(enforcement, { presenter: format === "text" ? createAnalysisTextPresenter() : null });
+        reporter.report("repo-policy.json", { ok: false, message: `Cannot read ${policyPath}: ${error.message}`, hint: "Create a valid repo-policy.json before validating integration wiring" });
+        return reporter.finish({ command: "validate-integration", repositoryRoot: roots.repoRoot, integration: emptyFacts(), diagnostics: { declared: count(), extracted: count(emptyFacts()), artifactErrors: [] } });
+    }
+    try {
+        schema = loadJSON(schemaPath);
+    }
+    catch (error) {
+        return { fatal: true, message: `ERROR: Cannot read ${schemaPath}: ${error.message}` };
+    }
+    const enforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy });
+    if (!enforcement.ok)
+        return { fatal: true, message: `ERROR: ${enforcement.message}` };
+    const quiet = format !== "text";
+    if (!quiet)
+        console.log("repo-guard validate-integration\n");
+    const reporter = createAnalysisCollector(enforcement, { presenter: quiet ? null : createAnalysisTextPresenter() });
+    const ajv = createAjv(), schemaOk = ajv.validate(schema, policy);
+    reporter.report("repo-policy.json", schemaOk
+        ? { ok: true, message: "repo-policy.json is valid JSON policy" }
+        : { ok: false, message: "repo-policy.json failed schema validation", errors: ajvErrors(ajv.errors), hint: "Fix policy schema errors before relying on integration diagnostics" });
+    const declared = count(policy.integration), compileErrors = schemaOk ? compileIntegrationPolicy(policy) : [];
+    if (!policy.integration)
+        reporter.report("integration-policy", { ok: false, message: "repo-policy.json has no integration section", hint: "Declare integration.workflows, integration.templates, integration.docs, or integration.profiles" });
+    else if (!declared.total)
+        reporter.report("integration-policy", { ok: false, message: "integration section declares no artifacts", hint: "Declare at least one integration workflow, template, doc, or profile" });
+    else if (compileErrors.length)
+        reporter.report("integration-policy", { ok: false, message: "Integration policy failed compilation", details: compileErrors.map((error) => error.message), hint: "Fix integration ids and profile references" });
+    else
+        reporter.report("integration-policy", { ok: true, message: "Integration policy compiles" });
+    let integration = emptyFacts();
+    if (policy.integration && schemaOk && !compileErrors.length) {
+        integration = extractIntegration(policy, { repoRoot: roots.repoRoot });
+        for (const entry of integrationConstraintEntries(integration))
+            reporter.report(entry.name, entry.check);
+    }
+    const diagnostics = {
+        declared,
+        extracted: count(integration),
+        artifactErrors: integration.errors.map((error) => `${error.section}${error.id ? `:${error.id}` : ""}${error.path ? ` (${error.path})` : ""}: ${error.message}`),
+    };
+    return reporter.finish({ command: "validate-integration", repositoryRoot: roots.repoRoot, integration, diagnostics });
+}
+export function runValidateIntegration(roots, args = []) {
+    const format = option(args, "--format", "text");
+    if (!["text", "json", "summary"].includes(format)) {
+        console.error(`Unknown validate-integration format: ${format}`);
+        return 1;
+    }
+    const report = createIntegrationAnalysisReport(roots, { format });
+    if (report.fatal) {
+        console.error(report.message);
+        return 1;
+    }
+    const output = renderAnalysisReport(report, { format });
+    if (output)
+        console.log(output);
+    return report.exitCode;
+}

--- a/dist/policy-compiler.mjs
+++ b/dist/policy-compiler.mjs
@@ -1,0 +1,99 @@
+const list = (value) => Array.isArray(value) ? value : [];
+const object = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
+export function compileForbidRegex(contentRules = []) {
+    const errors = [];
+    for (const rule of list(contentRules))
+        for (const pattern of list(rule?.forbid_regex)) {
+            try {
+                new RegExp(pattern);
+            }
+            catch (error) {
+                errors.push({ rule_id: rule?.id, pattern, message: error.message });
+            }
+        }
+    return errors;
+}
+export function compileChangeProfiles(policy = {}) {
+    const errors = [], profiles = object(policy.change_profiles);
+    const surfaces = new Set(Object.keys(object(policy.surfaces)));
+    const classes = new Set(Object.keys(object(policy.new_file_classes)));
+    for (const [changeType, profile] of Object.entries(profiles)) {
+        const p = object(profile), allowed = new Set(list(p.allow_surfaces));
+        for (const field of ["allow_surfaces", "forbid_surfaces", "require_surfaces"])
+            for (const surface of list(p[field])) {
+                if (!surfaces.has(surface))
+                    errors.push({ change_type: changeType, surface, message: `change_profiles["${changeType}"].${field} references unknown surface "${surface}"` });
+            }
+        for (const surface of list(p.forbid_surfaces))
+            if (allowed.has(surface))
+                errors.push({ change_type: changeType, surface, message: `change_profiles["${changeType}"] lists surface "${surface}" in both allow_surfaces and forbid_surfaces` });
+        const newFiles = object(p.new_files);
+        for (const fileClass of [...list(newFiles.allow_classes), ...Object.keys(object(newFiles.max_per_class))])
+            if (!classes.has(fileClass)) {
+                errors.push({ change_type: changeType, class: fileClass, message: `change_profiles["${changeType}"].new_files references unknown class "${fileClass}"` });
+            }
+    }
+    return errors;
+}
+export function compileAnchorPolicy(policy = {}) {
+    const errors = [], types = object(policy.anchors?.types), typeNames = new Set(Object.keys(types)), ids = new Set();
+    for (const [anchorType, config] of Object.entries(types))
+        for (const [sourceIndex, source] of list(config?.sources).entries()) {
+            if (source?.kind !== "regex")
+                continue;
+            try {
+                new RegExp(source.pattern);
+            }
+            catch (error) {
+                errors.push({ anchor_type: anchorType, source_index: sourceIndex, pattern: source.pattern, message: `anchors.types["${anchorType}"].sources[${sourceIndex}].pattern is invalid: ${error.message}` });
+            }
+        }
+    for (const [index, rule] of list(policy.trace_rules).entries()) {
+        if (ids.has(rule?.id))
+            errors.push({ trace_rule: rule?.id, message: `trace_rules[${index}].id duplicates trace rule "${rule?.id}"` });
+        ids.add(rule?.id);
+        if (rule?.kind === "must_resolve")
+            for (const field of ["from_anchor_type", "to_anchor_type"]) {
+                if (!typeNames.has(rule[field]))
+                    errors.push({ trace_rule: rule.id, anchor_type: rule[field], message: `trace_rules[${index}].${field} references unknown anchor type "${rule[field]}"` });
+            }
+        if (rule?.kind === "declared_anchors_require_evidence" && !["anchors.affects", "anchors.implements", "anchors.verifies"].includes(rule.change_intent_field)) {
+            errors.push({ trace_rule: rule.id, change_intent_field: rule.change_intent_field, message: `trace_rules[${index}].change_intent_field references unsupported ChangeIntent anchor field` });
+        }
+    }
+    return errors;
+}
+function semanticIntegrationEntries(integration) {
+    return ["workflows", "templates", "docs", "profiles"].flatMap((section) => list(integration?.[section]).map((entry, index) => ({ section, index, entry: object(entry) })));
+}
+export function compileIntegrationPolicy(policy = {}) {
+    const integration = object(policy.integration);
+    if (!policy.integration || !Object.keys(integration).length)
+        return [];
+    const errors = [], seen = new Map(), profileIds = new Set(), references = [];
+    for (const { section, index, entry } of semanticIntegrationEntries(integration)) {
+        const id = entry.id;
+        if (typeof id === "string" && id) {
+            if (seen.has(id)) {
+                const previous = seen.get(id);
+                errors.push({ section, id, index, previous_section: previous.section, previous_index: previous.index, message: `integration.${section}[${index}].id duplicates integration.${previous.section}[${previous.index}].id "${id}"` });
+            }
+            else
+                seen.set(id, { section, index });
+            if (section === "profiles")
+                profileIds.add(id);
+        }
+        for (const profileId of list(entry.profiles))
+            references.push({ section, index, field: "profiles", profileId });
+        if (section === "docs")
+            for (const profileId of list(entry.must_mention_profiles))
+                references.push({ section, index, field: "must_mention_profiles", profileId });
+    }
+    for (const ref of references)
+        if (!profileIds.has(ref.profileId))
+            errors.push({ section: ref.section, index: ref.index, field: ref.field, profile_id: ref.profileId, message: `integration.${ref.section}[${ref.index}].${ref.field} references unknown integration.profiles id "${ref.profileId}"` });
+    return errors;
+}
+export function warnReservedPolicyFields(policy = {}) {
+    return list(policy.paths?.public_api).length ? ["paths.public_api: defined but reserved for future use; not enforced at runtime"] : [];
+}

--- a/dist/policy-profiles.mjs
+++ b/dist/policy-profiles.mjs
@@ -1,0 +1,97 @@
+const REQUIREMENT_ID = "(?:BR|SR|FR|NFR|CR|IR)-[0-9]{3}";
+const PACKS = {
+    "requirements-strict": {
+        defaults: {
+            requirement_json_globs: [
+                "requirements/business/*.json", "requirements/stakeholder/*.json", "requirements/functional/*.json",
+                "requirements/nonfunctional/*.json", "requirements/constraints/*.json", "requirements/interface/*.json",
+            ],
+            code_reference_globs: [
+                "scripts/**/*.js", "include/**/*.{h,hpp,hh}", "src/**/*.{h,hpp,hh,c,cc,cpp,cxx}",
+                "tests/**/*.{h,hpp,hh,c,cc,cpp,cxx,js,mjs}", "examples/**/*.{h,hpp,hh,c,cc,cpp,cxx,js,mjs}",
+            ],
+            doc_reference_globs: ["*.md", "docs/**/*.md", "requirements/**/*.md", ".github/**/*.md"],
+            strict_heading_docs: ["docs/**/*.md"],
+            evidence_surfaces: ["src/**", "tests/**", "docs/**", "README.md", "requirements/README.md"],
+            implementation_evidence_surfaces: ["include/**", "src/**", "scripts/**", ".github/workflows/**"],
+            verification_evidence_surfaces: ["tests/**", "experiments/**", "scripts/**", ".github/workflows/**"],
+        },
+        anchors: {
+            requirement_id: { kind: "json_field", globs: "$requirement_json_globs", field: "id" },
+            requirement_json_req_ref: { kind: "regex", globs: "$requirement_json_globs", pattern: `"(${REQUIREMENT_ID})"` },
+            code_req_ref: { kind: "regex", globs: "$code_reference_globs", pattern: `(?:@req\\s+|,\\s*)(${REQUIREMENT_ID})` },
+            doc_req_ref: { kind: "regex", globs: "$doc_reference_globs", pattern: `(?:^|[^A-Z0-9])(${REQUIREMENT_ID})(?![0-9])` },
+            doc_heading_req_ref: { kind: "regex", globs: "$strict_heading_docs", pattern: `(?:^|\\n)#{1,6}\\s+[^\\n]*?\\[(${REQUIREMENT_ID})\\]` },
+            doc_heading_without_req_ref: { kind: "regex", globs: "$strict_heading_docs", pattern: `(?:^|\\n)(#{1,6}\\s+(?![^\\n]*\\[${REQUIREMENT_ID}\\])[^\\n]*)` },
+        },
+        trace_rules: [
+            { id: "requirement-json-req-refs-must-resolve", kind: "must_resolve", from_anchor_type: "requirement_json_req_ref", to_anchor_type: "requirement_id" },
+            { id: "code-req-refs-must-resolve", kind: "must_resolve", from_anchor_type: "code_req_ref", to_anchor_type: "requirement_id" },
+            { id: "doc-req-refs-must-resolve", kind: "must_resolve", from_anchor_type: "doc_req_ref", to_anchor_type: "requirement_id" },
+            { id: "doc-heading-req-refs-must-resolve", kind: "must_resolve", from_anchor_type: "doc_heading_req_ref", to_anchor_type: "requirement_id" },
+            { id: "doc-headings-must-have-req-ref", kind: "must_resolve", from_anchor_type: "doc_heading_without_req_ref", to_anchor_type: "requirement_id" },
+            { id: "changed-requirements-need-evidence", kind: "changed_files_require_evidence", if_changed: "$requirement_json_globs", must_touch_any: "$changed_requirement_evidence_surfaces" },
+            { id: "declared-affected-anchors-need-evidence", kind: "declared_anchors_require_evidence", change_intent_field: "anchors.affects", must_touch_any: "$affected_evidence_surfaces" },
+            { id: "declared-implemented-anchors-need-evidence", kind: "declared_anchors_require_evidence", change_intent_field: "anchors.implements", must_touch_any: "$implementation_evidence_surfaces" },
+            { id: "declared-verified-anchors-need-evidence", kind: "declared_anchors_require_evidence", change_intent_field: "anchors.verifies", must_touch_any: "$verification_evidence_surfaces" },
+        ],
+    },
+};
+const OVERRIDE_FIELDS = new Set([
+    ...Object.keys(PACKS["requirements-strict"].defaults),
+    "changed_requirement_evidence_surfaces", "affected_evidence_surfaces",
+]);
+const clone = (value) => structuredClone(value);
+const isObject = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
+const ref = (value, config) => typeof value === "string" && value.startsWith("$") ? clone(config[value.slice(1)]) : clone(value);
+function configFor(spec, overrides = {}) {
+    const config = clone(spec.defaults);
+    for (const [key, value] of Object.entries(overrides))
+        config[key] = clone(value);
+    config.changed_requirement_evidence_surfaces ||= clone(config.evidence_surfaces);
+    config.affected_evidence_surfaces ||= clone(config.evidence_surfaces);
+    return config;
+}
+function materializePack(spec, overrides) {
+    const config = configFor(spec, overrides), types = {};
+    for (const [name, source] of Object.entries(spec.anchors)) {
+        const globs = ref(source.globs, config);
+        types[name] = { sources: globs.map((glob) => source.kind === "json_field"
+                ? { kind: source.kind, glob, field: source.field }
+                : { kind: source.kind, glob, pattern: source.pattern }) };
+    }
+    const trace_rules = spec.trace_rules.map((rule) => Object.fromEntries(Object.entries(rule).map(([key, value]) => [key, ref(value, config)])));
+    return { anchors: { types }, trace_rules };
+}
+export const listBuiltInProfiles = () => Object.keys(PACKS).sort();
+export function compileProfilePolicy(policy) {
+    const errors = [], profile = policy?.profile, overrides = policy?.profile_overrides;
+    if (overrides !== undefined && !profile)
+        errors.push({ field: "profile_overrides", message: "profile_overrides requires top-level profile" });
+    if (profile !== undefined && !PACKS[profile])
+        errors.push({ field: "profile", profile, message: `profile "${profile}" is not supported; use ${listBuiltInProfiles().join(", ")}` });
+    if (overrides !== undefined) {
+        if (!isObject(overrides))
+            errors.push({ field: "profile_overrides", message: "profile_overrides must be an object" });
+        else
+            for (const [field, value] of Object.entries(overrides)) {
+                if (!OVERRIDE_FIELDS.has(field))
+                    errors.push({ field: `profile_overrides.${field}`, message: `profile_overrides.${field} is not supported` });
+                else if (!Array.isArray(value) || !value.length || value.some((item) => typeof item !== "string" || !item.trim())) {
+                    errors.push({ field: `profile_overrides.${field}`, message: `profile_overrides.${field} must be a non-empty array of non-empty strings` });
+                }
+            }
+    }
+    return errors;
+}
+export function expandPolicyProfile(policy) {
+    const base = clone(policy), spec = PACKS[base.profile];
+    if (!spec)
+        return base;
+    const patch = materializePack(spec, base.profile_overrides || {});
+    return { ...base, anchors: base.anchors || patch.anchors, trace_rules: base.trace_rules || patch.trace_rules };
+}
+export function resolvePolicyProfile(policy) {
+    const errors = compileProfilePolicy(policy);
+    return { ok: !errors.length, policy: errors.length ? clone(policy) : expandPolicyProfile(policy), errors };
+}

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { realpathSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, "..");
+const valueOptions = (...names) => Object.fromEntries(names.map((name) => [name, true]));
+const COMMAND_SPECS = {
+    validate: {
+        options: {}, positionals: 1,
+        run: async (roots, args) => (await import("./validate.mjs")).runValidate(roots, args),
+    },
+    "check-diff": {
+        options: valueOptions("--base", "--head", "--change-intent", "--format"), positionals: 0,
+        run: async (roots, args) => (await import("./check-diff.mjs")).runCheckDiff(roots, args),
+    },
+    "check-pr": {
+        options: {}, positionals: 0,
+        run: async (roots, args) => (await import("./github-pr.mjs")).runCheckPR(roots, args),
+    },
+    init: {
+        options: { ...valueOptions("--preset", "--mode"), "--help": false }, positionals: 0,
+        run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
+    },
+    doctor: {
+        options: { "--integration": false, ...valueOptions("--format") }, positionals: 0,
+        run: async (roots, args) => args.includes("--integration")
+            ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
+            : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
+    },
+    "validate-integration": {
+        options: valueOptions("--format"), positionals: 0,
+        run: async (roots, args) => (await import("./integration-validator.mjs")).runValidateIntegration(roots, args),
+    },
+};
+export const COMMANDS = Object.freeze(Object.keys(COMMAND_SPECS));
+const USAGE = `Usage: repo-guard [--repo-root <path>] [--enforcement <advisory|blocking>] [${COMMANDS.join("|")}] [options]`;
+export function resolveRoots(args) {
+    let repoRoot = process.cwd(), enforcementMode = null;
+    const filtered = [];
+    for (let i = 0; i < args.length; i++) {
+        const option = args[i];
+        if (!["--repo-root", "--enforcement", "--enforcement-mode"].includes(option)) {
+            filtered.push(option);
+            continue;
+        }
+        const next = args[++i];
+        if (!next || next.startsWith("-"))
+            throw new Error(`${option} requires ${option === "--repo-root" ? "a path" : "a mode"} argument\n${USAGE}`);
+        if (option === "--repo-root")
+            repoRoot = resolve(next);
+        else
+            enforcementMode = next;
+    }
+    return { packageRoot, repoRoot, enforcementMode, args: filtered };
+}
+function parseCommand(args) {
+    const remaining = [...args];
+    const first = remaining[0];
+    const command = COMMAND_SPECS[first] ? remaining.shift() : "validate";
+    if (first?.startsWith("-") && command === "validate")
+        throw new Error(`Unknown option: ${first}\n${USAGE}`);
+    const spec = COMMAND_SPECS[command];
+    let positionals = 0;
+    for (let i = 0; i < remaining.length; i++) {
+        const token = remaining[i];
+        if (!token.startsWith("-")) {
+            positionals++;
+            continue;
+        }
+        if (!Object.hasOwn(spec.options, token))
+            throw new Error(`Unknown option for ${command}: ${token}\n${USAGE}`);
+        if (!spec.options[token])
+            continue;
+        const value = remaining[++i];
+        if (!value || value.startsWith("-"))
+            throw new Error(`${token} requires a value\n${USAGE}`);
+    }
+    if (positionals > spec.positionals)
+        throw new Error(`Unexpected argument for ${command}\n${USAGE}`);
+    return { command, args: remaining };
+}
+function sameEntrypointPath(left, right) {
+    try {
+        return realpathSync(left) === realpathSync(right);
+    }
+    catch {
+        return resolve(left) === resolve(right);
+    }
+}
+async function dispatch(roots) {
+    const parsed = parseCommand(roots.args);
+    return COMMAND_SPECS[parsed.command].run(roots, parsed.args);
+}
+export async function runCli(args = process.argv.slice(2)) {
+    try {
+        return await dispatch(resolveRoots([...args]));
+    }
+    catch (error) {
+        console.error(`ERROR: ${error.message}`);
+        return 1;
+    }
+}
+const isMain = process.argv[1] && sameEntrypointPath(process.argv[1], resolve(__dirname, "repo-guard.mjs"));
+if (isMain)
+    process.exit(await runCli());

--- a/dist/reporting/anchor-diagnostics.mjs
+++ b/dist/reporting/anchor-diagnostics.mjs
@@ -1,0 +1,85 @@
+import { buildTraceRuleDiagnostics } from "../checks/trace-rules.mjs";
+const CHANGE_INTENT_ANCHOR_FIELDS = ["affects", "implements", "verifies"];
+function cloneAnchorInstance(instance) {
+    return { ...instance };
+}
+function sortedUnique(values) {
+    return [...new Set((values || []).map((value) => String(value)))].sort();
+}
+function groupByType(anchorTypes, instances) {
+    const byType = {};
+    for (const anchorType of Object.keys(anchorTypes || {}).sort()) {
+        byType[anchorType] = { detected: 0, changed: 0 };
+    }
+    for (const instance of instances.detected) {
+        if (!byType[instance.anchorType])
+            byType[instance.anchorType] = { detected: 0, changed: 0 };
+        byType[instance.anchorType].detected++;
+    }
+    for (const instance of instances.changed) {
+        if (!byType[instance.anchorType])
+            byType[instance.anchorType] = { detected: 0, changed: 0 };
+        byType[instance.anchorType].changed++;
+    }
+    return byType;
+}
+function declaredChangeIntentAnchors(changeIntent) {
+    const changeIntentAnchors = changeIntent?.anchors || {};
+    const declared = {};
+    const all = [];
+    for (const field of CHANGE_INTENT_ANCHOR_FIELDS) {
+        const values = sortedUnique(changeIntentAnchors[field]);
+        declared[field] = values;
+        for (const value of values) {
+            all.push({ relation: field, value });
+        }
+    }
+    declared.all = all;
+    return declared;
+}
+function flattenUnresolved(traceRuleResults) {
+    const unresolved = [];
+    for (const result of traceRuleResults) {
+        for (const item of result.unresolved || []) {
+            unresolved.push({
+                rule: result.id,
+                kind: result.kind,
+                fromAnchorType: result.fromAnchorType,
+                toAnchorType: result.toAnchorType,
+                value: item.value,
+                instances: item.instances,
+            });
+        }
+    }
+    return unresolved;
+}
+export function buildAnchorDiagnostics(facts) {
+    const traceRuleResults = buildTraceRuleDiagnostics(facts);
+    if (!facts.policy.anchors) {
+        return traceRuleResults.length > 0 ? { traceRuleResults } : {};
+    }
+    const detected = (facts.anchors?.instances || []).map(cloneAnchorInstance);
+    const changedPaths = new Set(facts.derived.changedPaths || []);
+    const changed = detected
+        .filter((instance) => changedPaths.has(instance.file))
+        .map(cloneAnchorInstance);
+    const declaredByChangeIntent = declaredChangeIntentAnchors(facts.changeIntent);
+    const unresolved = flattenUnresolved(traceRuleResults);
+    return {
+        anchors: {
+            detected,
+            changed,
+            declaredByChangeIntent,
+            unresolved,
+            stats: {
+                detected: detected.length,
+                changed: changed.length,
+                declaredByChangeIntent: declaredByChangeIntent.all.length,
+                unresolved: unresolved.length,
+                extractionErrors: (facts.anchors?.errors || []).length,
+                byType: groupByType(facts.policy.anchors.types, { detected, changed }),
+            },
+        },
+        traceRuleResults,
+    };
+}

--- a/dist/reporting/renderers.mjs
+++ b/dist/reporting/renderers.mjs
@@ -1,0 +1,150 @@
+function writeViolation(mode, message) {
+    if (mode === "advisory") {
+        console.warn(message);
+    }
+    else {
+        console.error(message);
+    }
+}
+function printCheckDetails(mode, check) {
+    const write = (message) => writeViolation(mode, message);
+    for (const detail of check.details || [])
+        write(`    ${detail}`);
+}
+function renderMarkdownTableCell(value) {
+    return String(value || "")
+        .replaceAll("|", "\\|")
+        .replaceAll("\n", "<br>");
+}
+function formatAnchorLocation(instance) {
+    const line = instance.line ? `:${instance.line}` : "";
+    const column = instance.column ? `:${instance.column}` : "";
+    return `${instance.file}${line}${column}`;
+}
+export function renderEnforcementMode(enforcement) {
+    if (enforcement.mode === "advisory") {
+        return "Enforcement mode: advisory (policy violations are reported as warnings; exit code remains 0)";
+    }
+    return "Enforcement mode: blocking (policy violations are enforced; exit code is 1 when violations exist)";
+}
+export function renderDiffAnalysis(facts) {
+    const skipped = facts.diagnostics.skippedOperationalFiles;
+    return `Diff analysis: ${facts.diff.files.all.length} file(s) changed${skipped ? ` (${skipped} operational skipped)` : ""}`;
+}
+export function createAnalysisTextPresenter() {
+    return {
+        check({ check, mode, outcome }) {
+            if (outcome === "pass") {
+                console.log(`  PASS: ${check.rule}`);
+                return;
+            }
+            if (outcome === "warning") {
+                writeViolation("advisory", `  WARN: ${check.rule}`);
+                printCheckDetails("advisory", check);
+                return;
+            }
+            const label = mode === "advisory" ? "WARN" : "FAIL";
+            writeViolation(mode, `  ${label}: ${check.rule}`);
+            printCheckDetails(mode, check);
+        },
+        finish(report) {
+            const advisoryPart = report.mode === "advisory" ? `, ${report.violationCount} advisory violation(s)` : "";
+            const modePart = report.mode === "advisory" ? "violations reported as warnings" : "violations enforced";
+            const warningPart = report.warnings > 0 ? `, ${report.warnings} warning(s)` : "";
+            console.log(`\nSummary: ${report.passed} passed, ${report.failed} failed${advisoryPart}${warningPart} (mode: ${report.mode}; ${modePart})`);
+            console.log(`Result: ${report.result} (mode: ${report.mode}; exit code ${report.exitCode})`);
+        },
+    };
+}
+function renderCountLine(report, label) {
+    return `- ${label}: ${report.passed} passed, ${report.failed} failed${report.mode === "advisory" ? `, ${report.violationCount} advisory violation(s)` : ""}${report.warnings ? `, ${report.warnings} warning(s)` : ""}`;
+}
+function renderCheckExtraLines(report) {
+    const lines = [];
+    if (report.diff) {
+        lines.push(`- Diff: ${report.diff.changedFiles} file(s) changed${report.diff.skippedOperationalFiles ? `, ${report.diff.skippedOperationalFiles} operational skipped` : ""}`);
+    }
+    if (report.anchors) {
+        const stats = report.anchors.stats;
+        lines.push(`- Anchors: ${stats.detected} detected, ${stats.changed} changed, ${stats.declaredByChangeIntent} declared, ${stats.unresolved} unresolved`);
+        if (report.anchors.unresolved.length > 0) {
+            lines.push("", "| Trace rule | Anchor | Locations |", "|---|---|---|");
+            for (const unresolved of report.anchors.unresolved.slice(0, 10)) {
+                const anchor = `${unresolved.fromAnchorType} -> ${unresolved.toAnchorType}: ${unresolved.value}`;
+                const locations = unresolved.instances.map(formatAnchorLocation).join(", ");
+                lines.push(`| ${renderMarkdownTableCell(unresolved.rule)} | ${renderMarkdownTableCell(anchor)} | ${renderMarkdownTableCell(locations)} |`);
+            }
+            if (report.anchors.unresolved.length > 10) {
+                lines.push(`| ... | ... | ${report.anchors.unresolved.length - 10} more unresolved anchor(s) |`);
+            }
+        }
+    }
+    return lines;
+}
+function renderIntegrationExtraLines(report) {
+    const declared = report.diagnostics.declared;
+    const extracted = report.diagnostics.extracted;
+    return [
+        `- Declared: ${declared.workflows} workflow(s), ${declared.templates} template(s), ${declared.docs} doc(s), ${declared.profiles} profile(s)`,
+        `- Extracted: ${extracted.workflows} workflow(s), ${extracted.templates} template(s), ${extracted.docs} doc(s), ${extracted.profiles} profile(s), ${extracted.errors} artifact error(s)`,
+    ];
+}
+function renderResultTable(lines, heading, entries, fallback) {
+    if (!entries || entries.length === 0)
+        return;
+    lines.push("", `| ${heading} | Details |`, "|---|---|");
+    for (const entry of entries) {
+        const details = (entry.details || []).join("<br>") || fallback;
+        lines.push(`| ${renderMarkdownTableCell(entry.rule)} | ${renderMarkdownTableCell(details)} |`);
+    }
+}
+function renderMarkdownSummary(report, { title, countLabel, violationLabel, violationFallback, extraLines = () => [], }) {
+    const lines = [
+        `## ${title}`,
+        "",
+        `- Result: ${report.result}`,
+        `- Mode: ${report.mode}`,
+        `- Repository root: \`${report.repositoryRoot}\``,
+        renderCountLine(report, countLabel),
+        ...extraLines(report),
+    ];
+    renderResultTable(lines, violationLabel, report.violations, violationFallback);
+    renderResultTable(lines, "Advisory", report.advisoryWarnings, "Warning reported");
+    if (report.hints.length > 0) {
+        lines.push("", "### Hints");
+        for (const hint of report.hints) {
+            lines.push(`- ${hint.rule}: ${hint.message}`);
+        }
+    }
+    return `${lines.join("\n")}\n`;
+}
+export function renderCheckSummary(report) {
+    return renderMarkdownSummary(report, {
+        title: "repo-guard summary",
+        countLabel: "Checks",
+        violationLabel: "Rule",
+        violationFallback: "Violation reported",
+        extraLines: renderCheckExtraLines,
+    });
+}
+export function renderIntegrationSummary(report) {
+    return renderMarkdownSummary(report, {
+        title: "repo-guard integration summary",
+        countLabel: "Diagnostics",
+        violationLabel: "Diagnostic",
+        violationFallback: "Diagnostic reported",
+        extraLines: renderIntegrationExtraLines,
+    });
+}
+export function renderAnalysisReport(report, { format, summary } = {}) {
+    if (format === "json") {
+        return JSON.stringify(report, null, 2);
+    }
+    if (format === "summary") {
+        const summaryKind = summary || (report.command === "validate-integration" ? "integration" : "check");
+        return summaryKind === "integration"
+            ? renderIntegrationSummary(report)
+            : renderCheckSummary(report);
+    }
+    return null;
+}

--- a/dist/runtime/analysis-report.mjs
+++ b/dist/runtime/analysis-report.mjs
@@ -1,0 +1,172 @@
+const CHECK_FIELDS = new Set([
+    "ok",
+    "advisory",
+    "message",
+    "details",
+    "errors",
+    "hint",
+    "rule",
+    "severity",
+    "data",
+]);
+function isPlainObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function isScalar(value) {
+    return value === null || ["string", "number", "boolean"].includes(typeof value);
+}
+function formatList(values) {
+    return values.length > 0 ? values.join(", ") : "(none)";
+}
+function compactValue(value) {
+    if (Array.isArray(value))
+        return value.map(compactValue).filter((item) => item !== undefined);
+    if (!isPlainObject(value))
+        return value;
+    const compacted = {};
+    for (const [key, nested] of Object.entries(value)) {
+        const clean = compactValue(nested);
+        if (clean !== undefined)
+            compacted[key] = clean;
+    }
+    return compacted;
+}
+function checkData(check) {
+    if (isPlainObject(check.data))
+        return check.data;
+    const data = {};
+    for (const [key, value] of Object.entries(check || {})) {
+        if (CHECK_FIELDS.has(key) || value === undefined)
+            continue;
+        const compacted = compactValue(value);
+        if (Array.isArray(compacted) && compacted.length === 0)
+            continue;
+        if (isPlainObject(compacted) && Object.keys(compacted).length === 0)
+            continue;
+        data[key] = compacted;
+    }
+    return data;
+}
+function dataDetails(data, { includeComplex }) {
+    const details = [];
+    for (const [key, value] of Object.entries(data)) {
+        if (value === undefined || value === null)
+            continue;
+        if (isScalar(value)) {
+            details.push(`${key}: ${value}`);
+        }
+        else if (Array.isArray(value) && value.every(isScalar)) {
+            if (value.length > 0)
+                details.push(`${key}: ${formatList(value)}`);
+        }
+        else if (includeComplex && isPlainObject(value) && Object.values(value).every(isScalar)) {
+            details.push(`${key}: ${JSON.stringify(value)}`);
+        }
+        else if (includeComplex && Array.isArray(value) && value.length > 0) {
+            details.push(`${key}: ${value.length} item(s)`);
+        }
+    }
+    return details;
+}
+function asList(value) {
+    if (!value)
+        return [];
+    return Array.isArray(value) ? value.map(String) : [String(value)];
+}
+export function detailFromCheck(check) {
+    const explicitDetails = asList(check.details);
+    const errors = asList(check.errors);
+    const data = checkData(check);
+    const includeComplex = explicitDetails.length === 0 && errors.length === 0;
+    return [
+        ...asList(check.message),
+        ...dataDetails(data, { includeComplex }),
+        ...explicitDetails,
+        ...errors,
+        ...asList(check.hint).map((hint) => `hint: ${hint}`),
+    ];
+}
+function normalizeCheckResult(name, check) {
+    const ok = Boolean(check.ok);
+    const result = {
+        rule: name,
+        ok,
+        severity: ok ? "pass" : check.advisory ? "warning" : "failure",
+        details: detailFromCheck(check),
+    };
+    const data = checkData(check);
+    if (check.message)
+        result.message = check.message;
+    if (check.hint)
+        result.hint = check.hint;
+    if (Object.keys(data).length > 0)
+        result.data = data;
+    return result;
+}
+function normalizeEnforcement(enforcement) {
+    if (typeof enforcement === "string")
+        return { mode: enforcement };
+    return enforcement || { mode: "blocking" };
+}
+export function createAnalysisCollector(enforcementInput, options = {}) {
+    const enforcement = normalizeEnforcement(enforcementInput);
+    const mode = enforcement.mode;
+    const presenter = options.presenter || null;
+    let passed = 0;
+    let violations = 0;
+    let warnings = 0;
+    const ruleResults = [];
+    const violationDetails = [];
+    const warningDetails = [];
+    const hints = [];
+    return {
+        report(name, check) {
+            const normalized = normalizeCheckResult(name, check);
+            ruleResults.push(normalized);
+            if (check.ok) {
+                passed++;
+                presenter?.check?.({ check: normalized, mode, outcome: "pass" });
+                return;
+            }
+            if (check.advisory) {
+                warnings++;
+                warningDetails.push(normalized);
+                if (normalized.hint)
+                    hints.push({ rule: name, message: normalized.hint });
+                presenter?.check?.({ check: normalized, mode, outcome: "warning" });
+                return;
+            }
+            violations++;
+            violationDetails.push(normalized);
+            if (normalized.hint)
+                hints.push({ rule: name, message: normalized.hint });
+            presenter?.check?.({ check: normalized, mode, outcome: "violation" });
+        },
+        finish(extra = {}) {
+            const enforcedFailures = mode === "blocking" ? violations : 0;
+            const exitCode = enforcedFailures > 0 ? 1 : 0;
+            const result = violations > 0 ? "failed" : warnings > 0 ? "passed_with_warnings" : "passed";
+            const report = {
+                command: extra.command || null,
+                mode,
+                ok: violations === 0,
+                result,
+                passed,
+                violations: violationDetails,
+                advisoryWarnings: warningDetails,
+                warnings,
+                violationCount: violations,
+                failed: enforcedFailures,
+                exitCode,
+                ruleResults,
+                hints,
+                ...extra,
+            };
+            presenter?.finish?.(report);
+            return report;
+        },
+        get violations() {
+            return violations;
+        },
+    };
+}

--- a/dist/runtime/pipeline.mjs
+++ b/dist/runtime/pipeline.mjs
@@ -1,0 +1,38 @@
+import { buildPolicyFacts } from "../facts/input.mjs";
+import { runPolicyChecks } from "../checks/orchestrator.mjs";
+import { buildAnchorDiagnostics } from "../reporting/anchor-diagnostics.mjs";
+import { createAnalysisCollector } from "./analysis-report.mjs";
+import { createAnalysisTextPresenter, renderDiffAnalysis, renderEnforcementMode, } from "../reporting/renderers.mjs";
+export function runPolicyPipeline(input, options = {}) {
+    const quiet = options.quiet || false;
+    if (!quiet && options.printEnforcement !== false) {
+        console.log(renderEnforcementMode(input.enforcement));
+    }
+    const reporter = createAnalysisCollector(input.enforcement, {
+        presenter: quiet ? null : createAnalysisTextPresenter(),
+    });
+    for (const initialCheck of input.initialChecks || []) {
+        reporter.report(initialCheck.name, initialCheck.check);
+    }
+    const { changeIntent = null, changeIntentSource = "none", ...runtimeInput } = input;
+    const facts = buildPolicyFacts({
+        ...runtimeInput,
+        changeIntent,
+        changeIntentSource,
+    });
+    if (!quiet) {
+        console.log(`\n${renderDiffAnalysis(facts)}`);
+    }
+    const anchorDiagnostics = buildAnchorDiagnostics(facts);
+    runPolicyChecks(facts, reporter, { anchorDiagnostics });
+    return reporter.finish({
+        command: input.mode,
+        repositoryRoot: facts.repositoryRoot,
+        diff: {
+            changedFiles: facts.diff.files.all.length,
+            checkedFiles: facts.diff.files.checked.length,
+            skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
+        },
+        ...anchorDiagnostics,
+    });
+}

--- a/dist/runtime/validation.mjs
+++ b/dist/runtime/validation.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Ajv from "ajv";
+import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
+import { resolvePolicyProfile } from "../policy-profiles.mjs";
+export const loadJSON = (path) => JSON.parse(readFileSync(path, "utf-8"));
+export const createAjv = () => new Ajv({ allErrors: true });
+export const ajvErrors = (errors) => (errors || []).map((error) => `${error.instancePath || "/"} ${error.message}`);
+export function validate(ajv, schema, data, label, { quiet = false } = {}) {
+    const valid = ajv.validate(schema, data);
+    if (!quiet) {
+        console[valid ? "log" : "error"](`${valid ? "OK" : "FAIL"}: ${label}`);
+        if (!valid)
+            for (const error of ajv.errors)
+                console.error(`  ${error.instancePath || "/"} ${error.message}`);
+    }
+    return valid;
+}
+export function validationCheck(ajv, schema, data, label) {
+    return ajv.validate(schema, data) ? { ok: true } : { ok: false, message: `${label} failed schema validation`, errors: ajvErrors(ajv.errors) };
+}
+export function loadPolicyRuntimeFromObject(roots, rawPolicy, options = {}) {
+    const schema = (name) => loadJSON(resolve(roots.packageRoot, `schemas/${name}.schema.json`));
+    const policySchema = schema("repo-policy"), changeIntentSchema = schema("change-intent"), governanceGrantSchema = schema("governance-grant");
+    const ajv = createAjv(), quiet = options.quiet || false, label = options.label || "repo-policy.json";
+    let ok = validate(ajv, policySchema, rawPolicy, label, { quiet });
+    const profile = resolvePolicyProfile(rawPolicy), policy = profile.policy;
+    const semanticGroups = [
+        ["profile compilation", profile.errors, (error) => error.message],
+        ["forbid_regex compilation", compileForbidRegex(policy.content_rules), (error) => `[${error.rule_id}] invalid regex /${error.pattern}/: ${error.message}`],
+        ["change_profiles compilation", compileChangeProfiles(policy), (error) => error.message],
+        ["anchor policy compilation", compileAnchorPolicy(policy), (error) => error.message],
+        ["integration policy compilation", compileIntegrationPolicy(policy), (error) => error.message],
+    ];
+    for (const [group, errors, format] of semanticGroups)
+        if (errors.length) {
+            ok = false;
+            if (!quiet) {
+                console.error(`FAIL: ${group}`);
+                for (const error of errors)
+                    console.error(`  ${format(error)}`);
+            }
+        }
+    if (!quiet)
+        for (const warning of warnReservedPolicyFields(policy))
+            console.warn(`WARN: ${warning}`);
+    return { ok, ajv, policy, changeIntentSchema, governanceGrantSchema };
+}
+export function loadPolicyRuntime(roots, options = {}) {
+    return loadPolicyRuntimeFromObject(roots, loadJSON(resolve(roots.repoRoot, "repo-policy.json")), options);
+}

--- a/dist/trusted-authorizer.mjs
+++ b/dist/trusted-authorizer.mjs
@@ -1,0 +1,137 @@
+import { execFileSync } from "node:child_process";
+const GITHUB_REPO_FULL_NAME = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const POSITIVE_INTEGER = /^[1-9][0-9]*$/;
+const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+const TRUSTED_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+const DEFAULT_GOVERNANCE_LABEL = "governance-approved";
+function isValidRepo(repoFullName) {
+    return typeof repoFullName === "string" && GITHUB_REPO_FULL_NAME.test(repoFullName);
+}
+function isValidIssueNumber(number) {
+    return POSITIVE_INTEGER.test(String(number));
+}
+function safeGhJson(args) {
+    try {
+        const out = execFileSync("gh", args, { encoding: "utf-8", timeout: 30000 });
+        return out.trim() ? JSON.parse(out) : null;
+    }
+    catch {
+        return null;
+    }
+}
+export function fetchIssueAuthorContext(repoFullName, issueNumber) {
+    if (!isValidRepo(repoFullName) || !isValidIssueNumber(issueNumber))
+        return null;
+    return safeGhJson([
+        "api",
+        `repos/${repoFullName}/issues/${issueNumber}`,
+        "--jq",
+        "{user: {login: .user.login, type: .user.type}, author_association: .author_association, labels: [.labels[].name]}",
+    ]);
+}
+export function fetchPullRequestContext(repoFullName, prNumber) {
+    if (!isValidRepo(repoFullName) || !isValidIssueNumber(prNumber))
+        return null;
+    return safeGhJson([
+        "api",
+        `repos/${repoFullName}/pulls/${prNumber}`,
+        "--jq",
+        "{labels: [.labels[].name]}",
+    ]);
+}
+export function fetchUserRepoPermission(repoFullName, username) {
+    if (!isValidRepo(repoFullName))
+        return null;
+    if (typeof username !== "string" || username.length === 0)
+        return null;
+    const encodedUsername = encodeURIComponent(username);
+    const result = safeGhJson([
+        "api",
+        `repos/${repoFullName}/collaborators/${encodedUsername}/permission`,
+        "--jq",
+        "{permission, role_name}",
+    ]);
+    if (!result)
+        return null;
+    return result.permission || null;
+}
+export function isPermissionTrusted(permission) {
+    if (typeof permission !== "string")
+        return false;
+    return TRUSTED_PERMISSIONS.has(permission);
+}
+export function isAuthorAssociationTrusted(authorAssociation) {
+    if (typeof authorAssociation !== "string")
+        return false;
+    return TRUSTED_AUTHOR_ASSOCIATIONS.has(authorAssociation);
+}
+export function isBotUser(user) {
+    if (!user || typeof user !== "object")
+        return false;
+    if (user.type === "Bot")
+        return true;
+    if (typeof user.login === "string" && /\[bot\]$/i.test(user.login))
+        return true;
+    return false;
+}
+export function detectTrustedAuthorizerLocally({ issueContext, prContext, permission, governanceApprovedLabel = DEFAULT_GOVERNANCE_LABEL, trustedTeamApproval = false, codeownerApproved = false, }) {
+    const summary = {
+        issue_author_permission_trusted: false,
+        governance_approved_label: false,
+        codeowner_approved: Boolean(codeownerApproved),
+        trusted_team_approval: Boolean(trustedTeamApproval),
+        issue_author_is_bot: false,
+        detected_label: null,
+        detected_author_login: null,
+        detected_author_permission: null,
+        detected_author_association: null,
+    };
+    if (issueContext && typeof issueContext === "object") {
+        summary.detected_author_login = issueContext.user?.login || null;
+        summary.detected_author_association = issueContext.author_association || null;
+        summary.issue_author_is_bot = isBotUser(issueContext.user);
+        if (!summary.issue_author_is_bot) {
+            if (isPermissionTrusted(permission)) {
+                summary.issue_author_permission_trusted = true;
+                summary.detected_author_permission = permission;
+            }
+            else if (isAuthorAssociationTrusted(issueContext.author_association)) {
+                summary.issue_author_permission_trusted = true;
+                summary.detected_author_permission = issueContext.author_association;
+            }
+        }
+        const labels = Array.isArray(issueContext.labels) ? issueContext.labels : [];
+        if (labels.includes(governanceApprovedLabel)) {
+            summary.governance_approved_label = true;
+            summary.detected_label = governanceApprovedLabel;
+        }
+    }
+    if (prContext && typeof prContext === "object") {
+        const labels = Array.isArray(prContext.labels) ? prContext.labels : [];
+        if (labels.includes(governanceApprovedLabel)) {
+            summary.governance_approved_label = true;
+            summary.detected_label = governanceApprovedLabel;
+        }
+    }
+    return summary;
+}
+export function resolveTrustedAuthorizer({ repoFullName, issueNumber, prNumber, options = {}, }) {
+    const governanceApprovedLabel = options.governanceApprovedLabel || DEFAULT_GOVERNANCE_LABEL;
+    const issueContext = issueNumber ? fetchIssueAuthorContext(repoFullName, issueNumber) : null;
+    const prContext = prNumber ? fetchPullRequestContext(repoFullName, prNumber) : null;
+    const username = issueContext?.user?.login;
+    const permission = username && !isBotUser(issueContext.user)
+        ? fetchUserRepoPermission(repoFullName, username)
+        : null;
+    // codeowner_approved / trusted_team_approval are accepted as trust sources by
+    // the rule engine but are not yet auto-resolved from the GitHub API here.
+    // They flow in only through caller-provided options for tests / future work.
+    return detectTrustedAuthorizerLocally({
+        issueContext,
+        prContext,
+        permission,
+        governanceApprovedLabel,
+        trustedTeamApproval: options.trustedTeamApproval,
+        codeownerApproved: options.codeownerApproved,
+    });
+}

--- a/dist/utils/collections.mjs
+++ b/dist/utils/collections.mjs
@@ -1,0 +1,6 @@
+export function uniqueSorted(values = []) {
+    return [...new Set(values)].sort();
+}
+export function formatList(values) {
+    return values && values.length > 0 ? values.join(", ") : "(none)";
+}

--- a/dist/utils/path-patterns.mjs
+++ b/dist/utils/path-patterns.mjs
@@ -1,0 +1,11 @@
+import { minimatch } from "minimatch";
+import { uniqueSorted } from "./collections.mjs";
+export function matchesAny(filePath, patterns = []) {
+    return (patterns || []).some((pattern) => minimatch(filePath, pattern, { dot: true }));
+}
+export function normalizePathEntry(value) {
+    return String(value || "").trim().replace(/^\.\//, "");
+}
+export function normalizePathList(values = []) {
+    return uniqueSorted((values || []).map(normalizePathEntry).filter(Boolean));
+}

--- a/dist/utils/repository-files.mjs
+++ b/dist/utils/repository-files.mjs
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+function readFromCallback(filePath, options = {}) {
+    if (!options.readFile)
+        return undefined;
+    const content = options.readFile(filePath);
+    if (content === undefined || content === null) {
+        throw new Error(`cannot read ${filePath}`);
+    }
+    return content;
+}
+export function readRepositoryTextFile(filePath, options = {}) {
+    const callbackContent = readFromCallback(filePath, options);
+    if (callbackContent !== undefined) {
+        return Buffer.isBuffer(callbackContent)
+            ? callbackContent.toString("utf-8")
+            : String(callbackContent);
+    }
+    return readFileSync(resolve(options.repoRoot || process.cwd(), filePath), "utf-8");
+}
+export function readRepositoryBufferFile(filePath, options = {}) {
+    const callbackContent = readFromCallback(filePath, options);
+    if (callbackContent !== undefined) {
+        return Buffer.isBuffer(callbackContent)
+            ? callbackContent
+            : Buffer.from(String(callbackContent));
+    }
+    const fullPath = resolve(options.repoRoot || process.cwd(), filePath);
+    if (!existsSync(fullPath))
+        return null;
+    return readFileSync(fullPath);
+}

--- a/dist/validate.mjs
+++ b/dist/validate.mjs
@@ -1,0 +1,10 @@
+import { resolve } from "node:path";
+import { loadJSON, loadPolicyRuntime, validate } from "./runtime/validation.mjs";
+export function runValidate(roots, args) {
+    const runtime = loadPolicyRuntime(roots);
+    const { ajv, changeIntentSchema } = runtime;
+    let ok = runtime.ok;
+    if (args[0])
+        ok = validate(ajv, changeIntentSchema, loadJSON(resolve(roots.repoRoot, args[0])), args[0]) && ok;
+    return ok ? 0 : 1;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,354 @@
         "minimatch": "^10.2.5",
         "yaml": "^2.8.3"
       },
+      "devDependencies": {
+        "typescript": "7.0.2"
+      },
       "bin": {
-        "repo-guard": "src/repo-guard.mjs"
+        "repo-guard": "dist/repo-guard.mjs"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/ajv": {
@@ -107,6 +450,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "description": "Исполняемая политика репозитория с проверкой JSON Schema и правил по git diff",
   "type": "module",
-  "main": "src/repo-guard.mjs",
+  "main": "dist/repo-guard.mjs",
   "bin": {
-    "repo-guard": "src/repo-guard.mjs"
+    "repo-guard": "dist/repo-guard.mjs"
   },
   "files": [
-    "src/",
+    "dist/",
     "schemas/",
     "templates/",
     "docs/",
@@ -17,11 +17,15 @@
     "LICENSE"
   ],
   "scripts": {
-    "validate": "node src/repo-guard.mjs",
+    "build": "node scripts/build.mjs",
+    "check:dist": "node scripts/check-dist.mjs",
+    "validate": "node dist/repo-guard.mjs",
+    "pretest": "npm run check:dist",
     "test": "node tests/run.mjs",
     "compression:metrics": "node scripts/compression-metrics.mjs",
     "verify:release-ref": "node scripts/verify-release-ref.mjs",
-    "prepublishOnly": "npm run verify:release-ref"
+    "prepack": "npm run build",
+    "prepublishOnly": "npm run check:dist && npm run verify:release-ref"
   },
   "keywords": [
     "repo-policy",
@@ -37,5 +41,8 @@
     "ajv": "^8.17.1",
     "minimatch": "^10.2.5",
     "yaml": "^2.8.3"
+  },
+  "devDependencies": {
+    "typescript": "7.0.2"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { existsSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+export const repositoryRoot = resolve(dirname(scriptPath), "..");
+export const distRoot = resolve(repositoryRoot, "dist");
+
+function assertSafeBuildRoot() {
+  if (dirname(distRoot) !== repositoryRoot || distRoot === repositoryRoot) {
+    throw new Error(`refusing to clean unsafe dist path: ${distRoot}`);
+  }
+}
+
+export function cleanBuild() {
+  assertSafeBuildRoot();
+  const compiler = resolve(repositoryRoot, "node_modules", "typescript", "bin", "tsc");
+  if (!existsSync(compiler)) {
+    throw new Error("TypeScript compiler is missing; run npm ci before building");
+  }
+
+  rmSync(distRoot, { recursive: true, force: true });
+  const result = spawnSync(process.execPath, [compiler, "--project", resolve(repositoryRoot, "tsconfig.json")], {
+    cwd: repositoryRoot,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+if (resolve(process.argv[1] || "") === scriptPath) cleanBuild();

--- a/scripts/check-dist.mjs
+++ b/scripts/check-dist.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanBuild, repositoryRoot } from "./build.mjs";
+
+function git(args, options = {}) {
+  return spawnSync("git", args, { cwd: repositoryRoot, encoding: "utf-8", ...options });
+}
+
+export function checkDistFreshness() {
+  cleanBuild();
+
+  const diff = git(["diff", "--exit-code", "--", "dist"], { stdio: "inherit" });
+  if (diff.error) throw diff.error;
+
+  const untracked = git(["ls-files", "--others", "--exclude-standard", "--", "dist"]);
+  if (untracked.error) throw untracked.error;
+  if (untracked.status !== 0) {
+    process.stderr.write(untracked.stderr || "failed to inspect generated dist files\n");
+    process.exit(untracked.status ?? 1);
+  }
+
+  const untrackedFiles = untracked.stdout.split(/\r?\n/).filter(Boolean);
+  if (diff.status !== 0 || untrackedFiles.length) {
+    if (untrackedFiles.length) {
+      console.error("Generated dist contains untracked files:");
+      for (const path of untrackedFiles) console.error(`  ${path}`);
+    }
+    console.error("Generated dist is stale. Run npm run build and commit the exact dist output.");
+    process.exit(diff.status && diff.status > 1 ? diff.status : 1);
+  }
+
+  console.log("Generated dist is current.");
+}
+
+if (resolve(process.argv[1] || "") === fileURLToPath(import.meta.url)) checkDistFreshness();

--- a/tests/test-anchor-extractors.mjs
+++ b/tests/test-anchor-extractors.mjs
@@ -1,7 +1,7 @@
 import { strict as assert } from "node:assert";
-import { buildPolicyFacts } from "../src/facts/input.mjs";
-import { extractAnchors } from "../src/extractors/anchors.mjs";
-import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+import { buildPolicyFacts } from "../dist/facts/input.mjs";
+import { extractAnchors } from "../dist/extractors/anchors.mjs";
+import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
 let failures = 0;
 

--- a/tests/test-build-boundary.mjs
+++ b/tests/test-build-boundary.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const projectRoot = resolve(new URL("..", import.meta.url).pathname);
+const read = (path) => readFileSync(resolve(projectRoot, path), "utf-8");
+
+console.log("\n--- package and Action execute checked dist without runtime TypeScript ---");
+{
+  const pkg = JSON.parse(read("package.json"));
+  assert.equal(pkg.main, "dist/repo-guard.mjs");
+  assert.equal(pkg.bin["repo-guard"], "dist/repo-guard.mjs");
+  assert.equal(pkg.files.includes("dist/"), true);
+  assert.equal(pkg.files.includes("src/"), false);
+  assert.equal(pkg.dependencies.typescript, undefined);
+  assert.equal(pkg.devDependencies.typescript, "7.0.2");
+
+  const config = JSON.parse(read("tsconfig.json"));
+  assert.equal(config.compilerOptions.module, "NodeNext");
+  assert.equal(config.compilerOptions.moduleResolution, "NodeNext");
+  assert.equal(config.compilerOptions.allowJs, true);
+  assert.equal(config.compilerOptions.checkJs, false);
+  assert.deepEqual(config.include, ["src/**/*.mjs"]);
+
+  const action = read("action.yml");
+  assert.match(action, /node \$\{GITHUB_ACTION_PATH\}\/dist\/repo-guard\.mjs/);
+  assert.doesNotMatch(action, /GITHUB_ACTION_PATH\}\/src\/repo-guard\.mjs/);
+  assert.match(action, /npm install --omit=dev --silent/);
+
+  const workflow = read(".github/workflows/ci.yml");
+  assert.match(workflow, /name: Verify generated dist freshness\n\s+run: npm run check:dist/);
+  assert.match(workflow, /node dist\/repo-guard\.mjs --enforcement advisory check-diff/);
+}
+
+console.log("\n--- stale generated dist is rejected ---");
+{
+  const sourcePath = resolve(projectRoot, "src/utils/collections.mjs");
+  const distPath = resolve(projectRoot, "dist/utils/collections.mjs");
+  const sourceBefore = readFileSync(sourcePath, "utf-8");
+  const distBefore = readFileSync(distPath, "utf-8");
+  try {
+    writeFileSync(sourcePath, `${sourceBefore}\n// stale-dist-fixture\n`);
+    const result = spawnSync(process.execPath, [resolve(projectRoot, "scripts/check-dist.mjs")], {
+      cwd: projectRoot,
+      encoding: "utf-8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}\n${result.stderr}`, /Generated dist is stale/);
+  } finally {
+    writeFileSync(sourcePath, sourceBefore);
+    writeFileSync(distPath, distBefore);
+  }
+}
+
+console.log("\n--- untracked generated output is rejected ---");
+{
+  const sourcePath = resolve(projectRoot, "src/untracked-dist-fixture.mjs");
+  const distPath = resolve(projectRoot, "dist/untracked-dist-fixture.mjs");
+  try {
+    writeFileSync(sourcePath, "export const fixture = true;\n");
+    const result = spawnSync(process.execPath, [resolve(projectRoot, "scripts/check-dist.mjs")], {
+      cwd: projectRoot,
+      encoding: "utf-8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(`${result.stdout}\n${result.stderr}`, /Generated dist contains untracked files/);
+  } finally {
+    try { unlinkSync(sourcePath); } catch {}
+    try { unlinkSync(distPath); } catch {}
+  }
+}
+
+console.log("Build boundary tests passed.");

--- a/tests/test-change-intent.mjs
+++ b/tests/test-change-intent.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { extractChangeIntent, extractGovernanceGrant, extractLinkedIssueNumbers, resolveChangeIntent } from "../src/change-intent.mjs";
+import { extractChangeIntent, extractGovernanceGrant, extractLinkedIssueNumbers, resolveChangeIntent } from "../dist/change-intent.mjs";
 
 const root = resolve(new URL("..", import.meta.url).pathname);
 const selfPolicy = JSON.parse(readFileSync(resolve(root, "repo-policy.json"), "utf-8"));

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { runCli } from "../src/repo-guard.mjs";
+import { runCli } from "../dist/repo-guard.mjs";
 
 const originalError = console.error, errors = [];
 console.error = (...args) => errors.push(args.join(" "));

--- a/tests/test-compression-rules.mjs
+++ b/tests/test-compression-rules.mjs
@@ -1,11 +1,11 @@
-import { defaultRuleFamilies } from "../src/checks/default-rule-families.mjs";
-import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
-import { checkChangeProfile } from "../src/checks/rules/change-profiles.mjs";
-import { compileConstraintIR, evaluateConstraintIR } from "../src/checks/rules/constraints.mjs";
-import { comparePolicyStrictness } from "../src/checks/rules/policy-delta-rules.mjs";
-import { checkSizeRules } from "../src/checks/rules/size-rules.mjs";
-import { parseMarkdown } from "../src/document-facts.mjs";
-import { classifyPathSets, selectPaths } from "../src/diff/classification.mjs";
+import { defaultRuleFamilies } from "../dist/checks/default-rule-families.mjs";
+import { checkContentRules } from "../dist/checks/rules/content-rules.mjs";
+import { checkChangeProfile } from "../dist/checks/rules/change-profiles.mjs";
+import { compileConstraintIR, evaluateConstraintIR } from "../dist/checks/rules/constraints.mjs";
+import { comparePolicyStrictness } from "../dist/checks/rules/policy-delta-rules.mjs";
+import { checkSizeRules } from "../dist/checks/rules/size-rules.mjs";
+import { parseMarkdown } from "../dist/document-facts.mjs";
+import { classifyPathSets, selectPaths } from "../dist/diff/classification.mjs";
 
 let failures = 0;
 function expect(label, actual, expected) {

--- a/tests/test-current-base-ref.mjs
+++ b/tests/test-current-base-ref.mjs
@@ -5,7 +5,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+const repoGuard = resolve(projectRoot, "dist/repo-guard.mjs");
 let failures = 0;
 const expect = (label, condition) => { const ok = Boolean(condition); console.log(`${ok ? "PASS" : "FAIL"}: ${label}`); if (!ok) failures++; };
 const git = (cwd, ...args) => execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" }).trim();

--- a/tests/test-diff-rules.mjs
+++ b/tests/test-diff-rules.mjs
@@ -1,16 +1,16 @@
 import assert from "node:assert/strict";
-import { classifyNewFiles, detectTouchedSurfaces } from "../src/diff/classification.mjs";
-import { filterOperationalPaths } from "../src/diff/filters.mjs";
-import { parseDiff } from "../src/diff/parser.mjs";
-import { checkAdvisoryTextRules } from "../src/checks/rules/advisory-text-rules.mjs";
-import { checkChangeProfile } from "../src/checks/rules/change-profiles.mjs";
-import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
+import { classifyNewFiles, detectTouchedSurfaces } from "../dist/diff/classification.mjs";
+import { filterOperationalPaths } from "../dist/diff/filters.mjs";
+import { parseDiff } from "../dist/diff/parser.mjs";
+import { checkAdvisoryTextRules } from "../dist/checks/rules/advisory-text-rules.mjs";
+import { checkChangeProfile } from "../dist/checks/rules/change-profiles.mjs";
+import { checkContentRules } from "../dist/checks/rules/content-rules.mjs";
 import {
   checkCanonicalDocsBudget, checkCochangeRules, checkForbiddenPaths, checkMustNotTouch, checkMustTouch,
   checkNetAddedLinesBudget, checkNewFilesBudget, checkScope, checkSurfaceDebt,
-} from "../src/checks/rules/constraints.mjs";
-import { checkRegistryRules } from "../src/checks/rules/registry-rules.mjs";
-import { checkSizeRules, countTextLines } from "../src/checks/rules/size-rules.mjs";
+} from "../dist/checks/rules/constraints.mjs";
+import { checkRegistryRules } from "../dist/checks/rules/registry-rules.mjs";
+import { checkSizeRules, countTextLines } from "../dist/checks/rules/size-rules.mjs";
 
 const sampleDiff = [
   "diff --git a/src/app.mjs b/src/app.mjs", "new file mode 100644", "--- /dev/null", "+++ b/src/app.mjs", "+one", "+two",

--- a/tests/test-doctor.mjs
+++ b/tests/test-doctor.mjs
@@ -58,7 +58,7 @@ function validPolicy() {
 }
 
 function runRepoGuard(args = "", opts = {}) {
-  const cmd = `node ${resolve(projectRoot, "src/repo-guard.mjs")} ${args}`;
+  const cmd = `node ${resolve(projectRoot, "dist/repo-guard.mjs")} ${args}`;
   try {
     const stdout = execSync(cmd, { encoding: "utf-8", cwd: opts.cwd || projectRoot, stdio: ["pipe", "pipe", "pipe"] });
     return { stdout, stderr: "", code: 0 };

--- a/tests/test-documentation-language.mjs
+++ b/tests/test-documentation-language.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
-import { checkContentRules } from "../src/checks/rules/content-rules.mjs";
+import { checkContentRules } from "../dist/checks/rules/content-rules.mjs";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const projectRoot = resolve(__dirname, "..");

--- a/tests/test-enforcement-mode.mjs
+++ b/tests/test-enforcement-mode.mjs
@@ -5,7 +5,7 @@ import { execSync, spawnSync } from "node:child_process";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const projectRoot = resolve(__dirname, "..");
-const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+const repoGuard = resolve(projectRoot, "dist/repo-guard.mjs");
 
 let failures = 0;
 

--- a/tests/test-github-pr.mjs
+++ b/tests/test-github-pr.mjs
@@ -4,11 +4,11 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } 
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync, spawnSync } from "node:child_process";
-import { loadGitHubEvent, resolvePRChangeIntentFacts } from "../src/github-pr.mjs";
-import { extractLinkedIssueNumbers, resolveChangeIntent } from "../src/change-intent.mjs";
+import { loadGitHubEvent, resolvePRChangeIntentFacts } from "../dist/github-pr.mjs";
+import { extractLinkedIssueNumbers, resolveChangeIntent } from "../dist/change-intent.mjs";
 
 const projectRoot = resolve(new URL("..", import.meta.url).pathname);
-const cli = resolve(projectRoot, "src/repo-guard.mjs");
+const cli = resolve(projectRoot, "dist/repo-guard.mjs");
 const git = (cwd, ...args) => execFileSync("git", args, { cwd, encoding: "utf-8", stdio: "pipe" }).trim();
 const intent = (scope = ["src/**"], type = "feature") => `\`\`\`repo-guard-yaml
 change_type: ${type}

--- a/tests/test-governance-paths.mjs
+++ b/tests/test-governance-paths.mjs
@@ -1,11 +1,11 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
-import { checkGovernanceChangeAuthorization } from "../src/checks/rules/governance-paths.mjs";
-import { createDefaultRuleRegistry } from "../src/checks/default-rule-families.mjs";
-import { buildPolicyFacts } from "../src/facts/input.mjs";
-import { runPolicyChecks } from "../src/checks/orchestrator.mjs";
-import { createAnalysisCollector } from "../src/runtime/analysis-report.mjs";
-import { extractGovernanceGrant } from "../src/change-intent.mjs";
+import { checkGovernanceChangeAuthorization } from "../dist/checks/rules/governance-paths.mjs";
+import { createDefaultRuleRegistry } from "../dist/checks/default-rule-families.mjs";
+import { buildPolicyFacts } from "../dist/facts/input.mjs";
+import { runPolicyChecks } from "../dist/checks/orchestrator.mjs";
+import { createAnalysisCollector } from "../dist/runtime/analysis-report.mjs";
+import { extractGovernanceGrant } from "../dist/change-intent.mjs";
 
 const PATHS = ["repo-policy.json", "schemas/", ".github/workflows/", ".github/PULL_REQUEST_TEMPLATE.md", ".github/ISSUE_TEMPLATE/", "templates/", "action.yml"];
 const TRUSTED = { issue_author_permission_trusted: true, governance_approved_label: false, codeowner_approved: false, trusted_team_approval: false };

--- a/tests/test-hardening.mjs
+++ b/tests/test-hardening.mjs
@@ -5,12 +5,12 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { execSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../src/policy-compiler.mjs";
-import { checkMustTouch } from "../src/checks/rules/constraints.mjs";
-import { checkIssueFallbackPrerequisites, checkPrerequisites } from "../src/github-pr.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../dist/policy-compiler.mjs";
+import { checkMustTouch } from "../dist/checks/rules/constraints.mjs";
+import { checkIssueFallbackPrerequisites, checkPrerequisites } from "../dist/github-pr.mjs";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+const repoGuard = resolve(projectRoot, "dist/repo-guard.mjs");
 const runRepoGuard = (args, options = {}) => spawnSync(process.execPath, [repoGuard, ...args], { cwd: options.cwd || projectRoot, env: options.env || process.env, encoding: "utf-8" });
 
 function initTinyRepo(prefix) {

--- a/tests/test-init.mjs
+++ b/tests/test-init.mjs
@@ -6,7 +6,7 @@ import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
 import Ajv from "ajv";
 
-const root = resolve(new URL("..", import.meta.url).pathname), cli = resolve(root, "src/repo-guard.mjs");
+const root = resolve(new URL("..", import.meta.url).pathname), cli = resolve(root, "dist/repo-guard.mjs");
 const schema = JSON.parse(readFileSync(resolve(root, "schemas/repo-policy.schema.json"), "utf-8"));
 const version = JSON.parse(readFileSync(resolve(root, "package.json"), "utf-8")).version;
 const validate = new Ajv({ allErrors: true }).compile(schema);

--- a/tests/test-integration-diagnostics.mjs
+++ b/tests/test-integration-diagnostics.mjs
@@ -36,7 +36,7 @@ function expectTrue(label, value) {
 
 function runGuard(args) {
   const result = spawnSync(process.execPath, [
-    resolve(projectRoot, "src/repo-guard.mjs"),
+    resolve(projectRoot, "dist/repo-guard.mjs"),
     ...args,
   ], {
     cwd: projectRoot,
@@ -236,7 +236,7 @@ function makeBrokenRepo() {
     "        continue-on-error: true",
     "        run: |",
     "          git clone https://github.com/netkeep80/repo-guard \"$RUNNER_TEMP/repo-guard\"",
-    "          node \"$RUNNER_TEMP/repo-guard/src/repo-guard.mjs\" check-diff",
+    "          node \"$RUNNER_TEMP/repo-guard/dist/repo-guard.mjs\" check-diff",
     "",
   ].join("\n"));
   writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), "## Missing ChangeIntent\n");

--- a/tests/test-integration-extractors.mjs
+++ b/tests/test-integration-extractors.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
-import { buildPolicyFacts } from "../src/facts/input.mjs";
-import { extractIntegration } from "../src/extractors/integration.mjs";
+import { buildPolicyFacts } from "../dist/facts/input.mjs";
+import { extractIntegration } from "../dist/extractors/integration.mjs";
 
 let failures = 0;
 
@@ -129,7 +129,7 @@ const files = {
     "        env:",
     "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
     "        run: |",
-    "          node src/repo-guard.mjs check-pr",
+    "          node dist/repo-guard.mjs check-pr",
     "          echo \"### repo-guard\" >> \"$GITHUB_STEP_SUMMARY\"",
     "      - uses: ./",
     "        with:",

--- a/tests/test-integration-fixtures.mjs
+++ b/tests/test-integration-fixtures.mjs
@@ -153,7 +153,7 @@ function makeFixtureRepo({ workflow, prTemplate, issueTemplate = null, readme })
 
 function runGuard(args, cwd = projectRoot) {
   const result = spawnSync(process.execPath, [
-    resolve(projectRoot, "src/repo-guard.mjs"),
+    resolve(projectRoot, "dist/repo-guard.mjs"),
     ...args,
   ], {
     cwd,

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -2,9 +2,9 @@ import { strict as assert } from "node:assert";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { buildPolicyFacts } from "../src/facts/input.mjs";
-import { createIntegrationAnalysisReport } from "../src/integration-validator.mjs";
-import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+import { buildPolicyFacts } from "../dist/facts/input.mjs";
+import { createIntegrationAnalysisReport } from "../dist/integration-validator.mjs";
+import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
 let failures = 0;
 const __dirname = new URL(".", import.meta.url).pathname;

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
-import { checkPolicyRelaxation, classifyChangedFiles, computePolicyDelta, policyRelaxationRuleFamily } from "../src/checks/rules/policy-delta-rules.mjs";
+import { checkPolicyRelaxation, classifyChangedFiles, computePolicyDelta, policyRelaxationRuleFamily } from "../dist/checks/rules/policy-delta-rules.mjs";
 
 const file = (path, extra = {}) => ({ path, status: "modified", addedLines: [], deletedLines: [], ...extra });
 const TRUSTED = { issue_author_permission_trusted: true };

--- a/tests/test-policy-profiles.mjs
+++ b/tests/test-policy-profiles.mjs
@@ -4,8 +4,8 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { strict as assert } from "node:assert";
 import Ajv from "ajv";
-import { loadJSON, loadPolicyRuntime } from "../src/runtime/validation.mjs";
-import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+import { loadJSON, loadPolicyRuntime } from "../dist/runtime/validation.mjs";
+import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");

--- a/tests/test-repo-root.mjs
+++ b/tests/test-repo-root.mjs
@@ -3,7 +3,7 @@ import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { resolveRoots } from "../src/repo-guard.mjs";
+import { resolveRoots } from "../dist/repo-guard.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
@@ -61,7 +61,7 @@ function expect(label, actual, expected) {
 
 {
   try {
-    const output = execSync(`node src/repo-guard.mjs`, {
+    const output = execSync(`node dist/repo-guard.mjs`, {
       encoding: "utf-8",
       cwd: projectRoot,
     });
@@ -78,7 +78,7 @@ function expect(label, actual, expected) {
   const binDir = join(tmp, "node_modules", ".bin");
   mkdirSync(binDir, { recursive: true });
   const binPath = join(binDir, "repo-guard");
-  symlinkSync(resolve(projectRoot, "src/repo-guard.mjs"), binPath);
+  symlinkSync(resolve(projectRoot, "dist/repo-guard.mjs"), binPath);
 
   try {
     const output = execSync(
@@ -113,7 +113,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs --repo-root ${tmp}`,
+      `node dist/repo-guard.mjs --repo-root ${tmp}`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("--repo-root validate loads external policy", output.includes("OK: repo-policy.json"), true);
@@ -144,7 +144,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs --repo-root ${tmp}`,
+      `node dist/repo-guard.mjs --repo-root ${tmp}`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("schemas load from package (no schemas/ in target)", output.includes("OK: repo-policy.json"), true);
@@ -183,7 +183,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
+      `node dist/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("check-diff --repo-root uses target git", output.includes("1 file(s) changed"), true);
@@ -226,7 +226,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs --repo-root ${tmp} change-intents/change.json`,
+      `node dist/repo-guard.mjs --repo-root ${tmp} change-intents/change.json`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("validate resolves ChangeIntent relative to repoRoot", output.includes("OK: repo-policy.json"), true);
@@ -280,7 +280,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD --change-intent change-intents/change.json`,
+      `node dist/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD --change-intent change-intents/change.json`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("check-diff resolves --change-intent relative to repoRoot", output.includes("1 file(s) changed"), true);
@@ -322,7 +322,7 @@ function expect(label, actual, expected) {
 
   try {
     const result = execSync(
-      `node src/repo-guard.mjs --repo-root ${tmp} check-pr 2>&1`,
+      `node dist/repo-guard.mjs --repo-root ${tmp} check-pr 2>&1`,
       { encoding: "utf-8", cwd: projectRoot, env: Object.fromEntries(Object.entries(process.env).filter(([k]) => k !== "GITHUB_EVENT_PATH")) }
     );
     const isCheckPR = result.includes("check-pr") && !result.includes("ENOENT");
@@ -364,7 +364,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs --repo-root ${tmp} check-diff --base HEAD~1 --head HEAD`,
+      `node dist/repo-guard.mjs --repo-root ${tmp} check-diff --base HEAD~1 --head HEAD`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("pre-command --repo-root check-diff works", output.includes("1 file(s) changed"), true);
@@ -407,7 +407,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs --repo-root ${tmp} change-intents/change.json`,
+      `node dist/repo-guard.mjs --repo-root ${tmp} change-intents/change.json`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("pre-command --repo-root validate with ChangeIntent works", output.includes("OK: repo-policy.json"), true);
@@ -426,7 +426,7 @@ function expect(label, actual, expected) {
 {
   try {
     execSync(
-      `node src/repo-guard.mjs --unknown-flag 2>&1`,
+      `node dist/repo-guard.mjs --unknown-flag 2>&1`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("unknown option exits with error", false, true);
@@ -465,7 +465,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
+      `node dist/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("post-command --repo-root check-diff still works", output.includes("1 file(s) changed"), true);
@@ -481,7 +481,7 @@ function expect(label, actual, expected) {
 {
   try {
     execSync(
-      `node src/repo-guard.mjs --repo-root 2>&1`,
+      `node dist/repo-guard.mjs --repo-root 2>&1`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("--repo-root without value exits with error", false, true);
@@ -497,7 +497,7 @@ function expect(label, actual, expected) {
 {
   try {
     execSync(
-      `node src/repo-guard.mjs check-diff --repo-root --base HEAD~1 --head HEAD 2>&1`,
+      `node dist/repo-guard.mjs check-diff --repo-root --base HEAD~1 --head HEAD 2>&1`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("--repo-root --base exits with error", false, true);
@@ -512,7 +512,7 @@ function expect(label, actual, expected) {
 {
   try {
     execSync(
-      `node src/repo-guard.mjs check-diff --hed HEAD 2>&1`,
+      `node dist/repo-guard.mjs check-diff --hed HEAD 2>&1`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("unknown check-diff option exits with error", false, true);
@@ -551,7 +551,7 @@ function expect(label, actual, expected) {
 
   try {
     const output = execSync(
-      `node src/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
+      `node dist/repo-guard.mjs check-diff --repo-root ${tmp} --base HEAD~1 --head HEAD`,
       { encoding: "utf-8", cwd: projectRoot }
     );
     expect("known check-diff options still accepted", output.includes("1 file(s) changed"), true);

--- a/tests/test-rule-registry.mjs
+++ b/tests/test-rule-registry.mjs
@@ -1,7 +1,7 @@
 import {
   createDefaultRuleRegistry,
   defaultRuleFamilies,
-} from "../src/checks/default-rule-families.mjs";
+} from "../dist/checks/default-rule-families.mjs";
 
 let failures = 0;
 

--- a/tests/test-self-hosting.mjs
+++ b/tests/test-self-hosting.mjs
@@ -2,10 +2,10 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { defaultRuleFamilies } from "../src/checks/default-rule-families.mjs";
-import { parseYaml } from "../src/document-facts.mjs";
-import { listBuiltInProfiles } from "../src/policy-profiles.mjs";
-import { COMMANDS } from "../src/repo-guard.mjs";
+import { defaultRuleFamilies } from "../dist/checks/default-rule-families.mjs";
+import { parseYaml } from "../dist/document-facts.mjs";
+import { listBuiltInProfiles } from "../dist/policy-profiles.mjs";
+import { COMMANDS } from "../dist/repo-guard.mjs";
 
 const projectRoot = resolve(new URL("..", import.meta.url).pathname);
 const read = (path) => readFileSync(resolve(projectRoot, path), "utf-8");

--- a/tests/test-structured-output.mjs
+++ b/tests/test-structured-output.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 
 const __dirname = new URL(".", import.meta.url).pathname;
 const projectRoot = resolve(__dirname, "..");
-const repoGuard = resolve(projectRoot, "src/repo-guard.mjs");
+const repoGuard = resolve(projectRoot, "dist/repo-guard.mjs");
 let failures = 0;
 
 function expect(label, actual, expected) {

--- a/tests/test-trace-evidence-rules.mjs
+++ b/tests/test-trace-evidence-rules.mjs
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { runPolicyPipeline } from "../src/runtime/pipeline.mjs";
+import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
 let failures = 0;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "noEmitOnError": true,
+    "declaration": false,
+    "sourceMap": false,
+    "removeComments": false,
+    "newLine": "lf",
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.mjs"]
+}


### PR DESCRIPTION
Fixes #183.
Refs #158, #159, #153.
Supersedes #184 after governance bridge #186.

## What changed

- adds the NodeNext/TypeScript bridge `src/**/*.mjs -> dist/**/*.mjs`;
- switches npm `main`/`bin`, composite Action, behavioral tests and direct CI execution to `dist`;
- pins TypeScript 7.0.2 plus official optional platform artifacts as development-only dependencies;
- adds a clean freshness veto for tracked drift and untracked generated output;
- preserves source filenames and internal `.mjs` specifiers for incremental `.mts` conversion.

## Boundary

Consumers receive executable JavaScript and production dependencies only. The Action never installs or executes TypeScript. `src` remains the sole editable source; `dist` is deterministic derived output.

## Proven validation

- real pinned compiler: 45 source modules -> 45 dist modules;
- draft freshness, complete discovered suite, validate-integration, doctor and advisory mode green;
- packaged npm artifact smoke green;
- dedicated stale and untracked output negative tests green;
- blocking self-policy previously reached the intended generated-class veto; governance bridge #186 is now merged into this PR's base;
- replacement branch is current to main, with no policy, source or schema delta.