### PR TITLE
TypeScript: convert anchor rule-family leaf

### DIFF
--- a/src/checks/rules/anchor-rules.mjs
+++ b/src/checks/rules/anchor-rules.mjs
@@ -1,7 +1,0 @@
-import { checkAnchorExtraction } from "../../extractors/anchors.mjs";
-
-export const anchorExtractionRuleFamily = {
-  id: "anchor-extraction",
-  applies: (facts) => Boolean(facts.policy.anchors),
-  evaluate: (facts) => ({ name: "anchor-extraction", check: checkAnchorExtraction(facts.anchors) }),
-};

--- a/src/checks/rules/anchor-rules.mts
+++ b/src/checks/rules/anchor-rules.mts
@@ -1,0 +1,14 @@
+import type { AnchorExtraction } from "../../extractors/anchors.mjs";
+import { checkAnchorExtraction } from "../../extractors/anchors.mjs";
+import type { RuleFamily } from "../rule-registry.mjs";
+
+interface AnchorRuleFacts {
+  policy: { anchors?: unknown };
+  anchors: AnchorExtraction;
+}
+
+export const anchorExtractionRuleFamily: RuleFamily = {
+  id: "anchor-extraction",
+  applies: (facts) => Boolean((facts as AnchorRuleFacts).policy.anchors),
+  evaluate: (facts) => ({ name: "anchor-extraction", check: checkAnchorExtraction((facts as AnchorRuleFacts).anchors) }),
+};

--- a/tests/test-build-boundary.mjs
+++ b/tests/test-build-boundary.mjs
@@ -58,6 +58,8 @@ console.log("\n--- package and Action execute checked dist without runtime TypeS
   assert.equal(existsSync(resolve(projectRoot, "src/checks/default-rule-families.mjs")), false);
   assert.equal(existsSync(resolve(projectRoot, "src/checks/orchestrator.mts")), true);
   assert.equal(existsSync(resolve(projectRoot, "src/checks/orchestrator.mjs")), false);
+  assert.equal(existsSync(resolve(projectRoot, "src/checks/rules/anchor-rules.mts")), true);
+  assert.equal(existsSync(resolve(projectRoot, "src/checks/rules/anchor-rules.mjs")), false);
   assert.equal(existsSync(resolve(projectRoot, "dist/utils/repository-files.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/git.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/diff/parser.mjs")), true);
@@ -72,6 +74,7 @@ console.log("\n--- package and Action execute checked dist without runtime TypeS
   assert.equal(existsSync(resolve(projectRoot, "dist/checks/rule-registry.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/checks/default-rule-families.mjs")), true);
   assert.equal(existsSync(resolve(projectRoot, "dist/checks/orchestrator.mjs")), true);
+  assert.equal(existsSync(resolve(projectRoot, "dist/checks/rules/anchor-rules.mjs")), true);
 
   const action = read("action.yml");
   assert.match(action, /node \$\{GITHUB_ACTION_PATH\}\/dist\/repo-guard\.mjs/);


### PR DESCRIPTION
Fixes #216.
Refs #159, #153.

Continue the strict-TypeScript source migration with the smallest concrete rule family:

- replaces `src/checks/rules/anchor-rules.mjs` with strict `anchor-rules.mts`;
- reuses the canonical `RuleFamily` and `AnchorExtraction` type boundaries;
- types only the minimal facts projection consumed by this family;
- preserves applicability, rule name, check construction and diagnostics exactly;
- removes the old editable `.mjs` source with no wrapper.

The checked `dist/checks/rules/anchor-rules.mjs` is intentionally unchanged; draft CI freshness must prove type erasure preserves the generated runtime exactly.

```repo-guard-yaml
change_type: feature
scope:
  - src/checks/rules/anchor-rules.mjs
  - src/checks/rules/anchor-rules.mts
  - tests/test-build-boundary.mjs
  - dist/checks/rules/anchor-rules.mjs
budgets:
  max_new_docs: 0
  max_new_files: 1
  max_net_added_lines: 50
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/checks/rules/anchor-rules.mts
  - tests/test-build-boundary.mjs
must_not_touch:
  - repo-policy.json
  - schemas/**
  - action.yml
  - .github/**
expected_effects:
  - anchor extraction rule family compiles under strict TypeScript
  - its minimal facts projection is explicit
  - rule behavior and diagnostics remain unchanged
  - emitted mjs path and runtime bytes remain stable
  - editable mjs copy is removed
```