### PR TITLE
TypeScript: convert policy-check orchestrator leaf

### DIFF
--- a/src/checks/orchestrator.mjs
+++ b/src/checks/orchestrator.mjs
@@ -1,9 +1,0 @@
-import { createDefaultRuleRegistry } from "./default-rule-families.mjs";
-
-export function runPolicyChecks(facts, reporter, options = {}) {
-  const registry = options.registry || createDefaultRuleRegistry();
-
-  for (const entry of registry.evaluate(facts, options)) {
-    reporter.report(entry.name, entry.check);
-  }
-}

--- a/src/checks/orchestrator.mts
+++ b/src/checks/orchestrator.mts
@@ -1,0 +1,18 @@
+import { createDefaultRuleRegistry } from "./default-rule-families.mjs";
+import type { RuleRegistry } from "./rule-registry.mjs";
+
+export interface PolicyCheckReporter {
+  report(name: string, check: unknown): unknown;
+}
+
+export interface PolicyCheckOptions extends Record<string, unknown> {
+  registry?: RuleRegistry;
+}
+
+export function runPolicyChecks(facts: unknown, reporter: PolicyCheckReporter, options: PolicyCheckOptions = {}): void {
+  const registry = options.registry || createDefaultRuleRegistry();
+
+  for (const entry of registry.evaluate(facts, options)) {
+    reporter.report(entry.name, entry.check);
+  }
+}

--- a/tests/test-build-boundary.mjs
+++ b/tests/test-build-boundary.mjs
@@ -56,6 +56,8 @@ console.log("\n--- package and Action execute checked dist without runtime TypeS
   assert.equal(existsSync(resolve(projectRoot, "src/checks/rule-registry.mjs")), false);
   assert.equal(existsSync(resolve(projectRoot, "src/checks/default-rule-families.mts")), true);
   assert.equal(existsSync(resolve(projectRoot, "src/checks/default-rule-families.mjs")), false);
+  assert.equal(existsSync(resolve(projectRoot, "src/checks/orchestrator.mts")), true);
+  assert.equal(existsSync(resolve(projectRoot, "src/checks/orchestrator.mjs")), false);
   assert.equal(existsSync(resolve(projectRoot, "dist/utils/repository-files.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/git.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/diff/parser.mjs")), true);
@@ -69,6 +71,7 @@ console.log("\n--- package and Action execute checked dist without runtime TypeS
   assert.equal(existsSync(resolve(projectRoot, "dist/checks/relation-kernel.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/checks/rule-registry.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/checks/default-rule-families.mjs")), true);
+  assert.equal(existsSync(resolve(projectRoot, "dist/checks/orchestrator.mjs")), true);
 
   const action = read("action.yml");
   assert.match(action, /node \$\{GITHUB_ACTION_PATH\}\/dist\/repo-guard\.mjs/);


### PR DESCRIPTION
Fixes #214.
Refs #159, #153.

Continue the strict-TypeScript source migration with the tiny policy-check orchestration boundary:

- replaces `src/checks/orchestrator.mjs` with strict `orchestrator.mts`;
- reuses the canonical rule-registry type boundary;
- types only reporter/options while keeping facts and check payloads generic;
- preserves registry selection, evaluation order and reporter calls exactly;
- removes the old editable `.mjs` source with no wrapper.

The checked `dist/checks/orchestrator.mjs` is intentionally unchanged; draft CI freshness must prove type erasure preserves the generated runtime exactly.

```repo-guard-yaml
change_type: feature
scope:
  - src/checks/orchestrator.mjs
  - src/checks/orchestrator.mts
  - tests/test-build-boundary.mjs
  - dist/checks/orchestrator.mjs
budgets:
  max_new_docs: 0
  max_new_files: 1
  max_net_added_lines: 60
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/checks/orchestrator.mts
  - tests/test-build-boundary.mjs
must_not_touch:
  - repo-policy.json
  - schemas/**
  - action.yml
  - .github/**
expected_effects:
  - policy-check orchestrator compiles under strict TypeScript
  - reporter and registry option boundaries are explicit
  - evaluation/report ordering remains unchanged
  - emitted mjs path and runtime bytes remain stable
  - editable mjs copy is removed
```