### PR TITLE
Governance: keep .mts files inside source size metrics

### DIFF
--- a/repo-policy.json
+++ b/repo-policy.json
@@ -188,7 +188,7 @@
       "id": "max-source-file-lines",
       "scope": "file",
       "metric": "lines",
-      "glob": "src/**/*.mjs",
+      "glob": "src/**/*.{mjs,mts}",
       "max": 900,
       "count": "all_tracked",
       "level": "advisory"


### PR DESCRIPTION
Fixes #188.
Refs #159, #153.

Extends the existing advisory source-size selector from `src/**/*.mjs` to `src/**/*.{mjs,mts}` so incremental TypeScript renames cannot escape the measured editable-source surface.

Exact scope: one governance file, one replacement line. Limits, level, count mode and max-growth remain unchanged.