### PR TITLE
Contract governance R1c: complete DocumentFact selector boundary

### DIFF
--- a/dist/document-facts.mjs
+++ b/dist/document-facts.mjs
@@ -2,8 +2,30 @@ import { parseDocument } from "yaml";
 import { readRepositoryTextFile } from "./utils/repository-files.mjs";
 import { uniqueSorted } from "./utils/collections.mjs";
 import { normalizePathEntry } from "./utils/path-patterns.mjs";
+export class DocumentFactFailure extends Error {
+    code;
+    pointer;
+    segment;
+    constructor(code, message, pointer = "", segment) {
+        super(message);
+        this.name = "DocumentFactFailure";
+        this.code = code;
+        this.pointer = pointer;
+        this.segment = segment;
+    }
+}
 function collapseMessage(message) {
     return String(message || "").replace(/\s+/g, " ").trim();
+}
+function failDocumentFact(code, message, pointer = "", segment) {
+    throw new DocumentFactFailure(code, message, pointer, segment);
+}
+function documentFactError(error, pointer) {
+    if (error instanceof DocumentFactFailure) {
+        return { code: error.code, pointer: error.pointer, ...(error.segment === undefined ? {} : { segment: error.segment }), message: error.message };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return { code: "document_read_error", pointer, message: collapseMessage(message) || "document read failed" };
 }
 export function parseYaml(content) {
     const doc = parseDocument(content, { prettyErrors: false });
@@ -16,19 +38,22 @@ export function parseJson(content) {
 }
 function decodeJsonPointerSegment(raw, pointer) {
     if (/~(?:[^01]|$)/.test(raw))
-        throw new Error(`invalid json_pointer "${pointer}"`);
+        failDocumentFact("malformed_pointer", `invalid json_pointer "${pointer}"`, pointer);
     return raw.replace(/~1/g, "/").replace(/~0/g, "~");
 }
 export function resolveJsonPointer(data, pointer) {
     if (pointer === "")
         return data;
-    if (typeof pointer !== "string" || !pointer.startsWith("/"))
-        throw new Error(`invalid json_pointer "${pointer}"`);
+    if (typeof pointer !== "string" || !pointer.startsWith("/")) {
+        const rendered = typeof pointer === "string" ? pointer : String(pointer ?? "");
+        failDocumentFact("malformed_pointer", `invalid json_pointer "${rendered}"`, rendered);
+    }
     let current = data;
     for (const raw of pointer.slice(1).split("/")) {
         const part = decodeJsonPointerSegment(raw, pointer);
-        if (current === null || typeof current !== "object" || !Object.hasOwn(current, part))
-            throw new Error(`json_pointer "${pointer}" does not exist`);
+        if (current === null || typeof current !== "object" || !Object.hasOwn(current, part)) {
+            failDocumentFact("missing_pointer_segment", `json_pointer "${pointer}" does not exist`, pointer, part);
+        }
         current = current[part];
     }
     return current;
@@ -38,22 +63,23 @@ export function projectDocumentValue(data, pointer, projection = "value") {
     if (projection === "value")
         return selected;
     if (projection === "array_items") {
-        if (!Array.isArray(selected))
-            throw new Error(`document projection "array_items" requires an array at json_pointer "${pointer}"`);
+        if (!Array.isArray(selected)) {
+            failDocumentFact("projection_type_mismatch", `document projection "array_items" requires an array at json_pointer "${pointer}"`, pointer);
+        }
         return [...selected];
     }
     if (projection === "object_values") {
         if (selected === null || typeof selected !== "object" || Array.isArray(selected)) {
-            throw new Error(`document projection "object_values" requires an object at json_pointer "${pointer}"`);
+            failDocumentFact("projection_type_mismatch", `document projection "object_values" requires an object at json_pointer "${pointer}"`, pointer);
         }
         return Object.values(selected);
     }
     const exhaustive = projection;
-    throw new Error(`unsupported document projection "${exhaustive}"`);
+    return failDocumentFact("projection_type_mismatch", `unsupported document projection "${String(exhaustive)}"`, pointer);
 }
-function normalizeRepositoryPathFact(value) {
+function normalizeRepositoryPathFact(value, pointer = "") {
     if (typeof value !== "string")
-        throw new Error("document fact repository_path requires a string");
+        failDocumentFact("fact_type_mismatch", "document fact repository_path requires a string", pointer);
     const normalized = normalizePathEntry(value);
     const parts = normalized.split("/");
     if (!normalized
@@ -62,46 +88,65 @@ function normalizeRepositoryPathFact(value) {
         || /^[A-Za-z]:/.test(normalized)
         || /^[a-z][a-z0-9+.-]*:/i.test(normalized)
         || parts.some((part) => !part || part === "." || part === "..")) {
-        throw new Error(`invalid repository_path "${value}"`);
+        failDocumentFact("invalid_repository_path", `invalid repository_path "${value}"`, pointer);
     }
     return normalized;
 }
-function normalizeStringSet(value, itemType) {
-    if (!Array.isArray(value))
-        throw new Error(`document fact ${itemType === "string" ? "string_set" : "repository_path_set"} requires a collection`);
+function normalizeStringSet(value, itemType, pointer = "") {
+    if (!Array.isArray(value)) {
+        failDocumentFact("fact_type_mismatch", `document fact ${itemType === "string" ? "string_set" : "repository_path_set"} requires a collection`, pointer);
+    }
     const normalized = value.map((item) => {
         if (itemType === "repository_path")
-            return normalizeRepositoryPathFact(item);
+            return normalizeRepositoryPathFact(item, pointer);
         if (typeof item !== "string")
-            throw new Error("document fact string_set requires string items");
+            failDocumentFact("fact_type_mismatch", "document fact string_set requires string items", pointer);
         return item;
     });
     return uniqueSorted(normalized);
 }
-export function normalizeDocumentFact(value, type) {
+export function normalizeDocumentFact(value, type, pointer = "") {
     if (type === "scalar") {
         if (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value)))
             return value;
-        throw new Error("document fact scalar requires a JSON scalar");
+        return failDocumentFact("fact_type_mismatch", "document fact scalar requires a JSON scalar", pointer);
     }
     if (type === "string") {
         if (typeof value === "string")
             return value;
-        throw new Error("document fact string requires a string");
+        return failDocumentFact("fact_type_mismatch", "document fact string requires a string", pointer);
     }
     if (type === "boolean") {
         if (typeof value === "boolean")
             return value;
-        throw new Error("document fact boolean requires a boolean");
+        return failDocumentFact("fact_type_mismatch", "document fact boolean requires a boolean", pointer);
     }
     if (type === "string_set")
-        return normalizeStringSet(value, "string");
+        return normalizeStringSet(value, "string", pointer);
     if (type === "repository_path")
-        return normalizeRepositoryPathFact(value);
+        return normalizeRepositoryPathFact(value, pointer);
     if (type === "repository_path_set")
-        return normalizeStringSet(value, "repository_path");
+        return normalizeStringSet(value, "repository_path", pointer);
     const exhaustive = type;
-    throw new Error(`unsupported document fact type "${exhaustive}"`);
+    return failDocumentFact("fact_type_mismatch", `unsupported document fact type "${String(exhaustive)}"`, pointer);
+}
+function readSelectorDocument(reader, path, pointer) {
+    const normalizedPath = normalizeRepositoryPathFact(path, pointer);
+    if (/\.json$/i.test(normalizedPath))
+        return reader.json(normalizedPath);
+    if (/\.ya?ml$/i.test(normalizedPath))
+        return reader.yaml(normalizedPath);
+    return failDocumentFact("unsupported_document_type", `unsupported document type for "${normalizedPath}"`, pointer);
+}
+export function readDocumentFact(reader, selector) {
+    try {
+        const document = readSelectorDocument(reader, selector.path, selector.pointer);
+        const projected = projectDocumentValue(document, selector.pointer, selector.projection ?? "value");
+        return { ok: true, value: normalizeDocumentFact(projected, selector.type, selector.pointer) };
+    }
+    catch (error) {
+        return { ok: false, error: documentFactError(error, selector.pointer) };
+    }
 }
 export function stripMarkdownInline(line) {
     return line.replace(/`[^`]*`/g, "").replace(/\]\([^)]*\)/g, "]").replace(/https?:\/\/\S+/g, "");

--- a/src/document-facts.mts
+++ b/src/document-facts.mts
@@ -167,6 +167,7 @@ export function resolveJsonPointer(data: unknown, pointer: string): unknown {
 export function projectDocumentValue(data: unknown, pointer: string): unknown;
 export function projectDocumentValue(data: unknown, pointer: string, projection: "value"): unknown;
 export function projectDocumentValue(data: unknown, pointer: string, projection: "array_items" | "object_values"): unknown[];
+export function projectDocumentValue(data: unknown, pointer: string, projection: DocumentProjection): unknown | unknown[];
 export function projectDocumentValue(data: unknown, pointer: string, projection: DocumentProjection = "value"): unknown | unknown[] {
   const selected = resolveJsonPointer(data, pointer);
   if (projection === "value") return selected;
@@ -220,6 +221,7 @@ export function normalizeDocumentFact(value: unknown, type: "string", pointer?: 
 export function normalizeDocumentFact(value: unknown, type: "boolean", pointer?: string): boolean;
 export function normalizeDocumentFact(value: unknown, type: "string_set" | "repository_path_set", pointer?: string): string[];
 export function normalizeDocumentFact(value: unknown, type: "repository_path", pointer?: string): string;
+export function normalizeDocumentFact(value: unknown, type: DocumentFactType, pointer?: string): NormalizedDocumentFact;
 export function normalizeDocumentFact(value: unknown, type: DocumentFactType, pointer = ""): NormalizedDocumentFact {
   if (type === "scalar") {
     if (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value))) return value;

--- a/src/document-facts.mts
+++ b/src/document-facts.mts
@@ -63,6 +63,47 @@ export interface DocumentReader {
 export type DocumentProjection = "value" | "array_items" | "object_values";
 export type DocumentFactType = "scalar" | "string" | "boolean" | "string_set" | "repository_path" | "repository_path_set";
 export type DocumentScalar = string | number | boolean | null;
+export type NormalizedDocumentFact = DocumentScalar | string[];
+export type DocumentFactErrorCode =
+  | "malformed_pointer"
+  | "missing_pointer_segment"
+  | "projection_type_mismatch"
+  | "fact_type_mismatch"
+  | "invalid_repository_path"
+  | "document_read_error"
+  | "unsupported_document_type";
+
+export interface DocumentFactSelector {
+  path: string;
+  pointer: string;
+  projection?: DocumentProjection;
+  type: DocumentFactType;
+}
+
+export interface DocumentFactError {
+  code: DocumentFactErrorCode;
+  pointer: string;
+  segment?: string;
+  message: string;
+}
+
+export type DocumentFactResult =
+  | { ok: true; value: NormalizedDocumentFact }
+  | { ok: false; error: DocumentFactError };
+
+export class DocumentFactFailure extends Error implements DocumentFactError {
+  readonly code: DocumentFactErrorCode;
+  readonly pointer: string;
+  readonly segment?: string;
+
+  constructor(code: DocumentFactErrorCode, message: string, pointer = "", segment?: string) {
+    super(message);
+    this.name = "DocumentFactFailure";
+    this.code = code;
+    this.pointer = pointer;
+    this.segment = segment;
+  }
+}
 
 type DocumentKind = "markdown" | "json" | "yaml";
 
@@ -79,6 +120,18 @@ function collapseMessage(message: unknown): string {
   return String(message || "").replace(/\s+/g, " ").trim();
 }
 
+function failDocumentFact(code: DocumentFactErrorCode, message: string, pointer = "", segment?: string): never {
+  throw new DocumentFactFailure(code, message, pointer, segment);
+}
+
+function documentFactError(error: unknown, pointer: string): DocumentFactError {
+  if (error instanceof DocumentFactFailure) {
+    return { code: error.code, pointer: error.pointer, ...(error.segment === undefined ? {} : { segment: error.segment }), message: error.message };
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return { code: "document_read_error", pointer, message: collapseMessage(message) || "document read failed" };
+}
+
 export function parseYaml(content: string): unknown {
   const doc = parseDocument(content, { prettyErrors: false });
   if (doc.errors.length) throw new Error(`invalid YAML: ${doc.errors.map((e) => collapseMessage(e.message)).join("; ")}`);
@@ -90,17 +143,22 @@ export function parseJson(content: string): unknown {
 }
 
 function decodeJsonPointerSegment(raw: string, pointer: string): string {
-  if (/~(?:[^01]|$)/.test(raw)) throw new Error(`invalid json_pointer "${pointer}"`);
+  if (/~(?:[^01]|$)/.test(raw)) failDocumentFact("malformed_pointer", `invalid json_pointer "${pointer}"`, pointer);
   return raw.replace(/~1/g, "/").replace(/~0/g, "~");
 }
 
 export function resolveJsonPointer(data: unknown, pointer: string): unknown {
   if (pointer === "") return data;
-  if (typeof pointer !== "string" || !pointer.startsWith("/")) throw new Error(`invalid json_pointer "${pointer}"`);
+  if (typeof pointer !== "string" || !pointer.startsWith("/")) {
+    const rendered = typeof pointer === "string" ? pointer : String(pointer ?? "");
+    failDocumentFact("malformed_pointer", `invalid json_pointer "${rendered}"`, rendered);
+  }
   let current: unknown = data;
   for (const raw of pointer.slice(1).split("/")) {
     const part = decodeJsonPointerSegment(raw, pointer);
-    if (current === null || typeof current !== "object" || !Object.hasOwn(current, part)) throw new Error(`json_pointer "${pointer}" does not exist`);
+    if (current === null || typeof current !== "object" || !Object.hasOwn(current, part)) {
+      failDocumentFact("missing_pointer_segment", `json_pointer "${pointer}" does not exist`, pointer, part);
+    }
     current = (current as Record<string, unknown>)[part];
   }
   return current;
@@ -113,21 +171,23 @@ export function projectDocumentValue(data: unknown, pointer: string, projection:
   const selected = resolveJsonPointer(data, pointer);
   if (projection === "value") return selected;
   if (projection === "array_items") {
-    if (!Array.isArray(selected)) throw new Error(`document projection "array_items" requires an array at json_pointer "${pointer}"`);
+    if (!Array.isArray(selected)) {
+      failDocumentFact("projection_type_mismatch", `document projection "array_items" requires an array at json_pointer "${pointer}"`, pointer);
+    }
     return [...selected];
   }
   if (projection === "object_values") {
     if (selected === null || typeof selected !== "object" || Array.isArray(selected)) {
-      throw new Error(`document projection "object_values" requires an object at json_pointer "${pointer}"`);
+      failDocumentFact("projection_type_mismatch", `document projection "object_values" requires an object at json_pointer "${pointer}"`, pointer);
     }
     return Object.values(selected as Record<string, unknown>);
   }
   const exhaustive: never = projection;
-  throw new Error(`unsupported document projection "${exhaustive}"`);
+  return failDocumentFact("projection_type_mismatch", `unsupported document projection "${String(exhaustive)}"`, pointer);
 }
 
-function normalizeRepositoryPathFact(value: unknown): string {
-  if (typeof value !== "string") throw new Error("document fact repository_path requires a string");
+function normalizeRepositoryPathFact(value: unknown, pointer = ""): string {
+  if (typeof value !== "string") failDocumentFact("fact_type_mismatch", "document fact repository_path requires a string", pointer);
   const normalized = normalizePathEntry(value);
   const parts = normalized.split("/");
   if (
@@ -138,44 +198,63 @@ function normalizeRepositoryPathFact(value: unknown): string {
     || /^[a-z][a-z0-9+.-]*:/i.test(normalized)
     || parts.some((part) => !part || part === "." || part === "..")
   ) {
-    throw new Error(`invalid repository_path "${value}"`);
+    failDocumentFact("invalid_repository_path", `invalid repository_path "${value}"`, pointer);
   }
   return normalized;
 }
 
-function normalizeStringSet(value: unknown, itemType: "string" | "repository_path"): string[] {
-  if (!Array.isArray(value)) throw new Error(`document fact ${itemType === "string" ? "string_set" : "repository_path_set"} requires a collection`);
+function normalizeStringSet(value: unknown, itemType: "string" | "repository_path", pointer = ""): string[] {
+  if (!Array.isArray(value)) {
+    failDocumentFact("fact_type_mismatch", `document fact ${itemType === "string" ? "string_set" : "repository_path_set"} requires a collection`, pointer);
+  }
   const normalized = value.map((item) => {
-    if (itemType === "repository_path") return normalizeRepositoryPathFact(item);
-    if (typeof item !== "string") throw new Error("document fact string_set requires string items");
+    if (itemType === "repository_path") return normalizeRepositoryPathFact(item, pointer);
+    if (typeof item !== "string") failDocumentFact("fact_type_mismatch", "document fact string_set requires string items", pointer);
     return item;
   });
   return uniqueSorted(normalized);
 }
 
-export function normalizeDocumentFact(value: unknown, type: "scalar"): DocumentScalar;
-export function normalizeDocumentFact(value: unknown, type: "string"): string;
-export function normalizeDocumentFact(value: unknown, type: "boolean"): boolean;
-export function normalizeDocumentFact(value: unknown, type: "string_set" | "repository_path_set"): string[];
-export function normalizeDocumentFact(value: unknown, type: "repository_path"): string;
-export function normalizeDocumentFact(value: unknown, type: DocumentFactType): DocumentScalar | string[] {
+export function normalizeDocumentFact(value: unknown, type: "scalar", pointer?: string): DocumentScalar;
+export function normalizeDocumentFact(value: unknown, type: "string", pointer?: string): string;
+export function normalizeDocumentFact(value: unknown, type: "boolean", pointer?: string): boolean;
+export function normalizeDocumentFact(value: unknown, type: "string_set" | "repository_path_set", pointer?: string): string[];
+export function normalizeDocumentFact(value: unknown, type: "repository_path", pointer?: string): string;
+export function normalizeDocumentFact(value: unknown, type: DocumentFactType, pointer = ""): NormalizedDocumentFact {
   if (type === "scalar") {
     if (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value))) return value;
-    throw new Error("document fact scalar requires a JSON scalar");
+    return failDocumentFact("fact_type_mismatch", "document fact scalar requires a JSON scalar", pointer);
   }
   if (type === "string") {
     if (typeof value === "string") return value;
-    throw new Error("document fact string requires a string");
+    return failDocumentFact("fact_type_mismatch", "document fact string requires a string", pointer);
   }
   if (type === "boolean") {
     if (typeof value === "boolean") return value;
-    throw new Error("document fact boolean requires a boolean");
+    return failDocumentFact("fact_type_mismatch", "document fact boolean requires a boolean", pointer);
   }
-  if (type === "string_set") return normalizeStringSet(value, "string");
-  if (type === "repository_path") return normalizeRepositoryPathFact(value);
-  if (type === "repository_path_set") return normalizeStringSet(value, "repository_path");
+  if (type === "string_set") return normalizeStringSet(value, "string", pointer);
+  if (type === "repository_path") return normalizeRepositoryPathFact(value, pointer);
+  if (type === "repository_path_set") return normalizeStringSet(value, "repository_path", pointer);
   const exhaustive: never = type;
-  throw new Error(`unsupported document fact type "${exhaustive}"`);
+  return failDocumentFact("fact_type_mismatch", `unsupported document fact type "${String(exhaustive)}"`, pointer);
+}
+
+function readSelectorDocument(reader: DocumentReader, path: string, pointer: string): unknown {
+  const normalizedPath = normalizeRepositoryPathFact(path, pointer);
+  if (/\.json$/i.test(normalizedPath)) return reader.json(normalizedPath);
+  if (/\.ya?ml$/i.test(normalizedPath)) return reader.yaml(normalizedPath);
+  return failDocumentFact("unsupported_document_type", `unsupported document type for "${normalizedPath}"`, pointer);
+}
+
+export function readDocumentFact(reader: DocumentReader, selector: DocumentFactSelector): DocumentFactResult {
+  try {
+    const document = readSelectorDocument(reader, selector.path, selector.pointer);
+    const projected = projectDocumentValue(document, selector.pointer, selector.projection ?? "value");
+    return { ok: true, value: normalizeDocumentFact(projected, selector.type, selector.pointer) };
+  } catch (error: unknown) {
+    return { ok: false, error: documentFactError(error, selector.pointer) };
+  }
 }
 
 export function stripMarkdownInline(line: string): string {

--- a/tests/test-document-facts-boundary.mjs
+++ b/tests/test-document-facts-boundary.mjs
@@ -1,6 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeDocumentFact, projectDocumentValue, resolveJsonPointer } from "../dist/document-facts.mjs";
+import {
+  createDocumentReader,
+  normalizeDocumentFact,
+  projectDocumentValue,
+  readDocumentFact,
+  resolveJsonPointer,
+} from "../dist/document-facts.mjs";
 import { checkRegistryRules } from "../dist/checks/rules/registry-rules.mjs";
 
 const document = {
@@ -15,6 +21,15 @@ const document = {
   enabled: true,
   nullable: null,
 };
+
+function captureFailure(run) {
+  try {
+    run();
+  } catch (error) {
+    return error;
+  }
+  assert.fail("expected DocumentFact failure");
+}
 
 describe("shared JSON Pointer boundary", () => {
   it("selects root, nested, empty-key, escaped and array values", () => {
@@ -116,5 +131,96 @@ describe("typed document fact normalization", () => {
     }
     assert.throws(() => normalizeDocumentFact(42, "repository_path"), /requires a string/);
     assert.throws(() => normalizeDocumentFact(["docs/a", "../outside"], "repository_path_set"), /invalid repository_path/);
+  });
+});
+
+describe("DocumentFact selector/read boundary", () => {
+  const files = {
+    "facts.json": JSON.stringify({
+      contract: "contracts/mts-contract-v0.7.json",
+      corpus: "./contracts/mts-conformance-v0.7.json",
+      owners: { runtime: "./core/runtime.ts", schema: "schemas/mts.json" },
+    }),
+    "facts.yaml": "enabled: true\ngates:\n  - ./tools/check.mjs\n  - tools/check.mjs\n  - tests/smoke.mjs\n",
+    "bad.json": "{not-json",
+    "bad.yaml": "[unterminated",
+  };
+  const reader = createDocumentReader({ readFile: (path) => files[path] });
+
+  it("reads JSON scalar/path facts and defaults projection to value", () => {
+    assert.deepEqual(readDocumentFact(reader, { path: "facts.json", pointer: "/contract", type: "string" }), {
+      ok: true,
+      value: "contracts/mts-contract-v0.7.json",
+    });
+    assert.deepEqual(readDocumentFact(reader, { path: "facts.json", pointer: "/corpus", type: "repository_path" }), {
+      ok: true,
+      value: "contracts/mts-conformance-v0.7.json",
+    });
+  });
+
+  it("composes object/array projections with deterministic path sets", () => {
+    assert.deepEqual(readDocumentFact(reader, { path: "facts.json", pointer: "/owners", projection: "object_values", type: "repository_path_set" }), {
+      ok: true,
+      value: ["core/runtime.ts", "schemas/mts.json"],
+    });
+    assert.deepEqual(readDocumentFact(reader, { path: "facts.yaml", pointer: "/gates", projection: "array_items", type: "repository_path_set" }), {
+      ok: true,
+      value: ["tests/smoke.mjs", "tools/check.mjs"],
+    });
+    assert.deepEqual(readDocumentFact(reader, { path: "facts.yaml", pointer: "/enabled", type: "boolean" }), { ok: true, value: true });
+  });
+
+  it("exposes required structured failure codes without parsing messages", () => {
+    const malformed = captureFailure(() => resolveJsonPointer(document, "/a~2b"));
+    assert.equal(malformed.code, "malformed_pointer");
+    assert.equal(malformed.pointer, "/a~2b");
+
+    const missing = captureFailure(() => resolveJsonPointer(document, "/owner/missing"));
+    assert.equal(missing.code, "missing_pointer_segment");
+    assert.equal(missing.segment, "missing");
+
+    const projection = captureFailure(() => projectDocumentValue(document, "/owner", "array_items"));
+    assert.equal(projection.code, "projection_type_mismatch");
+
+    const type = captureFailure(() => normalizeDocumentFact(1, "string", "/contract"));
+    assert.equal(type.code, "fact_type_mismatch");
+    assert.equal(type.pointer, "/contract");
+
+    const path = captureFailure(() => normalizeDocumentFact("../outside", "repository_path", "/corpus"));
+    assert.equal(path.code, "invalid_repository_path");
+    assert.equal(path.pointer, "/corpus");
+  });
+
+  it("returns the same structured codes through the read boundary", () => {
+    const missing = readDocumentFact(reader, { path: "facts.json", pointer: "/missing", type: "string" });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.error.code, "missing_pointer_segment");
+    assert.equal(missing.error.segment, "missing");
+
+    const projection = readDocumentFact(reader, { path: "facts.json", pointer: "/owners", projection: "array_items", type: "string_set" });
+    assert.equal(projection.ok, false);
+    assert.equal(projection.error.code, "projection_type_mismatch");
+
+    const type = readDocumentFact(reader, { path: "facts.json", pointer: "/contract", type: "boolean" });
+    assert.equal(type.ok, false);
+    assert.equal(type.error.code, "fact_type_mismatch");
+
+    const path = readDocumentFact(reader, { path: "../facts.json", pointer: "/contract", type: "string" });
+    assert.equal(path.ok, false);
+    assert.equal(path.error.code, "invalid_repository_path");
+  });
+
+  it("fails closed for parser/read and unsupported document errors", () => {
+    const badJson = readDocumentFact(reader, { path: "bad.json", pointer: "", type: "string" });
+    assert.equal(badJson.ok, false);
+    assert.equal(badJson.error.code, "document_read_error");
+
+    const badYaml = readDocumentFact(reader, { path: "bad.yaml", pointer: "", type: "string" });
+    assert.equal(badYaml.ok, false);
+    assert.equal(badYaml.error.code, "document_read_error");
+
+    const unsupported = readDocumentFact(reader, { path: "facts.toml", pointer: "", type: "string" });
+    assert.equal(unsupported.ok, false);
+    assert.equal(unsupported.error.code, "unsupported_document_type");
   });
 });


### PR DESCRIPTION
Fixes #281

Completes the R1 reusable DocumentFacts API without introducing R2 policy syntax:
- adds generic `DocumentFactSelector` / `readDocumentFact` over the existing DocumentReader cache/parsers;
- preserves the canonical strict pointer, projection, and typed-normalization implementation;
- adds deterministic machine-readable fact failures (`malformed_pointer`, `missing_pointer_segment`, `projection_type_mismatch`, `fact_type_mismatch`, `invalid_repository_path`) plus fail-closed read/unsupported-document codes;
- existing direct APIs remain throwing for compatibility, but now carry structured metadata; the selector/read boundary returns a discriminated result without parsing error strings;
- built-dist regressions cover JSON/YAML consumer shapes, set/path normalization, failing segments, parser failures, and unsupported document types.

No repo-policy/schema changes, document relations, new rule family, MTS-specific semantics, JSONPath/wildcards, expressions, or execution.

`dist/document-facts.mjs` is compiler-generated. The exact compiler input was verified byte-for-byte against GitHub source blob `789cb72d…`; compiler emit blob `7bfb593b…` is exactly the blob committed to this branch. Pinned CI remains the independent strict TypeScript/freshness authority.