### PR TITLE
Contract governance R1b: add typed DocumentFacts projections

### DIFF
--- a/dist/document-facts.mjs
+++ b/dist/document-facts.mjs
@@ -1,5 +1,7 @@
 import { parseDocument } from "yaml";
 import { readRepositoryTextFile } from "./utils/repository-files.mjs";
+import { uniqueSorted } from "./utils/collections.mjs";
+import { normalizePathEntry } from "./utils/path-patterns.mjs";
 function collapseMessage(message) {
     return String(message || "").replace(/\s+/g, " ").trim();
 }
@@ -30,6 +32,76 @@ export function resolveJsonPointer(data, pointer) {
         current = current[part];
     }
     return current;
+}
+export function projectDocumentValue(data, pointer, projection = "value") {
+    const selected = resolveJsonPointer(data, pointer);
+    if (projection === "value")
+        return selected;
+    if (projection === "array_items") {
+        if (!Array.isArray(selected))
+            throw new Error(`document projection "array_items" requires an array at json_pointer "${pointer}"`);
+        return [...selected];
+    }
+    if (projection === "object_values") {
+        if (selected === null || typeof selected !== "object" || Array.isArray(selected)) {
+            throw new Error(`document projection "object_values" requires an object at json_pointer "${pointer}"`);
+        }
+        return Object.values(selected);
+    }
+    const exhaustive = projection;
+    throw new Error(`unsupported document projection "${exhaustive}"`);
+}
+function normalizeRepositoryPathFact(value) {
+    if (typeof value !== "string")
+        throw new Error("document fact repository_path requires a string");
+    const normalized = normalizePathEntry(value);
+    const parts = normalized.split("/");
+    if (!normalized
+        || normalized.includes("\\")
+        || normalized.startsWith("/")
+        || /^[A-Za-z]:/.test(normalized)
+        || /^[a-z][a-z0-9+.-]*:/i.test(normalized)
+        || parts.some((part) => !part || part === "." || part === "..")) {
+        throw new Error(`invalid repository_path "${value}"`);
+    }
+    return normalized;
+}
+function normalizeStringSet(value, itemType) {
+    if (!Array.isArray(value))
+        throw new Error(`document fact ${itemType === "string" ? "string_set" : "repository_path_set"} requires a collection`);
+    const normalized = value.map((item) => {
+        if (itemType === "repository_path")
+            return normalizeRepositoryPathFact(item);
+        if (typeof item !== "string")
+            throw new Error("document fact string_set requires string items");
+        return item;
+    });
+    return uniqueSorted(normalized);
+}
+export function normalizeDocumentFact(value, type) {
+    if (type === "scalar") {
+        if (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value)))
+            return value;
+        throw new Error("document fact scalar requires a JSON scalar");
+    }
+    if (type === "string") {
+        if (typeof value === "string")
+            return value;
+        throw new Error("document fact string requires a string");
+    }
+    if (type === "boolean") {
+        if (typeof value === "boolean")
+            return value;
+        throw new Error("document fact boolean requires a boolean");
+    }
+    if (type === "string_set")
+        return normalizeStringSet(value, "string");
+    if (type === "repository_path")
+        return normalizeRepositoryPathFact(value);
+    if (type === "repository_path_set")
+        return normalizeStringSet(value, "repository_path");
+    const exhaustive = type;
+    throw new Error(`unsupported document fact type "${exhaustive}"`);
 }
 export function stripMarkdownInline(line) {
     return line.replace(/`[^`]*`/g, "").replace(/\]\([^)]*\)/g, "]").replace(/https?:\/\/\S+/g, "");

--- a/src/document-facts.mts
+++ b/src/document-facts.mts
@@ -1,5 +1,7 @@
 import { parseDocument } from "yaml";
 import { readRepositoryTextFile } from "./utils/repository-files.mjs";
+import { uniqueSorted } from "./utils/collections.mjs";
+import { normalizePathEntry } from "./utils/path-patterns.mjs";
 
 export interface MarkdownHeading {
   level: number;
@@ -58,6 +60,10 @@ export interface DocumentReader {
   yaml(path: string): unknown;
 }
 
+export type DocumentProjection = "value" | "array_items" | "object_values";
+export type DocumentFactType = "scalar" | "string" | "boolean" | "string_set" | "repository_path" | "repository_path_set";
+export type DocumentScalar = string | number | boolean | null;
+
 type DocumentKind = "markdown" | "json" | "yaml";
 
 interface OpenMarkdownFence {
@@ -98,6 +104,78 @@ export function resolveJsonPointer(data: unknown, pointer: string): unknown {
     current = (current as Record<string, unknown>)[part];
   }
   return current;
+}
+
+export function projectDocumentValue(data: unknown, pointer: string): unknown;
+export function projectDocumentValue(data: unknown, pointer: string, projection: "value"): unknown;
+export function projectDocumentValue(data: unknown, pointer: string, projection: "array_items" | "object_values"): unknown[];
+export function projectDocumentValue(data: unknown, pointer: string, projection: DocumentProjection = "value"): unknown | unknown[] {
+  const selected = resolveJsonPointer(data, pointer);
+  if (projection === "value") return selected;
+  if (projection === "array_items") {
+    if (!Array.isArray(selected)) throw new Error(`document projection "array_items" requires an array at json_pointer "${pointer}"`);
+    return [...selected];
+  }
+  if (projection === "object_values") {
+    if (selected === null || typeof selected !== "object" || Array.isArray(selected)) {
+      throw new Error(`document projection "object_values" requires an object at json_pointer "${pointer}"`);
+    }
+    return Object.values(selected as Record<string, unknown>);
+  }
+  const exhaustive: never = projection;
+  throw new Error(`unsupported document projection "${exhaustive}"`);
+}
+
+function normalizeRepositoryPathFact(value: unknown): string {
+  if (typeof value !== "string") throw new Error("document fact repository_path requires a string");
+  const normalized = normalizePathEntry(value);
+  const parts = normalized.split("/");
+  if (
+    !normalized
+    || normalized.includes("\\")
+    || normalized.startsWith("/")
+    || /^[A-Za-z]:/.test(normalized)
+    || /^[a-z][a-z0-9+.-]*:/i.test(normalized)
+    || parts.some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`invalid repository_path "${value}"`);
+  }
+  return normalized;
+}
+
+function normalizeStringSet(value: unknown, itemType: "string" | "repository_path"): string[] {
+  if (!Array.isArray(value)) throw new Error(`document fact ${itemType === "string" ? "string_set" : "repository_path_set"} requires a collection`);
+  const normalized = value.map((item) => {
+    if (itemType === "repository_path") return normalizeRepositoryPathFact(item);
+    if (typeof item !== "string") throw new Error("document fact string_set requires string items");
+    return item;
+  });
+  return uniqueSorted(normalized);
+}
+
+export function normalizeDocumentFact(value: unknown, type: "scalar"): DocumentScalar;
+export function normalizeDocumentFact(value: unknown, type: "string"): string;
+export function normalizeDocumentFact(value: unknown, type: "boolean"): boolean;
+export function normalizeDocumentFact(value: unknown, type: "string_set" | "repository_path_set"): string[];
+export function normalizeDocumentFact(value: unknown, type: "repository_path"): string;
+export function normalizeDocumentFact(value: unknown, type: DocumentFactType): DocumentScalar | string[] {
+  if (type === "scalar") {
+    if (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value))) return value;
+    throw new Error("document fact scalar requires a JSON scalar");
+  }
+  if (type === "string") {
+    if (typeof value === "string") return value;
+    throw new Error("document fact string requires a string");
+  }
+  if (type === "boolean") {
+    if (typeof value === "boolean") return value;
+    throw new Error("document fact boolean requires a boolean");
+  }
+  if (type === "string_set") return normalizeStringSet(value, "string");
+  if (type === "repository_path") return normalizeRepositoryPathFact(value);
+  if (type === "repository_path_set") return normalizeStringSet(value, "repository_path");
+  const exhaustive: never = type;
+  throw new Error(`unsupported document fact type "${exhaustive}"`);
 }
 
 export function stripMarkdownInline(line: string): string {

--- a/tests/test-document-facts-boundary.mjs
+++ b/tests/test-document-facts-boundary.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveJsonPointer } from "../dist/document-facts.mjs";
+import { normalizeDocumentFact, projectDocumentValue, resolveJsonPointer } from "../dist/document-facts.mjs";
 import { checkRegistryRules } from "../dist/checks/rules/registry-rules.mjs";
 
 const document = {
@@ -9,7 +9,10 @@ const document = {
   "a/b": "slash",
   "m~n": "tilde",
   items: ["zero", "one"],
+  repeated: ["b", "a", "b"],
+  owners: { second: "./src/b.mts", first: "src/a.mts" },
   value: 42,
+  enabled: true,
   nullable: null,
 };
 
@@ -55,5 +58,63 @@ describe("shared JSON Pointer boundary", () => {
     assert.equal(result.results[0]?.ok, true);
     assert.deepEqual(result.results[0]?.left_entries, ["docs/canonical.md"]);
     assert.deepEqual(result.results[0]?.right_entries, ["docs/canonical.md"]);
+  });
+});
+
+describe("DocumentFacts projections", () => {
+  it("supports exact value, array items and object values", () => {
+    assert.equal(projectDocumentValue(document, "/owner/name"), "repo-guard");
+    assert.deepEqual(projectDocumentValue(document, "/repeated", "array_items"), ["b", "a", "b"]);
+    assert.deepEqual(projectDocumentValue(document, "/owners", "object_values"), ["./src/b.mts", "src/a.mts"]);
+  });
+
+  it("keeps list duplicates observable until explicit set normalization", () => {
+    const projected = projectDocumentValue(document, "/repeated", "array_items");
+    assert.deepEqual(projected, ["b", "a", "b"]);
+    assert.deepEqual(normalizeDocumentFact(projected, "string_set"), ["a", "b"]);
+  });
+
+  it("fails closed when collection projection does not match the selected value", () => {
+    assert.throws(() => projectDocumentValue(document, "/owner", "array_items"), /requires an array/);
+    assert.throws(() => projectDocumentValue(document, "/items", "object_values"), /requires an object/);
+    assert.throws(() => projectDocumentValue(document, "/nullable", "object_values"), /requires an object/);
+  });
+});
+
+describe("typed document fact normalization", () => {
+  it("narrows JSON scalars, strings and booleans without coercion", () => {
+    assert.equal(normalizeDocumentFact(42, "scalar"), 42);
+    assert.equal(normalizeDocumentFact(null, "scalar"), null);
+    assert.equal(normalizeDocumentFact("repo-guard", "string"), "repo-guard");
+    assert.equal(normalizeDocumentFact(true, "boolean"), true);
+    assert.throws(() => normalizeDocumentFact({}, "scalar"), /requires a JSON scalar/);
+    assert.throws(() => normalizeDocumentFact(Infinity, "scalar"), /requires a JSON scalar/);
+    assert.throws(() => normalizeDocumentFact(1, "string"), /requires a string/);
+    assert.throws(() => normalizeDocumentFact("true", "boolean"), /requires a boolean/);
+  });
+
+  it("normalizes sets deterministically and keeps empty sets valid", () => {
+    assert.deepEqual(normalizeDocumentFact(["b", "a", "b"], "string_set"), ["a", "b"]);
+    assert.deepEqual(normalizeDocumentFact([], "string_set"), []);
+    assert.deepEqual(normalizeDocumentFact(projectDocumentValue({ a: "z", b: "a", c: "z" }, "", "object_values"), "string_set"), ["a", "z"]);
+    assert.deepEqual(normalizeDocumentFact(projectDocumentValue({ c: "z", b: "a", a: "z" }, "", "object_values"), "string_set"), ["a", "z"]);
+    assert.throws(() => normalizeDocumentFact(["a", 2], "string_set"), /requires string items/);
+  });
+
+  it("normalizes repository paths through canonical spelling and deduplicates path sets", () => {
+    assert.equal(normalizeDocumentFact(" ./docs/contract.json ", "repository_path"), "docs/contract.json");
+    assert.deepEqual(
+      normalizeDocumentFact(projectDocumentValue(document, "/owners", "object_values"), "repository_path_set"),
+      ["src/a.mts", "src/b.mts"],
+    );
+    assert.deepEqual(normalizeDocumentFact([], "repository_path_set"), []);
+  });
+
+  it("rejects malformed and out-of-repository path values", () => {
+    for (const path of ["", "   ", "/etc/passwd", "../outside", "docs/../outside", "docs/./file", "docs\\file", "https://example.test/x", "C:/outside"]) {
+      assert.throws(() => normalizeDocumentFact(path, "repository_path"), /invalid repository_path/);
+    }
+    assert.throws(() => normalizeDocumentFact(42, "repository_path"), /requires a string/);
+    assert.throws(() => normalizeDocumentFact(["docs/a", "../outside"], "repository_path_set"), /invalid repository_path/);
   });
 });


### PR DESCRIPTION
Fixes #279

Adds the R1-only reusable DocumentFacts projection and typed-normalization layer on top of the strict JSON Pointer resolver:
- exact `value`, `array_items`, and `object_values` projections;
- explicit scalar/string/boolean/string-set/repository-path/repository-path-set narrowing;
- list duplicates remain observable until explicit set normalization;
- repository path facts reuse existing `normalizePathEntry` spelling normalization and add fail-closed repository-bound validation without changing existing callers.

No policy schema, R2 relations, new rule family, filesystem existence checks, MTS-specific semantics, JSONPath, expressions, or execution are added.

`dist/document-facts.mjs` is compiler-generated. Before committing it, baseline compiler emit for current `main` was verified byte-for-byte against the checked dist; the modified GitHub blob matches the compiler-emitted blob exactly. Pinned CI remains the independent freshness/typecheck authority.