### PR TITLE
Policy transition: enforce proposed head runtime policy

### DIFF
--- a/dist/checks/orchestrator.mjs
+++ b/dist/checks/orchestrator.mjs
@@ -1,7 +1,12 @@
 import { createDefaultRuleRegistry } from "./default-rule-families.mjs";
 export function runPolicyChecks(facts, reporter, options = {}) {
     const registry = options.registry || createDefaultRuleRegistry();
+    const excludedFamilies = new Set(options.excludeFamilies || []);
+    // Повторный proposed-policy проход использует тот же registry, но не должен повторно
+    // выполнять transition/trust rules, авторитет которых принадлежит trusted base policy.
     for (const entry of registry.evaluate(facts, options)) {
+        if (excludedFamilies.has(entry.family))
+            continue;
         reporter.report(entry.name, entry.check);
     }
 }

--- a/dist/github-pr.mjs
+++ b/dist/github-pr.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { isDeepStrictEqual } from "node:util";
 import { getDiff, readBasePolicy, resolveRemoteBaseRef } from "./git.mjs";
 import { extractChangeIntent, extractGovernanceGrant, extractLinkedIssueNumbers, resolveChangeIntent } from "./change-intent.mjs";
 import { resolveEnforcementMode } from "./enforcement.mjs";
@@ -7,6 +8,7 @@ import { loadPolicyRuntime, loadPolicyRuntimeFromObject, validationCheck } from 
 import { runPolicyPipeline } from "./runtime/pipeline.mjs";
 import { resolveTrustedAuthorizer } from "./trusted-authorizer.mjs";
 const REPO = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, ISSUE = /^[1-9][0-9]*$/;
+const PROPOSED_POLICY_EXCLUDED_FAMILIES = ["governance-paths", "policy-delta"];
 export function loadGitHubEvent() {
     const eventPath = process.env.GITHUB_EVENT_PATH;
     if (!eventPath)
@@ -184,8 +186,28 @@ export function runCheckPR(roots, args = []) {
             trustedAuthorizer = resolveTrustedAuthorizer({ repoFullName, issueNumber: linkedIssues.length === 1 ? linkedIssues[0] : null, prNumber });
         }
         catch { }
-    return runPolicyPipeline({
+    const baseResult = runPolicyPipeline({
         mode: "check-pr", repositoryRoot: roots.repoRoot, policy, basePolicy, headPolicy: headRuntime.policy,
         changeIntent, changeIntentSource, governanceGrant, trustedGovernancePaths, trustedAuthorizer, enforcement, diffText, initialChecks,
-    }).exitCode;
+    });
+    if (!basePolicy || isDeepStrictEqual(basePolicy, headRuntime.policy))
+        return baseResult.exitCode;
+    const proposedEnforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy: headRuntime.policy });
+    if (!proposedEnforcement.ok) {
+        console.error(`ERROR: proposed policy enforcement: ${proposedEnforcement.message}`);
+        return 1;
+    }
+    // Head policy — только дополнительный veto. Governance authorization и policy-delta уже
+    // проверены trusted base pass и намеренно не могут быть переопределены самим head policy.
+    console.log("\nProposed policy differs from trusted base; checking head runtime policy as an additional veto.");
+    const proposedResult = runPolicyPipeline({
+        mode: "check-pr", repositoryRoot: roots.repoRoot, policy: headRuntime.policy, basePolicy, headPolicy: headRuntime.policy,
+        changeIntent, changeIntentSource, governanceGrant, trustedGovernancePaths, trustedAuthorizer,
+        enforcement: proposedEnforcement, diffText, initialChecks: [],
+    }, {
+        printEnforcement: false,
+        ruleNamePrefix: "proposed-policy:",
+        excludeRuleFamilies: PROPOSED_POLICY_EXCLUDED_FAMILIES,
+    });
+    return Math.max(baseResult.exitCode, proposedResult.exitCode);
 }

--- a/dist/runtime/pipeline.mjs
+++ b/dist/runtime/pipeline.mjs
@@ -11,8 +11,9 @@ export function runPolicyPipeline(input, options = {}) {
     const reporter = createAnalysisCollector(input.enforcement, {
         presenter: quiet ? null : createAnalysisTextPresenter(),
     });
+    const report = (name, check) => reporter.report(`${options.ruleNamePrefix || ""}${name}`, check);
     for (const initialCheck of input.initialChecks || []) {
-        reporter.report(initialCheck.name, initialCheck.check);
+        report(initialCheck.name, initialCheck.check);
     }
     const { changeIntent = null, changeIntentSource = "none", ...runtimeInput } = input;
     const facts = buildPolicyFacts({
@@ -24,7 +25,9 @@ export function runPolicyPipeline(input, options = {}) {
         console.log(`\n${renderDiffAnalysis(facts)}`);
     }
     const anchorDiagnostics = buildAnchorDiagnostics(facts);
-    runPolicyChecks(facts, reporter, { anchorDiagnostics });
+    // Префикс меняет только diagnostic namespace; вычисление остаётся в одном canonical
+    // pipeline и одном RuleRegistry, чтобы base/head не получили разные semantics engines.
+    runPolicyChecks(facts, { report }, { anchorDiagnostics, excludeFamilies: options.excludeRuleFamilies });
     return reporter.finish({
         command: input.mode,
         repositoryRoot: facts.repositoryRoot,

--- a/src/checks/orchestrator.mts
+++ b/src/checks/orchestrator.mts
@@ -7,12 +7,17 @@ export interface PolicyCheckReporter {
 
 export interface PolicyCheckOptions extends Record<string, unknown> {
   registry?: RuleRegistry;
+  excludeFamilies?: readonly string[];
 }
 
 export function runPolicyChecks(facts: unknown, reporter: PolicyCheckReporter, options: PolicyCheckOptions = {}): void {
   const registry = options.registry || createDefaultRuleRegistry();
+  const excludedFamilies = new Set(options.excludeFamilies || []);
 
+  // Повторный proposed-policy проход использует тот же registry, но не должен повторно
+  // выполнять transition/trust rules, авторитет которых принадлежит trusted base policy.
   for (const entry of registry.evaluate(facts, options)) {
+    if (excludedFamilies.has(entry.family)) continue;
     reporter.report(entry.name, entry.check);
   }
 }

--- a/src/github-pr.mts
+++ b/src/github-pr.mts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { isDeepStrictEqual } from "node:util";
 import { getDiff, readBasePolicy, resolveRemoteBaseRef } from "./git.mjs";
 import { extractChangeIntent, extractGovernanceGrant, extractLinkedIssueNumbers, resolveChangeIntent } from "./change-intent.mjs";
 import { resolveEnforcementMode } from "./enforcement.mjs";
@@ -41,6 +42,7 @@ type PRChangeIntentFacts =
 interface InitialCheck { name: string; check: unknown; }
 
 const REPO = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, ISSUE = /^[1-9][0-9]*$/;
+const PROPOSED_POLICY_EXCLUDED_FAMILIES = ["governance-paths", "policy-delta"] as const;
 export function loadGitHubEvent(): GitHubEventResult {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) return { ok: false, error: "no_event", message: "GITHUB_EVENT_PATH not set; not running in GitHub Actions" };
@@ -155,8 +157,27 @@ export function runCheckPR(roots: CheckPrRoots, args: string[] = []) {
   let trustedAuthorizer: ReturnType<typeof resolveTrustedAuthorizer> | null = null;
   if (basePolicy && repoFullName) try { trustedAuthorizer = resolveTrustedAuthorizer({ repoFullName, issueNumber: linkedIssues.length === 1 ? linkedIssues[0] : null, prNumber }); } catch {}
 
-  return runPolicyPipeline({
+  const baseResult = runPolicyPipeline({
     mode: "check-pr", repositoryRoot: roots.repoRoot, policy, basePolicy, headPolicy: headRuntime.policy,
     changeIntent, changeIntentSource, governanceGrant, trustedGovernancePaths, trustedAuthorizer, enforcement, diffText, initialChecks,
-  } as Parameters<typeof runPolicyPipeline>[0]).exitCode;
+  } as Parameters<typeof runPolicyPipeline>[0]);
+  if (!basePolicy || isDeepStrictEqual(basePolicy, headRuntime.policy)) return baseResult.exitCode;
+
+  const proposedEnforcement = resolveEnforcementMode({ cliValue: roots.enforcementMode, policy: headRuntime.policy } as Parameters<typeof resolveEnforcementMode>[0]);
+  if (!proposedEnforcement.ok) { console.error(`ERROR: proposed policy enforcement: ${proposedEnforcement.message}`); return 1; }
+
+  // Head policy — только дополнительный veto. Governance authorization и policy-delta уже
+  // проверены trusted base pass и намеренно не могут быть переопределены самим head policy.
+  console.log("\nProposed policy differs from trusted base; checking head runtime policy as an additional veto.");
+  const proposedResult = runPolicyPipeline({
+    mode: "check-pr", repositoryRoot: roots.repoRoot, policy: headRuntime.policy, basePolicy, headPolicy: headRuntime.policy,
+    changeIntent, changeIntentSource, governanceGrant, trustedGovernancePaths, trustedAuthorizer,
+    enforcement: proposedEnforcement, diffText, initialChecks: [],
+  } as Parameters<typeof runPolicyPipeline>[0], {
+    printEnforcement: false,
+    ruleNamePrefix: "proposed-policy:",
+    excludeRuleFamilies: PROPOSED_POLICY_EXCLUDED_FAMILIES,
+  });
+
+  return Math.max(baseResult.exitCode, proposedResult.exitCode);
 }

--- a/src/runtime/pipeline.mts
+++ b/src/runtime/pipeline.mts
@@ -22,6 +22,8 @@ export interface PolicyPipelineInput extends RepositoryFactsInput {
 export interface PolicyPipelineOptions {
   quiet?: boolean;
   printEnforcement?: boolean;
+  ruleNamePrefix?: string;
+  excludeRuleFamilies?: readonly string[];
 }
 
 export function runPolicyPipeline(input: PolicyPipelineInput, options: PolicyPipelineOptions = {}) {
@@ -33,9 +35,10 @@ export function runPolicyPipeline(input: PolicyPipelineInput, options: PolicyPip
   const reporter = createAnalysisCollector(input.enforcement, {
     presenter: quiet ? null : createAnalysisTextPresenter(),
   });
+  const report = (name: string, check: unknown) => reporter.report(`${options.ruleNamePrefix || ""}${name}`, check);
 
   for (const initialCheck of input.initialChecks || []) {
-    reporter.report(initialCheck.name, initialCheck.check);
+    report(initialCheck.name, initialCheck.check);
   }
 
   const { changeIntent = null, changeIntentSource = "none", ...runtimeInput } = input;
@@ -49,7 +52,9 @@ export function runPolicyPipeline(input: PolicyPipelineInput, options: PolicyPip
   }
 
   const anchorDiagnostics = buildAnchorDiagnostics(facts);
-  runPolicyChecks(facts, reporter, { anchorDiagnostics });
+  // Префикс меняет только diagnostic namespace; вычисление остаётся в одном canonical
+  // pipeline и одном RuleRegistry, чтобы base/head не получили разные semantics engines.
+  runPolicyChecks(facts, { report }, { anchorDiagnostics, excludeFamilies: options.excludeRuleFamilies });
 
   return reporter.finish({
     command: input.mode,

--- a/tests/test-github-pr.mjs
+++ b/tests/test-github-pr.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync, spawnSync } from "node:child_process";
@@ -36,6 +36,10 @@ function tinyRepo(prefix, governance = ["repo-policy.json"]) {
   }));
   writeFileSync(join(root, "a.txt"), "a\n"); git(root, "add", "-A"); git(root, "commit", "-m", "base");
   return root;
+}
+function rewritePolicy(root, mutate) {
+  const path = join(root, "repo-policy.json"), policy = JSON.parse(readFileSync(path, "utf-8"));
+  mutate(policy); writeFileSync(path, JSON.stringify(policy));
 }
 function run(root, body, extraEnv = {}) {
   const eventPath = join(root, "event.json");
@@ -106,5 +110,48 @@ else console.log(JSON.stringify({labels:[]}));
     const output = `${result.stdout || ""}${result.stderr || ""}`;
     assert.equal(result.status, 0, output); assert.match(output, /PASS: governance-change-authorization/);
     rmSync(root, { recursive: true, force: true }); rmSync(fakeDir, { recursive: true, force: true });
+  });
+
+  it("skips duplicate proposed-policy evaluation when policy is unchanged", () => {
+    const root = tinyRepo("rg-pr-same-policy-", []);
+    writeFileSync(join(root, "a.txt"), "changed\n"); git(root, "add", "-A"); git(root, "commit", "-m", "change");
+    const result = run(root, intent(["a.txt"], "bugfix")), output = `${result.stdout || ""}${result.stderr || ""}`;
+    assert.equal(result.status, 0, output); assert.doesNotMatch(output, /proposed-policy:/);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("applies stricter proposed head constraints in the same PR", () => {
+    const root = tinyRepo("rg-pr-head-strict-", []);
+    rewritePolicy(root, (policy) => { policy.paths.forbidden = ["a.txt"]; });
+    writeFileSync(join(root, "a.txt"), "changed\n"); git(root, "add", "-A"); git(root, "commit", "-m", "tighten policy");
+    const result = run(root, intent(["a.txt", "repo-policy.json"])), output = `${result.stdout || ""}${result.stderr || ""}`;
+    assert.equal(result.status, 1, output); assert.match(output, /FAIL: proposed-policy:forbidden-paths/);
+    assert.doesNotMatch(output, /proposed-policy:(governance-change-authorization|policy-relaxation)/);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rejects a broken registry rule in the policy adoption PR", () => {
+    const root = tinyRepo("rg-pr-head-registry-", []);
+    writeFileSync(join(root, "facts.json"), JSON.stringify({ expected: ["a"], actual: ["b"] })); git(root, "add", "-A"); git(root, "commit", "-m", "fixture");
+    rewritePolicy(root, (policy) => { policy.registry_rules = [{
+      id: "same-pr-registry", kind: "set_equality",
+      left: { type: "json_array", file: "facts.json", json_pointer: "/expected" },
+      right: { type: "json_array", file: "facts.json", json_pointer: "/actual" },
+    }]; });
+    git(root, "add", "repo-policy.json"); git(root, "commit", "-m", "add registry rule");
+    const result = run(root, intent(["repo-policy.json"])), output = `${result.stdout || ""}${result.stderr || ""}`;
+    assert.equal(result.status, 1, output); assert.match(output, /FAIL: proposed-policy:registry-rules/);
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rejects a broken integration expectation in the policy adoption PR", () => {
+    const root = tinyRepo("rg-pr-head-integration-", []);
+    rewritePolicy(root, (policy) => { policy.integration = { workflows: [{
+      id: "same-pr-missing-workflow", kind: "github_actions", path: ".github/workflows/missing.yml", role: "repo_guard_pr_gate",
+    }] }; });
+    git(root, "add", "repo-policy.json"); git(root, "commit", "-m", "add integration expectation");
+    const result = run(root, intent(["repo-policy.json"])), output = `${result.stdout || ""}${result.stderr || ""}`;
+    assert.equal(result.status, 1, output); assert.match(output, /FAIL: proposed-policy:integration-artifacts/);
+    rmSync(root, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Fixes #167

Implements transactional `check-pr` policy transition semantics: trusted base runtime policy remains authoritative, while a differing proposed head policy is evaluated by the same pipeline/RuleRegistry as an additional veto. Proposed-policy diagnostics are namespaced and transition/trust families remain base-only.

`dist` is intentionally not hand-edited: the initial draft CI is used to obtain/verify canonical compiler output before committing generated artifacts.