### PR TITLE
Contract governance R2a: add scalar document relations

### DIFF
--- a/dist/checks/constraint-program.mjs
+++ b/dist/checks/constraint-program.mjs
@@ -1,3 +1,4 @@
+import { normalizeDocumentFact } from "../document-facts.mjs";
 const RANKS = {
     enforcement: { advisory: 0, blocking: 1 },
     count: { changed_only: 0, all_tracked: 1 },
@@ -8,6 +9,27 @@ const scalar = (relation, value, metadata) => compare(relation, value, metadata)
 const set = (relation, value, metadata) => compare(relation, array(value), metadata);
 const exact = (value, metadata) => compare("equal_or_incomparable", value, metadata);
 const entity = (metadata) => compare("required_entity", true, metadata);
+function object(value) {
+    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+function canonicalDocumentPath(value) {
+    try {
+        return normalizeDocumentFact(value, "repository_path");
+    }
+    catch {
+        return typeof value === "string" ? value : String(value ?? "");
+    }
+}
+function compileDocumentSelector(selectorValue, documents) {
+    const selector = object(selectorValue), name = typeof selector.document === "string" ? selector.document : "", definition = documents[name] || {};
+    return {
+        document: name,
+        path: canonicalDocumentPath(definition.path),
+        format: definition.format,
+        pointer: typeof selector.pointer === "string" ? selector.pointer : "",
+        type: selector.type,
+    };
+}
 export function compileConstraintProgram(policy = {}, changeIntent = null) {
     const program = [], diff = policy.diff_rules || {}, budgets = changeIntent?.budgets || {};
     const add = (key, runtime = null, strictness = null) => program.push({ key, runtime, strictness });
@@ -60,6 +82,25 @@ export function compileConstraintProgram(policy = {}, changeIntent = null) {
                 message: (a, b) => `integration.workflows[${workflow.id}].expect.enforcement: ${a} -> ${b}`, removeMessage: `integration.workflows[${workflow.id}].expect.enforcement removed (was ${enforcement})`,
             }));
     }
+    const documentRelations = policy.document_relations, documents = documentRelations?.documents || {};
+    for (const rule of array(documentRelations?.rules)) {
+        const id = String(rule.id ?? ""), owner = `document-relation:${id}`, pointer = `/document_relations/rules/${id}`;
+        const runtimeBase = { name: owner, relation_id: id };
+        let runtime = null, shape = { kind: rule.kind };
+        if (rule.kind === "scalar_equal") {
+            const left = compileDocumentSelector(rule.left, documents), right = compileDocumentSelector(rule.right, documents);
+            runtime = { ...runtimeBase, kind: "document_scalar_equal", left, right };
+            shape = { kind: rule.kind, left, right };
+        }
+        else if (rule.kind === "scalar_equals_literal") {
+            const source = compileDocumentSelector(rule.source, documents);
+            runtime = { ...runtimeBase, kind: "document_scalar_equals_literal", source, value: rule.value };
+            shape = { kind: rule.kind, source, value: rule.value };
+        }
+        add(owner, runtime, entity({ owner, pointer, removeKind: "document_relation_removed", rule_id: id,
+            removeBefore: shape, removeAfter: { present: false }, removeMessage: `document_relations rule "${id}" removed` }));
+        add(`${owner}:shape`, null, exact(shape, { owner, pointer, rule_id: id, incomparableMessage: `document_relations rule "${id}" changed semantics` }));
+    }
     if (array(policy.size_rules).length)
         add("runtime:size-rules", { kind: "size_rules", name: "size-rules", rules: policy.size_rules });
     if (array(policy.registry_rules).length)
@@ -91,6 +132,7 @@ function unknownProjection(policy = {}) {
     delete copy.enforcement;
     delete copy.diff_rules;
     delete copy.size_rules;
+    delete copy.document_relations;
     if (copy.paths) {
         for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"])
             delete copy.paths[field];

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -1,5 +1,6 @@
 import { calculateDiffGrowth } from "../../diff/growth.mjs";
 import { selectPaths } from "../../diff/classification.mjs";
+import { readDocumentFact } from "../../document-facts.mjs";
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
 import { integrationConstraintEntries } from "../integration-constraints.mjs";
@@ -65,6 +66,27 @@ function evaluateMetric(files, constraint, policy) {
         return checkNewFilesBudget(files, constraint.max);
     return checkNetAddedLinesBudget(files, constraint.max);
 }
+function factOperand(reader, selector) {
+    if (!reader || !selector)
+        return { ok: false, error: { code: "document_read_error", pointer: selector?.pointer || "", message: "document reader or selector is unavailable" } };
+    return readDocumentFact(reader, selector);
+}
+function checkDocumentScalarEqual(facts, constraint) {
+    const left = factOperand(facts.documents, constraint.left), right = factOperand(facts.documents, constraint.right);
+    const data = { kind: "scalar_equal", left, right };
+    if (!left.ok || !right.ok)
+        return { ok: false, message: `document relation "${constraint.relation_id}" could not read scalar operands`, data };
+    const ok = left.value === right.value;
+    return { ok, message: ok ? undefined : `document relation "${constraint.relation_id}" scalar values differ`, data };
+}
+function checkDocumentScalarLiteral(facts, constraint) {
+    const source = factOperand(facts.documents, constraint.source), expected = constraint.value;
+    const data = { kind: "scalar_equals_literal", source, expected };
+    if (!source.ok)
+        return { ok: false, message: `document relation "${constraint.relation_id}" could not read scalar operand`, data };
+    const ok = source.value === expected;
+    return { ok, message: ok ? undefined : `document relation "${constraint.relation_id}" scalar value does not match literal`, data };
+}
 export function evaluateConstraintIR(facts, context = {}) {
     const { files, constraints } = compileConstraintIR(facts), results = [], cochange = [];
     for (const constraint of constraints) {
@@ -113,6 +135,10 @@ export function evaluateConstraintIR(facts, context = {}) {
             results.push(...integrationConstraintEntries(facts.integration));
             continue;
         }
+        else if (constraint.kind === "document_scalar_equal")
+            check = checkDocumentScalarEqual(facts, constraint);
+        else if (constraint.kind === "document_scalar_equals_literal")
+            check = checkDocumentScalarLiteral(facts, constraint);
         else
             continue;
         results.push({ name: constraint.name, check });

--- a/dist/policy-compiler.mjs
+++ b/dist/policy-compiler.mjs
@@ -1,3 +1,4 @@
+import { normalizeDocumentFact } from "./document-facts.mjs";
 const list = (value) => Array.isArray(value) ? value : [];
 const object = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
 export function compileForbidRegex(contentRules = []) {
@@ -92,6 +93,65 @@ export function compileIntegrationPolicy(policy = {}) {
     for (const ref of references)
         if (!profileIds.has(ref.profileId))
             errors.push({ section: ref.section, index: ref.index, field: ref.field, profile_id: ref.profileId, message: `integration.${ref.section}[${ref.index}].${ref.field} references unknown integration.profiles id "${ref.profileId}"` });
+    return errors;
+}
+function scalarLiteralMatches(type, value) {
+    if (type === "string")
+        return typeof value === "string";
+    if (type === "boolean")
+        return typeof value === "boolean";
+    return type === "scalar" && (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value)));
+}
+function normalizeDeclaredDocumentPath(name, definition, errors) {
+    try {
+        const path = normalizeDocumentFact(definition.path, "repository_path");
+        const format = definition.format;
+        const matchesFormat = format === "json" ? /\.json$/i.test(path) : format === "yaml" ? /\.ya?ml$/i.test(path) : false;
+        if (!matchesFormat)
+            errors.push({ document: name, path, format, message: `document_relations.documents["${name}"] format "${format}" does not match path "${path}"` });
+        return path;
+    }
+    catch (error) {
+        errors.push({ document: name, path: definition.path, message: `document_relations.documents["${name}"].path is invalid: ${error.message}` });
+        return null;
+    }
+}
+export function compileDocumentRelationsPolicy(policy = {}) {
+    if (!policy.document_relations)
+        return [];
+    const section = object(policy.document_relations), documents = object(section.documents), rules = list(section.rules);
+    const errors = [], seenRuleIds = new Set(), usedDocuments = new Set();
+    for (const [name, rawDefinition] of Object.entries(documents))
+        normalizeDeclaredDocumentPath(name, object(rawDefinition), errors);
+    const useSelector = (ruleId, field, rawSelector) => {
+        const selector = object(rawSelector), document = selector.document;
+        if (typeof document !== "string" || !Object.hasOwn(documents, document)) {
+            errors.push({ rule_id: ruleId, field, document, message: `document_relations rule "${ruleId}" ${field} references unknown document "${document}"` });
+            return;
+        }
+        usedDocuments.add(document);
+    };
+    for (const [index, rule] of rules.entries()) {
+        const id = rule.id;
+        if (seenRuleIds.has(id))
+            errors.push({ rule_id: id, index, message: `document_relations.rules[${index}].id duplicates rule "${id}"` });
+        seenRuleIds.add(id);
+        if (rule.kind === "scalar_equal") {
+            useSelector(id, "left", rule.left);
+            useSelector(id, "right", rule.right);
+        }
+        else if (rule.kind === "scalar_equals_literal") {
+            useSelector(id, "source", rule.source);
+            const selector = object(rule.source);
+            if (!scalarLiteralMatches(selector.type, rule.value)) {
+                errors.push({ rule_id: id, type: selector.type, value: rule.value, message: `document_relations rule "${id}" literal is incompatible with source type "${selector.type}"` });
+            }
+        }
+    }
+    for (const name of Object.keys(documents))
+        if (!usedDocuments.has(name)) {
+            errors.push({ document: name, message: `document_relations.documents["${name}"] is declared but unused` });
+        }
     return errors;
 }
 export function warnReservedPolicyFields(policy = {}) {

--- a/dist/runtime/validation.mjs
+++ b/dist/runtime/validation.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
 import { resolvePolicyProfile } from "../policy-profiles.mjs";
 export const loadJSON = (path) => JSON.parse(readFileSync(path, "utf-8"));
 export const createAjv = () => new Ajv({ allErrors: true });
@@ -31,6 +31,7 @@ export function loadPolicyRuntimeFromObject(roots, rawPolicy, options = {}) {
         ["change_profiles compilation", compileChangeProfiles(policy), (error) => error.message],
         ["anchor policy compilation", compileAnchorPolicy(policy), (error) => error.message],
         ["integration policy compilation", compileIntegrationPolicy(policy), (error) => error.message],
+        ["document relation policy compilation", compileDocumentRelationsPolicy(policy), (error) => error.message],
     ];
     for (const [group, errors, format] of semanticGroups)
         if (errors.length) {

--- a/dist/runtime/validation.mjs
+++ b/dist/runtime/validation.mjs
@@ -4,7 +4,9 @@ import Ajv from "ajv";
 import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
 import { resolvePolicyProfile } from "../policy-profiles.mjs";
 export const loadJSON = (path) => JSON.parse(readFileSync(path, "utf-8"));
-export const createAjv = () => new Ajv({ allErrors: true });
+// Draft-07 разрешает массив типов. Оставляем Ajv strict mode включённым, но явно
+// разрешаем этот стандартный синтаксис, чтобы валидная policy не писала warning в stderr.
+export const createAjv = () => new Ajv({ allErrors: true, allowUnionTypes: true });
 export const ajvErrors = (errors) => (errors || []).map((error) => `${error.instancePath || "/"} ${error.message}`);
 export function validate(ajv, schema, data, label, { quiet = false } = {}) {
     const valid = ajv.validate(schema, data);

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -239,6 +239,9 @@
         }
       }
     },
+    "document_relations": {
+      "$ref": "#/definitions/document_relations"
+    },
     "advisory_text_rules": {
       "type": "object",
       "description": "Optional heuristic markdown duplication advisories. These warnings never block the PR in v1.",
@@ -364,6 +367,68 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "minItems": 1
+    },
+    "document_relations": {
+      "type": "object",
+      "required": ["documents", "rules"],
+      "additionalProperties": false,
+      "properties": {
+        "documents": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "$ref": "#/definitions/document_relation_document" }
+        },
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/document_relation_rule" }
+        }
+      }
+    },
+    "document_relation_document": {
+      "type": "object",
+      "required": ["path", "format"],
+      "additionalProperties": false,
+      "properties": {
+        "path": { "$ref": "#/definitions/non_empty_string" },
+        "format": { "type": "string", "enum": ["json", "yaml"] }
+      }
+    },
+    "document_scalar_selector": {
+      "type": "object",
+      "required": ["document", "pointer", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "document": { "$ref": "#/definitions/non_empty_string" },
+        "pointer": { "type": "string" },
+        "type": { "type": "string", "enum": ["scalar", "string", "boolean"] }
+      }
+    },
+    "document_relation_rule": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["id", "kind", "left", "right"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "$ref": "#/definitions/non_empty_string" },
+            "kind": { "const": "scalar_equal" },
+            "left": { "$ref": "#/definitions/document_scalar_selector" },
+            "right": { "$ref": "#/definitions/document_scalar_selector" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["id", "kind", "source", "value"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "$ref": "#/definitions/non_empty_string" },
+            "kind": { "const": "scalar_equals_literal" },
+            "source": { "$ref": "#/definitions/document_scalar_selector" },
+            "value": { "type": ["string", "number", "boolean", "null"] }
+          }
+        }
+      ]
     },
     "profile_overrides": {
       "type": "object",

--- a/src/checks/constraint-program.mts
+++ b/src/checks/constraint-program.mts
@@ -1,3 +1,5 @@
+import { normalizeDocumentFact } from "../document-facts.mjs";
+
 type EnforcementMode = "advisory" | "blocking";
 type CountMode = "changed_only" | "all_tracked";
 type RankRelation = "lower_stricter" | "higher_stricter";
@@ -5,6 +7,7 @@ type SetRelation = "superset_stricter" | "subset_stricter";
 type StrictnessRelation = RankRelation | SetRelation | "equal_or_incomparable" | "required_entity";
 type ComparisonRelation = "equal" | "weaker" | "incomparable" | "stricter";
 type DiagnosticValue = string | number | boolean | null | undefined;
+type DocumentScalarType = "scalar" | "string" | "boolean";
 
 interface StrictnessMetadata {
   owner?: string;
@@ -89,6 +92,31 @@ interface CochangeRuleProjection {
   [key: string]: unknown;
 }
 
+interface DocumentDefinitionProjection {
+  path?: unknown;
+  format?: unknown;
+}
+
+interface DocumentScalarSelectorProjection {
+  document?: unknown;
+  pointer?: unknown;
+  type?: unknown;
+}
+
+interface DocumentRelationRuleProjection {
+  id?: unknown;
+  kind?: unknown;
+  left?: unknown;
+  right?: unknown;
+  source?: unknown;
+  value?: unknown;
+}
+
+interface DocumentRelationsProjection {
+  documents?: Record<string, DocumentDefinitionProjection>;
+  rules?: DocumentRelationRuleProjection[];
+}
+
 export interface ConstraintPolicyProjection {
   diff_rules?: DiffRulesProjection;
   paths?: PathsProjection;
@@ -99,6 +127,7 @@ export interface ConstraintPolicyProjection {
   trace_rules?: unknown[];
   change_profiles?: unknown;
   cochange_rules?: CochangeRuleProjection[];
+  document_relations?: DocumentRelationsProjection;
 }
 
 interface ChangeIntentProjection {
@@ -145,6 +174,26 @@ const scalar = (relation: RankRelation, value: number, metadata: StrictnessMetad
 const set = (relation: SetRelation, value: unknown, metadata: StrictnessMetadata): SetStrictness => compare(relation, array(value as Array<string | number> | undefined), metadata) as SetStrictness;
 const exact = (value: unknown, metadata: StrictnessMetadata): ExactStrictness => compare("equal_or_incomparable", value, metadata) as ExactStrictness;
 const entity = (metadata: StrictnessMetadata): EntityStrictness => compare("required_entity", true, metadata) as EntityStrictness;
+
+function object(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function canonicalDocumentPath(value: unknown): string {
+  try { return normalizeDocumentFact(value, "repository_path") as string; }
+  catch { return typeof value === "string" ? value : String(value ?? ""); }
+}
+
+function compileDocumentSelector(selectorValue: unknown, documents: Record<string, DocumentDefinitionProjection>) {
+  const selector = object(selectorValue), name = typeof selector.document === "string" ? selector.document : "", definition = documents[name] || {};
+  return {
+    document: name,
+    path: canonicalDocumentPath(definition.path),
+    format: definition.format,
+    pointer: typeof selector.pointer === "string" ? selector.pointer : "",
+    type: selector.type as DocumentScalarType,
+  };
+}
 
 export function compileConstraintProgram(policy: ConstraintPolicyProjection = {}, changeIntent: ChangeIntentProjection | null = null): ConstraintProgramEntry[] {
   const program: ConstraintProgramEntry[] = [], diff = policy.diff_rules || {}, budgets = changeIntent?.budgets || {};
@@ -202,6 +251,25 @@ export function compileConstraintProgram(policy: ConstraintPolicyProjection = {}
     }));
   }
 
+  const documentRelations = policy.document_relations, documents = documentRelations?.documents || {};
+  for (const rule of array(documentRelations?.rules)) {
+    const id = String(rule.id ?? ""), owner = `document-relation:${id}`, pointer = `/document_relations/rules/${id}`;
+    const runtimeBase = { name: owner, relation_id: id };
+    let runtime: RuntimeConstraint | null = null, shape: unknown = { kind: rule.kind };
+    if (rule.kind === "scalar_equal") {
+      const left = compileDocumentSelector(rule.left, documents), right = compileDocumentSelector(rule.right, documents);
+      runtime = { ...runtimeBase, kind: "document_scalar_equal", left, right };
+      shape = { kind: rule.kind, left, right };
+    } else if (rule.kind === "scalar_equals_literal") {
+      const source = compileDocumentSelector(rule.source, documents);
+      runtime = { ...runtimeBase, kind: "document_scalar_equals_literal", source, value: rule.value };
+      shape = { kind: rule.kind, source, value: rule.value };
+    }
+    add(owner, runtime, entity({ owner, pointer, removeKind: "document_relation_removed", rule_id: id,
+      removeBefore: shape, removeAfter: { present: false }, removeMessage: `document_relations rule "${id}" removed` }));
+    add(`${owner}:shape`, null, exact(shape, { owner, pointer, rule_id: id, incomparableMessage: `document_relations rule "${id}" changed semantics` }));
+  }
+
   if (array(policy.size_rules).length) add("runtime:size-rules", { kind: "size_rules", name: "size-rules", rules: policy.size_rules });
   if (array(policy.registry_rules).length) add("runtime:registry-rules", { kind: "registry_rules", name: "registry-rules", rules: policy.registry_rules });
   if (array(policy.trace_rules).length) add("runtime:trace-rules", { kind: "trace_rules", name: "trace-rules" });
@@ -223,7 +291,7 @@ function canonical(value: unknown): unknown { if (Array.isArray(value)) return v
 const same = (a: unknown, b: unknown): boolean => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
 const clone = <T,>(value: T): T | undefined => value === undefined ? undefined : structuredClone(value);
 function unknownProjection(policy: ConstraintPolicyProjection = {}): ConstraintPolicyProjection {
-  const copy = clone(policy) || {}; delete copy.enforcement; delete copy.diff_rules; delete copy.size_rules;
+  const copy = clone(policy) || {}; delete copy.enforcement; delete copy.diff_rules; delete copy.size_rules; delete copy.document_relations;
   if (copy.paths) { for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"]) delete copy.paths[field as keyof PathsProjection]; if (!Object.keys(copy.paths).length) delete copy.paths; }
   if (copy.integration) { delete copy.integration.workflows; if (!Object.keys(copy.integration).length) delete copy.integration; }
   return copy;

--- a/src/checks/rules/constraints.mts
+++ b/src/checks/rules/constraints.mts
@@ -1,6 +1,7 @@
 import type { ParsedDiffFile } from "../../diff/parser.mjs";
 import { calculateDiffGrowth } from "../../diff/growth.mjs";
 import { selectPaths } from "../../diff/classification.mjs";
+import { readDocumentFact, type DocumentFactSelector, type DocumentReader } from "../../document-facts.mjs";
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
 import { integrationConstraintEntries } from "../integration-constraints.mjs";
@@ -35,7 +36,9 @@ type RuntimeConstraintKind =
   | "registry_rules"
   | "change_profile"
   | "trace_rules"
-  | "integration";
+  | "integration"
+  | "document_scalar_equal"
+  | "document_scalar_equals_literal";
 
 interface RuntimeConstraint {
   kind: RuntimeConstraintKind;
@@ -48,6 +51,11 @@ interface RuntimeConstraint {
   if_changed?: string[];
   must_change_any?: string[];
   rules?: unknown;
+  relation_id?: string;
+  left?: DocumentFactSelector;
+  right?: DocumentFactSelector;
+  source?: DocumentFactSelector;
+  value?: unknown;
 }
 
 interface ConstraintPolicyProjection {
@@ -59,7 +67,7 @@ interface ConstraintFacts {
   repositoryRoot?: string;
   trackedFiles?: string[];
   readFile?: (filePath: string) => unknown;
-  documents?: unknown;
+  documents?: DocumentReader;
   policy: ConstraintPolicyProjection;
   changeIntent?: { change_type?: string } | null;
   diff: { files: { checked: ParsedDiffFile[] } };
@@ -128,6 +136,27 @@ function evaluateMetric(files: ParsedDiffFile[], constraint: RuntimeConstraint, 
   return checkNetAddedLinesBudget(files, constraint.max);
 }
 
+function factOperand(reader: DocumentReader | undefined, selector: DocumentFactSelector | undefined) {
+  if (!reader || !selector) return { ok: false as const, error: { code: "document_read_error", pointer: selector?.pointer || "", message: "document reader or selector is unavailable" } };
+  return readDocumentFact(reader, selector);
+}
+
+function checkDocumentScalarEqual(facts: ConstraintFacts, constraint: RuntimeConstraint) {
+  const left = factOperand(facts.documents, constraint.left), right = factOperand(facts.documents, constraint.right);
+  const data = { kind: "scalar_equal", left, right };
+  if (!left.ok || !right.ok) return { ok: false, message: `document relation "${constraint.relation_id}" could not read scalar operands`, data };
+  const ok = left.value === right.value;
+  return { ok, message: ok ? undefined : `document relation "${constraint.relation_id}" scalar values differ`, data };
+}
+
+function checkDocumentScalarLiteral(facts: ConstraintFacts, constraint: RuntimeConstraint) {
+  const source = factOperand(facts.documents, constraint.source), expected = constraint.value;
+  const data = { kind: "scalar_equals_literal", source, expected };
+  if (!source.ok) return { ok: false, message: `document relation "${constraint.relation_id}" could not read scalar operand`, data };
+  const ok = source.value === expected;
+  return { ok, message: ok ? undefined : `document relation "${constraint.relation_id}" scalar value does not match literal`, data };
+}
+
 export function evaluateConstraintIR(facts: ConstraintFacts, context: ConstraintContext = {}): RuleResult[] {
   const { files, constraints } = compileConstraintIR(facts), results: RuleResult[] = [], cochange: RuntimeConstraint[] = [];
   for (const constraint of constraints) {
@@ -158,7 +187,9 @@ export function evaluateConstraintIR(facts: ConstraintFacts, context: Constraint
     } else if (constraint.kind === "integration") {
       results.push(...integrationConstraintEntries(facts.integration as Parameters<typeof integrationConstraintEntries>[0]));
       continue;
-    } else continue;
+    } else if (constraint.kind === "document_scalar_equal") check = checkDocumentScalarEqual(facts, constraint);
+    else if (constraint.kind === "document_scalar_equals_literal") check = checkDocumentScalarLiteral(facts, constraint);
+    else continue;
     results.push({ name: constraint.name, check });
   }
   results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed!.join(",")} -> ${item.must_change_any!.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));

--- a/src/policy-compiler.mts
+++ b/src/policy-compiler.mts
@@ -1,3 +1,5 @@
+import { normalizeDocumentFact } from "./document-facts.mjs";
+
 type LooseObject = Record<string, unknown>;
 type SemanticDiagnostic = { message: string } & LooseObject;
 type IntegrationSection = "workflows" | "templates" | "docs" | "profiles";
@@ -33,6 +35,7 @@ interface PolicyProjection {
   integration?: unknown;
   paths?: { public_api?: unknown };
   content_rules?: unknown;
+  document_relations?: unknown;
 }
 interface IntegrationReference {
   section: IntegrationSection;
@@ -111,6 +114,63 @@ export function compileIntegrationPolicy(policy: PolicyProjection = {}): Semanti
     if (section === "docs") for (const profileId of list(entry.must_mention_profiles)) references.push({ section, index, field: "must_mention_profiles", profileId });
   }
   for (const ref of references) if (!profileIds.has(ref.profileId)) errors.push({ section: ref.section, index: ref.index, field: ref.field, profile_id: ref.profileId, message: `integration.${ref.section}[${ref.index}].${ref.field} references unknown integration.profiles id "${ref.profileId}"` });
+  return errors;
+}
+
+function scalarLiteralMatches(type: unknown, value: unknown): boolean {
+  if (type === "string") return typeof value === "string";
+  if (type === "boolean") return typeof value === "boolean";
+  return type === "scalar" && (value === null || typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value)));
+}
+
+function normalizeDeclaredDocumentPath(name: string, definition: LooseObject, errors: SemanticDiagnostic[]): string | null {
+  try {
+    const path = normalizeDocumentFact(definition.path, "repository_path") as string;
+    const format = definition.format;
+    const matchesFormat = format === "json" ? /\.json$/i.test(path) : format === "yaml" ? /\.ya?ml$/i.test(path) : false;
+    if (!matchesFormat) errors.push({ document: name, path, format, message: `document_relations.documents["${name}"] format "${format}" does not match path "${path}"` });
+    return path;
+  } catch (error) {
+    errors.push({ document: name, path: definition.path, message: `document_relations.documents["${name}"].path is invalid: ${(error as Error).message}` });
+    return null;
+  }
+}
+
+export function compileDocumentRelationsPolicy(policy: PolicyProjection = {}): SemanticDiagnostic[] {
+  if (!policy.document_relations) return [];
+  const section = object(policy.document_relations), documents = object(section.documents), rules = list<LooseObject>(section.rules);
+  const errors: SemanticDiagnostic[] = [], seenRuleIds = new Set<unknown>(), usedDocuments = new Set<string>();
+
+  for (const [name, rawDefinition] of Object.entries(documents)) normalizeDeclaredDocumentPath(name, object(rawDefinition), errors);
+
+  const useSelector = (ruleId: unknown, field: string, rawSelector: unknown) => {
+    const selector = object(rawSelector), document = selector.document;
+    if (typeof document !== "string" || !Object.hasOwn(documents, document)) {
+      errors.push({ rule_id: ruleId, field, document, message: `document_relations rule "${ruleId}" ${field} references unknown document "${document}"` });
+      return;
+    }
+    usedDocuments.add(document);
+  };
+
+  for (const [index, rule] of rules.entries()) {
+    const id = rule.id;
+    if (seenRuleIds.has(id)) errors.push({ rule_id: id, index, message: `document_relations.rules[${index}].id duplicates rule "${id}"` });
+    seenRuleIds.add(id);
+    if (rule.kind === "scalar_equal") {
+      useSelector(id, "left", rule.left);
+      useSelector(id, "right", rule.right);
+    } else if (rule.kind === "scalar_equals_literal") {
+      useSelector(id, "source", rule.source);
+      const selector = object(rule.source);
+      if (!scalarLiteralMatches(selector.type, rule.value)) {
+        errors.push({ rule_id: id, type: selector.type, value: rule.value, message: `document_relations rule "${id}" literal is incompatible with source type "${selector.type}"` });
+      }
+    }
+  }
+
+  for (const name of Object.keys(documents)) if (!usedDocuments.has(name)) {
+    errors.push({ document: name, message: `document_relations.documents["${name}"] is declared but unused` });
+  }
   return errors;
 }
 

--- a/src/runtime/validation.mts
+++ b/src/runtime/validation.mts
@@ -9,7 +9,7 @@ interface AjvRuntime {
   errors: readonly AjvErrorProjection[] | null;
   validate(schema: unknown, data: unknown): boolean | Promise<unknown>;
 }
-type AjvConstructor = new (options?: { allErrors?: boolean }) => AjvRuntime;
+type AjvConstructor = new (options?: { allErrors?: boolean; allowUnionTypes?: boolean }) => AjvRuntime;
 type AjvSchema = unknown;
 type RuntimePolicyProjection = Parameters<typeof compileChangeProfiles>[0] & { content_rules?: unknown };
 type SemanticGroup = readonly [string, readonly unknown[], (error: unknown) => string];
@@ -18,7 +18,9 @@ interface RuntimeValidationOptions { quiet?: boolean; label?: string; }
 interface QuietOption { quiet?: boolean; }
 
 export const loadJSON = (path: string): unknown => JSON.parse(readFileSync(path, "utf-8"));
-export const createAjv = (): AjvRuntime => new (Ajv as unknown as AjvConstructor)({ allErrors: true });
+// Draft-07 разрешает массив типов. Оставляем Ajv strict mode включённым, но явно
+// разрешаем этот стандартный синтаксис, чтобы валидная policy не писала warning в stderr.
+export const createAjv = (): AjvRuntime => new (Ajv as unknown as AjvConstructor)({ allErrors: true, allowUnionTypes: true });
 export const ajvErrors = (errors: readonly AjvErrorProjection[] | null | undefined): string[] => (errors || []).map((error) => `${error.instancePath || "/"} ${error.message}`);
 export function validate(ajv: AjvRuntime, schema: AjvSchema, data: unknown, label: string, { quiet = false }: QuietOption = {}) {
   const valid = ajv.validate(schema, data);

--- a/src/runtime/validation.mts
+++ b/src/runtime/validation.mts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import { compileAnchorPolicy, compileChangeProfiles, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
 import { resolvePolicyProfile } from "../policy-profiles.mjs";
 
 type AjvErrorProjection = { instancePath?: string; message?: string };
@@ -44,6 +44,7 @@ export function loadPolicyRuntimeFromObject(roots: RuntimeRoots, rawPolicy: unkn
     ["change_profiles compilation", compileChangeProfiles(policy), (error) => (error as { message: string }).message],
     ["anchor policy compilation", compileAnchorPolicy(policy), (error) => (error as { message: string }).message],
     ["integration policy compilation", compileIntegrationPolicy(policy), (error) => (error as { message: string }).message],
+    ["document relation policy compilation", compileDocumentRelationsPolicy(policy), (error) => (error as { message: string }).message],
   ];
   for (const [group, errors, format] of semanticGroups) if (errors.length) {
     ok = false;

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -186,5 +186,67 @@ console.log("\n--- check-pr style pipeline evaluates size rules ---");
   expect("check-pr pipeline reports measured lines", violation?.data?.size_violations?.[0]?.actual, 1);
 }
 
+console.log("\n--- scalar document relations execute through Constraint Program ---");
+{
+  const relationPolicy = {
+    ...policy,
+    document_relations: {
+      documents: {
+        contract: { path: "contracts/contract.json", format: "json" },
+        conformance: { path: "contracts/conformance.yaml", format: "yaml" },
+      },
+      rules: [
+        {
+          id: "contract-id-matches",
+          kind: "scalar_equal",
+          left: { document: "conformance", pointer: "/contract", type: "string" },
+          right: { document: "contract", pointer: "/id", type: "string" },
+        },
+        {
+          id: "root-is-infinity",
+          kind: "scalar_equals_literal",
+          source: { document: "contract", pointer: "/root", type: "string" },
+          value: "∞",
+        },
+      ],
+    },
+  };
+  const files = {
+    "contracts/contract.json": JSON.stringify({ id: "mts-v0.7", root: "∞" }),
+    "contracts/conformance.yaml": "contract: mts-v0.7\nenabled: true\n",
+  };
+  const readFile = (path) => files[path];
+  const passing = runEquivalentInput({ policy: relationPolicy, readFile });
+  expect("JSON/YAML scalar equality passes", passing.ruleResults.find((item) => item.rule === "document-relation:contract-id-matches")?.ok, true);
+  expect("scalar literal relation passes", passing.ruleResults.find((item) => item.rule === "document-relation:root-is-infinity")?.ok, true);
+
+  const mismatch = runEquivalentInput({
+    policy: relationPolicy,
+    readFile: (path) => path === "contracts/conformance.yaml" ? "contract: other\n" : files[path],
+  });
+  const mismatchViolation = mismatch.violations.find((item) => item.rule === "document-relation:contract-id-matches");
+  expect("scalar mismatch fails in same pipeline", Boolean(mismatchViolation), true);
+  expect("scalar mismatch exposes relation kind", mismatchViolation?.data?.kind, "scalar_equal");
+  expect("scalar mismatch exposes normalized left value", mismatchViolation?.data?.left?.value, "other");
+  expect("scalar mismatch exposes normalized right value", mismatchViolation?.data?.right?.value, "mts-v0.7");
+
+  const missingDocument = runEquivalentInput({ policy: relationPolicy, readFile: (path) => path === "contracts/contract.json" ? undefined : files[path] });
+  const missingViolation = missingDocument.violations.find((item) => item.rule === "document-relation:contract-id-matches");
+  expect("missing document fails relation implicitly", Boolean(missingViolation), true);
+  expect("missing document surfaces structured read error", missingViolation?.data?.right?.error?.code, "document_read_error");
+
+  const malformedPointerPolicy = structuredClone(relationPolicy);
+  malformedPointerPolicy.document_relations.rules[0].left.pointer = "/contract~2";
+  const malformedPointer = runEquivalentInput({ policy: malformedPointerPolicy, readFile });
+  const pointerViolation = malformedPointer.violations.find((item) => item.rule === "document-relation:contract-id-matches");
+  expect("malformed pointer fails closed", pointerViolation?.data?.left?.error?.code, "malformed_pointer");
+
+  const wrongTypePolicy = structuredClone(relationPolicy);
+  wrongTypePolicy.document_relations.rules[0].left = { document: "conformance", pointer: "/enabled", type: "string" };
+  const wrongType = runEquivalentInput({ policy: wrongTypePolicy, readFile });
+  const typeViolation = wrongType.violations.find((item) => item.rule === "document-relation:contract-id-matches");
+  expect("wrong scalar type fails closed", typeViolation?.data?.left?.error?.code, "fact_type_mismatch");
+}
+
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-policy-compiler-boundary.mjs
+++ b/tests/test-policy-compiler-boundary.mjs
@@ -1,6 +1,37 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { compileForbidRegex, compileIntegrationPolicy } from "../dist/policy-compiler.mjs";
+import { resolve } from "node:path";
+import { compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy } from "../dist/policy-compiler.mjs";
+import { loadPolicyRuntimeFromObject } from "../dist/runtime/validation.mjs";
+
+const projectRoot = resolve(new URL("..", import.meta.url).pathname);
+const basePolicy = {
+  policy_format_version: "0.3.0",
+  repository_kind: "tooling",
+  paths: { forbidden: [], canonical_docs: [], governance_paths: [] },
+  diff_rules: { max_new_docs: 5, max_new_files: 5 },
+  content_rules: [],
+  cochange_rules: [],
+};
+const documents = {
+  contract: { path: "contracts/contract.json", format: "json" },
+  conformance: { path: "contracts/conformance.yaml", format: "yaml" },
+};
+const scalarEqual = {
+  id: "contract-id-matches",
+  kind: "scalar_equal",
+  left: { document: "conformance", pointer: "/contract", type: "string" },
+  right: { document: "contract", pointer: "/id", type: "string" },
+};
+const scalarLiteral = {
+  id: "root-is-infinity",
+  kind: "scalar_equals_literal",
+  source: { document: "contract", pointer: "/root", type: "string" },
+  value: "∞",
+};
+const relationPolicy = (overrides = {}) => ({
+  document_relations: { documents: structuredClone(documents), rules: [structuredClone(scalarEqual), structuredClone(scalarLiteral)], ...overrides },
+});
 
 describe("semantic policy compiler boundary", () => {
   it("keeps non-array nested values inert before semantic compilation", () => {
@@ -11,5 +42,65 @@ describe("semantic policy compiler boundary", () => {
         docs: [{ id: "readme", must_mention_profiles: "missing" }],
       },
     }), []);
+  });
+
+  it("accepts semantically consistent scalar document relations", () => {
+    assert.deepEqual(compileDocumentRelationsPolicy(relationPolicy()), []);
+  });
+
+  it("rejects duplicate ids, unknown references and unused documents", () => {
+    const policy = relationPolicy({
+      documents: { ...documents, unused: { path: "contracts/unused.json", format: "json" } },
+      rules: [
+        structuredClone(scalarEqual),
+        { ...structuredClone(scalarEqual), right: { document: "missing", pointer: "/id", type: "string" } },
+      ],
+    });
+    const messages = compileDocumentRelationsPolicy(policy).map((error) => error.message);
+    assert.ok(messages.some((message) => /duplicates rule/.test(message)));
+    assert.ok(messages.some((message) => /unknown document "missing"/.test(message)));
+    assert.ok(messages.some((message) => /"unused".*declared but unused/.test(message)));
+    assert.ok(messages.some((message) => /"contract".*declared but unused/.test(message)));
+  });
+
+  it("rejects invalid paths, format mismatches and incompatible literals", () => {
+    const policy = relationPolicy({
+      documents: {
+        contract: { path: "../contract.json", format: "json" },
+        conformance: { path: "contracts/conformance.json", format: "yaml" },
+      },
+      rules: [
+        structuredClone(scalarEqual),
+        { ...structuredClone(scalarLiteral), source: { document: "contract", pointer: "/root", type: "boolean" }, value: "true" },
+      ],
+    });
+    const messages = compileDocumentRelationsPolicy(policy).map((error) => error.message);
+    assert.ok(messages.some((message) => /path is invalid/.test(message)));
+    assert.ok(messages.some((message) => /format "yaml" does not match path/.test(message)));
+    assert.ok(messages.some((message) => /literal is incompatible/.test(message)));
+  });
+});
+
+describe("document relation public schema boundary", () => {
+  const validate = (documentRelations) => loadPolicyRuntimeFromObject(
+    { packageRoot: projectRoot, repoRoot: projectRoot },
+    { ...basePolicy, document_relations: documentRelations },
+    { quiet: true },
+  );
+
+  it("accepts only the executable R2a scalar relation kinds", () => {
+    assert.equal(validate(relationPolicy().document_relations).ok, true);
+    assert.equal(validate({ documents, rules: [{ ...scalarEqual, kind: "set_equal" }] }).ok, false);
+  });
+
+  it("rejects collection projections and unsupported document formats in R2a schema", () => {
+    assert.equal(validate({
+      documents,
+      rules: [{ ...scalarEqual, left: { ...scalarEqual.left, projection: "array_items" } }],
+    }).ok, false);
+    assert.equal(validate({
+      documents: { contract: { path: "contracts/contract.md", format: "markdown" } },
+      rules: [{ ...scalarLiteral, source: { ...scalarLiteral.source, document: "contract" } }],
+    }).ok, false);
   });
 });

--- a/tests/test-policy-compiler-boundary.mjs
+++ b/tests/test-policy-compiler-boundary.mjs
@@ -60,7 +60,6 @@ describe("semantic policy compiler boundary", () => {
     assert.ok(messages.some((message) => /duplicates rule/.test(message)));
     assert.ok(messages.some((message) => /unknown document "missing"/.test(message)));
     assert.ok(messages.some((message) => /"unused".*declared but unused/.test(message)));
-    assert.ok(messages.some((message) => /"contract".*declared but unused/.test(message)));
   });
 
   it("rejects invalid paths, format mismatches and incompatible literals", () => {

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -93,7 +93,7 @@ describe("document relation strictness projection", () => {
 
   for (const [name, edit] of [
     ["selector", (policy) => { policy.document_relations.rules[0].left.pointer = "/other"; }],
-    ["literal", (policy) => { policy.document_relations.rules.push(structuredClone(literalRule)); policy.document_relations.rules[1].value = "R"; }],
+    ["literal", (policy) => { policy.document_relations.rules[1].value = "R"; }],
     ["document path", (policy) => { policy.document_relations.documents.contract.path = "contracts/other.json"; }],
     ["document format", (policy) => { policy.document_relations.documents.contract.path = "contracts/contract.yaml"; policy.document_relations.documents.contract.format = "yaml"; }],
   ]) it(`treats ${name} edit as incomparable`, () => {

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -1,5 +1,6 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
+import { compareConstraintPrograms } from "../dist/checks/constraint-program.mjs";
 import { checkPolicyRelaxation, classifyChangedFiles, computePolicyDelta, policyRelaxationRuleFamily } from "../dist/checks/rules/policy-delta-rules.mjs";
 
 const file = (path, extra = {}) => ({ path, status: "modified", addedLines: [], deletedLines: [], ...extra });
@@ -20,6 +21,28 @@ const mutate = (fn) => { const copy = structuredClone(BASE); fn(copy); return co
 const relax = () => mutate((policy) => { policy.size_rules[0].max = 1000; });
 const grant = (pointer = "/size_rules/max-source/max") => ({ allow_policy_relaxation: [pointer] });
 
+const relationPolicy = (rules = null) => ({
+  ...structuredClone(BASE),
+  document_relations: {
+    documents: {
+      contract: { path: "contracts/contract.json", format: "json" },
+      conformance: { path: "contracts/conformance.json", format: "json" },
+    },
+    rules: rules || [{
+      id: "contract-id-matches",
+      kind: "scalar_equal",
+      left: { document: "conformance", pointer: "/contract", type: "string" },
+      right: { document: "contract", pointer: "/id", type: "string" },
+    }],
+  },
+});
+const literalRule = {
+  id: "root-is-infinity",
+  kind: "scalar_equals_literal",
+  source: { document: "contract", pointer: "/root", type: "string" },
+  value: "∞",
+};
+
 describe("Constraint Program strictness projection", () => {
   const cases = [
     ["size max", (p) => { p.size_rules[0].max = 1000; }, "size_rule_max_increased"],
@@ -39,6 +62,48 @@ describe("Constraint Program strictness projection", () => {
   it("fails closed for unknown semantic sections", () => {
     const result = computePolicyDelta(BASE, mutate((p) => { p.content_rules = [{ id: "x", glob: "**", mode: "added_lines", forbid_regex: ["x"] }]; }));
     assert.equal(result.relaxations[0].kind, "policy_incomparable");
+  });
+});
+
+describe("document relation strictness projection", () => {
+  it("treats first relation adoption as stricter rather than unknown/incomparable", () => {
+    const comparison = compareConstraintPrograms(BASE, relationPolicy());
+    assert.equal(comparison.relation, "stricter");
+    assert.deepEqual(comparison.relaxations, []);
+    assert.deepEqual(comparison.incomparable, []);
+  });
+
+  it("treats an added relation id as stricter", () => {
+    const base = relationPolicy(), head = structuredClone(base);
+    head.document_relations.rules.push(structuredClone(literalRule));
+    const comparison = compareConstraintPrograms(base, head);
+    assert.equal(comparison.relation, "stricter");
+    assert.deepEqual(comparison.relaxations, []);
+    assert.deepEqual(comparison.incomparable, []);
+  });
+
+  it("treats a removed relation id as weaker", () => {
+    const base = relationPolicy();
+    base.document_relations.rules.push(structuredClone(literalRule));
+    const head = structuredClone(base);
+    head.document_relations.rules = head.document_relations.rules.filter((rule) => rule.id !== literalRule.id);
+    const delta = computePolicyDelta(base, head);
+    assert.ok(delta.relaxations.some((item) => item.kind === "document_relation_removed" && item.rule_id === "root-is-infinity"));
+  });
+
+  for (const [name, edit] of [
+    ["selector", (policy) => { policy.document_relations.rules[0].left.pointer = "/other"; }],
+    ["literal", (policy) => { policy.document_relations.rules.push(structuredClone(literalRule)); policy.document_relations.rules[1].value = "R"; }],
+    ["document path", (policy) => { policy.document_relations.documents.contract.path = "contracts/other.json"; }],
+    ["document format", (policy) => { policy.document_relations.documents.contract.path = "contracts/contract.yaml"; policy.document_relations.documents.contract.format = "yaml"; }],
+  ]) it(`treats ${name} edit as incomparable`, () => {
+    const base = relationPolicy();
+    if (name === "literal") base.document_relations.rules.push(structuredClone(literalRule));
+    const head = structuredClone(base);
+    edit(head);
+    const comparison = compareConstraintPrograms(base, head);
+    assert.equal(comparison.relation, "incomparable");
+    assert.ok(comparison.incomparable.some((item) => item.pointer === "/document_relations/rules/contract-id-matches" || item.pointer === "/document_relations/rules/root-is-infinity"));
   });
 });
 


### PR DESCRIPTION
Fixes #283

Draft compiler probe for the first fully executable R2 slice. Current source commits wire semantic compilation and scalar document relations through the existing Constraint Program/runtime evaluator; schema, regressions and compiler-generated dist are still intentionally incomplete at this stage.

This PR must remain draft/red until schema, tests and generated dist are completed and a full draft CI is green.