### PR TITLE
Contract governance R1a: centralize strict JSON Pointer facts

### DIFF
--- a/dist/checks/rules/registry-rules.mjs
+++ b/dist/checks/rules/registry-rules.mjs
@@ -1,22 +1,8 @@
-import { createDocumentReader, markdownSection } from "../../document-facts.mjs";
+import { createDocumentReader, markdownSection, resolveJsonPointer } from "../../document-facts.mjs";
 import { compareSets } from "../relation-kernel.mjs";
 import { formatList, uniqueSorted } from "../../utils/collections.mjs";
 import { normalizePathEntry } from "../../utils/path-patterns.mjs";
 const normalizeAll = (values) => uniqueSorted(values.map(normalizePathEntry).filter(Boolean));
-function resolveJsonPointer(data, pointer) {
-    if (pointer === "")
-        return data;
-    if (!pointer?.startsWith("/"))
-        throw new Error(`invalid json_pointer "${pointer}"`);
-    let current = data;
-    for (const raw of pointer.slice(1).split("/")) {
-        const part = raw.replace(/~1/g, "/").replace(/~0/g, "~");
-        if (current == null || !Object.hasOwn(current, part))
-            throw new Error(`json_pointer "${pointer}" does not exist`);
-        current = current[part];
-    }
-    return current;
-}
 function normalizeMarkdownLinkTarget(target, source) {
     const clean = normalizePathEntry(target.split("#")[0].split("?")[0]);
     if (!clean || /^[a-z][a-z0-9+.-]*:/i.test(clean) || clean.startsWith("#"))

--- a/dist/document-facts.mjs
+++ b/dist/document-facts.mjs
@@ -12,6 +12,25 @@ export function parseYaml(content) {
 export function parseJson(content) {
     return JSON.parse(content);
 }
+function decodeJsonPointerSegment(raw, pointer) {
+    if (/~(?:[^01]|$)/.test(raw))
+        throw new Error(`invalid json_pointer "${pointer}"`);
+    return raw.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+export function resolveJsonPointer(data, pointer) {
+    if (pointer === "")
+        return data;
+    if (typeof pointer !== "string" || !pointer.startsWith("/"))
+        throw new Error(`invalid json_pointer "${pointer}"`);
+    let current = data;
+    for (const raw of pointer.slice(1).split("/")) {
+        const part = decodeJsonPointerSegment(raw, pointer);
+        if (current === null || typeof current !== "object" || !Object.hasOwn(current, part))
+            throw new Error(`json_pointer "${pointer}" does not exist`);
+        current = current[part];
+    }
+    return current;
+}
 export function stripMarkdownInline(line) {
     return line.replace(/`[^`]*`/g, "").replace(/\]\([^)]*\)/g, "]").replace(/https?:\/\/\S+/g, "");
 }

--- a/src/checks/rules/registry-rules.mts
+++ b/src/checks/rules/registry-rules.mts
@@ -1,4 +1,4 @@
-import { createDocumentReader, markdownSection } from "../../document-facts.mjs";
+import { createDocumentReader, markdownSection, resolveJsonPointer } from "../../document-facts.mjs";
 import type { DocumentReader, DocumentReaderOptions } from "../../document-facts.mjs";
 import { compareSets } from "../relation-kernel.mjs";
 import { formatList, uniqueSorted } from "../../utils/collections.mjs";
@@ -32,17 +32,6 @@ interface RegistryRuleOptions extends DocumentReaderOptions {
 }
 
 const normalizeAll = (values: string[]): string[] => uniqueSorted(values.map(normalizePathEntry).filter(Boolean) as string[]);
-function resolveJsonPointer(data: unknown, pointer: string): unknown {
-  if (pointer === "") return data;
-  if (!pointer?.startsWith("/")) throw new Error(`invalid json_pointer "${pointer}"`);
-  let current: unknown = data;
-  for (const raw of pointer.slice(1).split("/")) {
-    const part = raw.replace(/~1/g, "/").replace(/~0/g, "~");
-    if (current == null || !Object.hasOwn(current as object, part)) throw new Error(`json_pointer "${pointer}" does not exist`);
-    current = (current as Record<string, unknown>)[part];
-  }
-  return current;
-}
 function normalizeMarkdownLinkTarget(target: string, source: MarkdownSectionRegistrySource): string {
   const clean = normalizePathEntry(target.split("#")[0].split("?")[0]);
   if (!clean || /^[a-z][a-z0-9+.-]*:/i.test(clean) || clean.startsWith("#")) return "";

--- a/src/document-facts.mts
+++ b/src/document-facts.mts
@@ -83,6 +83,23 @@ export function parseJson(content: string): unknown {
   return JSON.parse(content);
 }
 
+function decodeJsonPointerSegment(raw: string, pointer: string): string {
+  if (/~(?:[^01]|$)/.test(raw)) throw new Error(`invalid json_pointer "${pointer}"`);
+  return raw.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+export function resolveJsonPointer(data: unknown, pointer: string): unknown {
+  if (pointer === "") return data;
+  if (typeof pointer !== "string" || !pointer.startsWith("/")) throw new Error(`invalid json_pointer "${pointer}"`);
+  let current: unknown = data;
+  for (const raw of pointer.slice(1).split("/")) {
+    const part = decodeJsonPointerSegment(raw, pointer);
+    if (current === null || typeof current !== "object" || !Object.hasOwn(current, part)) throw new Error(`json_pointer "${pointer}" does not exist`);
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
 export function stripMarkdownInline(line: string): string {
   return line.replace(/`[^`]*`/g, "").replace(/\]\([^)]*\)/g, "]").replace(/https?:\/\/\S+/g, "");
 }

--- a/tests/test-document-facts-boundary.mjs
+++ b/tests/test-document-facts-boundary.mjs
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveJsonPointer } from "../dist/document-facts.mjs";
+
+const document = {
+  "": "empty-key",
+  owner: { name: "repo-guard" },
+  "a/b": "slash",
+  "m~n": "tilde",
+  items: ["zero", "one"],
+  value: 42,
+  nullable: null,
+};
+
+describe("shared JSON Pointer boundary", () => {
+  it("selects root, nested, empty-key, escaped and array values", () => {
+    assert.equal(resolveJsonPointer(document, ""), document);
+    assert.equal(resolveJsonPointer(document, "/owner/name"), "repo-guard");
+    assert.equal(resolveJsonPointer(document, "/"), "empty-key");
+    assert.equal(resolveJsonPointer(document, "/a~1b"), "slash");
+    assert.equal(resolveJsonPointer(document, "/m~0n"), "tilde");
+    assert.equal(resolveJsonPointer(document, "/items/1"), "one");
+  });
+
+  it("fails closed for missing segments and primitive/null traversal", () => {
+    assert.throws(() => resolveJsonPointer(document, "/missing"), /json_pointer .* does not exist/);
+    assert.throws(() => resolveJsonPointer(document, "/value/x"), /json_pointer .* does not exist/);
+    assert.throws(() => resolveJsonPointer(document, "/nullable/x"), /json_pointer .* does not exist/);
+  });
+
+  it("rejects malformed pointer syntax and escapes", () => {
+    assert.throws(() => resolveJsonPointer(document, "owner/name"), /invalid json_pointer/);
+    assert.throws(() => resolveJsonPointer(document, "/a~2b"), /invalid json_pointer/);
+    assert.throws(() => resolveJsonPointer(document, "/m~"), /invalid json_pointer/);
+    assert.throws(() => resolveJsonPointer(document, null), /invalid json_pointer/);
+  });
+});

--- a/tests/test-document-facts-boundary.mjs
+++ b/tests/test-document-facts-boundary.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { resolveJsonPointer } from "../dist/document-facts.mjs";
+import { checkRegistryRules } from "../dist/checks/rules/registry-rules.mjs";
 
 const document = {
   "": "empty-key",
@@ -33,5 +34,26 @@ describe("shared JSON Pointer boundary", () => {
     assert.throws(() => resolveJsonPointer(document, "/a~2b"), /invalid json_pointer/);
     assert.throws(() => resolveJsonPointer(document, "/m~"), /invalid json_pointer/);
     assert.throws(() => resolveJsonPointer(document, null), /invalid json_pointer/);
+  });
+
+  it("preserves registry behavior through the shared escaped-key resolver", () => {
+    const registryDocument = { "a/b": ["docs/canonical.md"], canonical: ["docs/canonical.md"] };
+    const documents = {
+      text: () => "",
+      markdown: () => { throw new Error("not used"); },
+      json: () => registryDocument,
+      yaml: () => { throw new Error("not used"); },
+    };
+    const result = checkRegistryRules([{
+      id: "escaped-json-pointer",
+      kind: "equal",
+      left: { type: "json_array", file: "registry.json", json_pointer: "/a~1b" },
+      right: { type: "json_array", file: "registry.json", json_pointer: "/canonical" },
+    }], { documents });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.results[0]?.ok, true);
+    assert.deepEqual(result.results[0]?.left_entries, ["docs/canonical.md"]);
+    assert.deepEqual(result.results[0]?.right_entries, ["docs/canonical.md"]);
   });
 });


### PR DESCRIPTION
Fixes #276.
Refs #154, #149, `netkeep80/anum_docs#446`.

First R1 fact-layer slice, deliberately limited to JSON Pointer semantics and architecture compression:

- adds one shared `resolveJsonPointer` primitive to `DocumentFacts`;
- keeps selected document data as `unknown`; the resolver selects a value but does not assert its type;
- supports root `""`, normal `/` traversal, empty-key `/`, `~0`/`~1` escapes and array own-property indices;
- fails closed on non-pointer syntax, malformed escapes (`~2`, trailing `~`), missing segments and traversal through primitive/null values;
- removes the private JSON Pointer implementation from `registry-rules` and imports the shared primitive instead;
- preserves registry `json_array` array-of-strings validation and existing normalization/comparison behavior;
- adds built-dist tests for pointer edge cases and an escaped-key registry relation through the real rule family;
- does not add projection/type-normalization R1b, R2 relations, schema changes or contract/MTS-specific code;
- checked `dist` is compiler output. Before generation, the available local compiler was baseline-verified byte-for-byte against current checked `dist` for both affected modules; pinned CI remains the independent canonical freshness gate.

```repo-guard-yaml
change_type: feature
scope:
  - src/document-facts.mts
  - src/checks/rules/registry-rules.mts
  - tests/test-document-facts-boundary.mjs
  - dist/document-facts.mjs
  - dist/checks/rules/registry-rules.mjs
budgets:
  max_new_files: 1
  max_new_docs: 0
  max_net_added_lines: 150
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - src/document-facts.mts
  - src/checks/rules/registry-rules.mts
  - tests/test-document-facts-boundary.mjs
must_not_touch:
  - repo-policy.json
  - schemas/**
  - action.yml
  - .github/**
expected_effects:
  - provide one strict reusable JSON Pointer primitive
  - remove registry-owned duplicate pointer semantics
  - preserve registry observable behavior
  - prepare R1 projection facts without adding them yet
```