### PR TITLE
Contract governance R2b: add referenced path existence relation

### DIFF
--- a/dist/checks/constraint-program.mjs
+++ b/dist/checks/constraint-program.mjs
@@ -27,6 +27,7 @@ function compileDocumentSelector(selectorValue, documents) {
         path: canonicalDocumentPath(definition.path),
         format: definition.format,
         pointer: typeof selector.pointer === "string" ? selector.pointer : "",
+        projection: selector.projection,
         type: selector.type,
     };
 }
@@ -96,6 +97,11 @@ export function compileConstraintProgram(policy = {}, changeIntent = null) {
             const source = compileDocumentSelector(rule.source, documents);
             runtime = { ...runtimeBase, kind: "document_scalar_equals_literal", source, value: rule.value };
             shape = { kind: rule.kind, source, value: rule.value };
+        }
+        else if (rule.kind === "referenced_paths_exist") {
+            const source = compileDocumentSelector(rule.source, documents);
+            runtime = { ...runtimeBase, kind: "document_referenced_paths_exist", source };
+            shape = { kind: rule.kind, source };
         }
         add(owner, runtime, entity({ owner, pointer, removeKind: "document_relation_removed", rule_id: id,
             removeBefore: shape, removeAfter: { present: false }, removeMessage: `document_relations rule "${id}" removed` }));

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -28,7 +28,7 @@ export function checkSurfaceDebt(files, debt) {
     if (!debt)
         return { ok: true, status: "undeclared", growth, details: [`new files: ${growth.new_files}`, `net added lines: ${growth.net_added_lines}`] };
     if (!debt.repayment_issue)
-        return { ok: false, status: "missing_repayment_target", message: "declared surface debt is missing repayment target: repayment_issue", growth, surface_debt: debt, details: ["missing repayment_issue"], hint: "Set repayment_issue to match intentional temporary growth or reduce the diff." };
+        return { ok: false, status: "missing_repayment_target", message: "declared surface debt is missing repayment target: repayment_issue", growth, surface_debt: debt, details: ["missing repayment_issue"], hint: "Set repayment_issue to the issue number where the temporary growth will be repaid." };
     const expected = debt.expected_delta || {}, exceeded = [];
     if (expected.max_new_files !== undefined && growth.new_files > expected.max_new_files)
         exceeded.push(`new files ${growth.new_files} exceeds declared debt ${expected.max_new_files}`);

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -28,7 +28,7 @@ export function checkSurfaceDebt(files, debt) {
     if (!debt)
         return { ok: true, status: "undeclared", growth, details: [`new files: ${growth.new_files}`, `net added lines: ${growth.net_added_lines}`] };
     if (!debt.repayment_issue)
-        return { ok: false, status: "missing_repayment_target", message: "declared surface debt is missing repayment target: repayment_issue", growth, surface_debt: debt, details: ["missing repayment_issue"], hint: "Set repayment_issue to the issue number where the temporary growth will be repaid." };
+        return { ok: false, status: "missing_repayment_target", message: "declared surface debt is missing repayment target: repayment_issue", growth, surface_debt: debt, details: ["missing repayment_issue"], hint: "Set repayment_issue to match intentional temporary growth or reduce the diff." };
     const expected = debt.expected_delta || {}, exceeded = [];
     if (expected.max_new_files !== undefined && growth.new_files > expected.max_new_files)
         exceeded.push(`new files ${growth.new_files} exceeds declared debt ${expected.max_new_files}`);
@@ -87,6 +87,35 @@ function checkDocumentScalarLiteral(facts, constraint) {
     const ok = source.value === expected;
     return { ok, message: ok ? undefined : `document relation "${constraint.relation_id}" scalar value does not match literal`, data };
 }
+function checkDocumentReferencedPathsExist(facts, constraint) {
+    const source = factOperand(facts.documents, constraint.source);
+    if (!source.ok)
+        return {
+            ok: false,
+            message: `document relation "${constraint.relation_id}" could not read repository path references`,
+            data: { kind: "referenced_paths_exist", source },
+        };
+    if (!Array.isArray(source.value))
+        return {
+            ok: false,
+            message: `document relation "${constraint.relation_id}" did not produce a repository path set`,
+            data: { kind: "referenced_paths_exist", source },
+        };
+    const referencedPaths = source.value;
+    if (facts.trackedFiles === undefined)
+        return {
+            ok: false,
+            message: `document relation "${constraint.relation_id}" cannot verify references without tracked repository facts`,
+            data: { kind: "referenced_paths_exist", source, referenced_paths: referencedPaths, missing_paths: [], tracked_repository_available: false },
+        };
+    const tracked = new Set(facts.trackedFiles);
+    const missingPaths = referencedPaths.filter((path) => !tracked.has(path)).sort();
+    return {
+        ok: missingPaths.length === 0,
+        message: missingPaths.length ? `document relation "${constraint.relation_id}" references missing repository paths` : undefined,
+        data: { kind: "referenced_paths_exist", source, referenced_paths: referencedPaths, missing_paths: missingPaths },
+    };
+}
 export function evaluateConstraintIR(facts, context = {}) {
     const { files, constraints } = compileConstraintIR(facts), results = [], cochange = [];
     for (const constraint of constraints) {
@@ -139,6 +168,8 @@ export function evaluateConstraintIR(facts, context = {}) {
             check = checkDocumentScalarEqual(facts, constraint);
         else if (constraint.kind === "document_scalar_equals_literal")
             check = checkDocumentScalarLiteral(facts, constraint);
+        else if (constraint.kind === "document_referenced_paths_exist")
+            check = checkDocumentReferencedPathsExist(facts, constraint);
         else
             continue;
         results.push({ name: constraint.name, check });

--- a/dist/policy-compiler.mjs
+++ b/dist/policy-compiler.mjs
@@ -147,6 +147,9 @@ export function compileDocumentRelationsPolicy(policy = {}) {
                 errors.push({ rule_id: id, type: selector.type, value: rule.value, message: `document_relations rule "${id}" literal is incompatible with source type "${selector.type}"` });
             }
         }
+        else if (rule.kind === "referenced_paths_exist") {
+            useSelector(id, "source", rule.source);
+        }
     }
     for (const name of Object.keys(documents))
         if (!usedDocuments.has(name)) {

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -404,6 +404,17 @@
         "type": { "type": "string", "enum": ["scalar", "string", "boolean"] }
       }
     },
+    "document_repository_path_set_selector": {
+      "type": "object",
+      "required": ["document", "pointer", "projection", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "document": { "$ref": "#/definitions/non_empty_string" },
+        "pointer": { "type": "string" },
+        "projection": { "type": "string", "enum": ["array_items", "object_values"] },
+        "type": { "const": "repository_path_set" }
+      }
+    },
     "document_relation_rule": {
       "oneOf": [
         {
@@ -426,6 +437,16 @@
             "kind": { "const": "scalar_equals_literal" },
             "source": { "$ref": "#/definitions/document_scalar_selector" },
             "value": { "type": ["string", "number", "boolean", "null"] }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["id", "kind", "source"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "$ref": "#/definitions/non_empty_string" },
+            "kind": { "const": "referenced_paths_exist" },
+            "source": { "$ref": "#/definitions/document_repository_path_set_selector" }
           }
         }
       ]

--- a/src/checks/constraint-program.mts
+++ b/src/checks/constraint-program.mts
@@ -191,6 +191,7 @@ function compileDocumentSelector(selectorValue: unknown, documents: Record<strin
     path: canonicalDocumentPath(definition.path),
     format: definition.format,
     pointer: typeof selector.pointer === "string" ? selector.pointer : "",
+    projection: selector.projection,
     type: selector.type as DocumentScalarType,
   };
 }
@@ -264,6 +265,10 @@ export function compileConstraintProgram(policy: ConstraintPolicyProjection = {}
       const source = compileDocumentSelector(rule.source, documents);
       runtime = { ...runtimeBase, kind: "document_scalar_equals_literal", source, value: rule.value };
       shape = { kind: rule.kind, source, value: rule.value };
+    } else if (rule.kind === "referenced_paths_exist") {
+      const source = compileDocumentSelector(rule.source, documents);
+      runtime = { ...runtimeBase, kind: "document_referenced_paths_exist", source };
+      shape = { kind: rule.kind, source };
     }
     add(owner, runtime, entity({ owner, pointer, removeKind: "document_relation_removed", rule_id: id,
       removeBefore: shape, removeAfter: { present: false }, removeMessage: `document_relations rule "${id}" removed` }));

--- a/src/checks/rules/constraints.mts
+++ b/src/checks/rules/constraints.mts
@@ -38,7 +38,8 @@ type RuntimeConstraintKind =
   | "trace_rules"
   | "integration"
   | "document_scalar_equal"
-  | "document_scalar_equals_literal";
+  | "document_scalar_equals_literal"
+  | "document_referenced_paths_exist";
 
 interface RuntimeConstraint {
   kind: RuntimeConstraintKind;
@@ -157,6 +158,35 @@ function checkDocumentScalarLiteral(facts: ConstraintFacts, constraint: RuntimeC
   return { ok, message: ok ? undefined : `document relation "${constraint.relation_id}" scalar value does not match literal`, data };
 }
 
+function checkDocumentReferencedPathsExist(facts: ConstraintFacts, constraint: RuntimeConstraint) {
+  const source = factOperand(facts.documents, constraint.source);
+  if (!source.ok) return {
+    ok: false,
+    message: `document relation "${constraint.relation_id}" could not read repository path references`,
+    data: { kind: "referenced_paths_exist", source },
+  };
+  if (!Array.isArray(source.value)) return {
+    ok: false,
+    message: `document relation "${constraint.relation_id}" did not produce a repository path set`,
+    data: { kind: "referenced_paths_exist", source },
+  };
+
+  const referencedPaths = source.value;
+  if (facts.trackedFiles === undefined) return {
+    ok: false,
+    message: `document relation "${constraint.relation_id}" cannot verify references without tracked repository facts`,
+    data: { kind: "referenced_paths_exist", source, referenced_paths: referencedPaths, missing_paths: [], tracked_repository_available: false },
+  };
+
+  const tracked = new Set(facts.trackedFiles);
+  const missingPaths = referencedPaths.filter((path) => !tracked.has(path)).sort();
+  return {
+    ok: missingPaths.length === 0,
+    message: missingPaths.length ? `document relation "${constraint.relation_id}" references missing repository paths` : undefined,
+    data: { kind: "referenced_paths_exist", source, referenced_paths: referencedPaths, missing_paths: missingPaths },
+  };
+}
+
 export function evaluateConstraintIR(facts: ConstraintFacts, context: ConstraintContext = {}): RuleResult[] {
   const { files, constraints } = compileConstraintIR(facts), results: RuleResult[] = [], cochange: RuntimeConstraint[] = [];
   for (const constraint of constraints) {
@@ -189,6 +219,7 @@ export function evaluateConstraintIR(facts: ConstraintFacts, context: Constraint
       continue;
     } else if (constraint.kind === "document_scalar_equal") check = checkDocumentScalarEqual(facts, constraint);
     else if (constraint.kind === "document_scalar_equals_literal") check = checkDocumentScalarLiteral(facts, constraint);
+    else if (constraint.kind === "document_referenced_paths_exist") check = checkDocumentReferencedPathsExist(facts, constraint);
     else continue;
     results.push({ name: constraint.name, check });
   }

--- a/src/policy-compiler.mts
+++ b/src/policy-compiler.mts
@@ -165,6 +165,8 @@ export function compileDocumentRelationsPolicy(policy: PolicyProjection = {}): S
       if (!scalarLiteralMatches(selector.type, rule.value)) {
         errors.push({ rule_id: id, type: selector.type, value: rule.value, message: `document_relations rule "${id}" literal is incompatible with source type "${selector.type}"` });
       }
+    } else if (rule.kind === "referenced_paths_exist") {
+      useSelector(id, "source", rule.source);
     }
   }
 

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -294,10 +294,17 @@ console.log("\n--- referenced repository paths execute through Constraint Progra
   });
   expect("invalid repository path stays a structured R1 failure", invalid.violations.find((item) => item.rule === "document-relation:gates-exist")?.data?.source?.error?.code, "invalid_repository_path");
 
-  const noTrackedFacts = runEquivalentInput({ policy: relationPolicy, readFile, trackedFiles: undefined });
-  const noTrackedViolation = noTrackedFacts.violations.find((item) => item.rule === "document-relation:owners-exist");
-  expect("missing tracked repository facts fail closed", Boolean(noTrackedViolation), true);
-  expect("missing tracked repository facts are explicit", noTrackedViolation?.data?.tracked_repository_available, false);
+  const { evaluateConstraintIR } = await import("../dist/checks/rules/constraints.mjs");
+  const { createDocumentReader } = await import("../dist/document-facts.mjs");
+  const noTrackedChecks = evaluateConstraintIR({
+    policy: relationPolicy,
+    diff: { files: { checked: [] } },
+    documents: createDocumentReader({ readFile }),
+    trackedFiles: undefined,
+  });
+  const noTrackedCheck = noTrackedChecks.find((item) => item.name === "document-relation:owners-exist")?.check;
+  expect("missing tracked repository facts fail closed", noTrackedCheck?.ok, false);
+  expect("missing tracked repository facts are explicit", noTrackedCheck?.data?.tracked_repository_available, false);
 }
 
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);

--- a/tests/test-pipeline.mjs
+++ b/tests/test-pipeline.mjs
@@ -248,5 +248,57 @@ console.log("\n--- scalar document relations execute through Constraint Program 
   expect("wrong scalar type fails closed", typeViolation?.data?.left?.error?.code, "fact_type_mismatch");
 }
 
+console.log("\n--- referenced repository paths execute through Constraint Program ---");
+{
+  const relationPolicy = {
+    ...policy,
+    document_relations: {
+      documents: { contract: { path: "contracts/contract.json", format: "json" } },
+      rules: [
+        {
+          id: "owners-exist",
+          kind: "referenced_paths_exist",
+          source: { document: "contract", pointer: "/owners", projection: "object_values", type: "repository_path_set" },
+        },
+        {
+          id: "gates-exist",
+          kind: "referenced_paths_exist",
+          source: { document: "contract", pointer: "/gates", projection: "array_items", type: "repository_path_set" },
+        },
+      ],
+    },
+  };
+  const contract = {
+    owners: { spec: "./docs/spec.md", verify: "tests/verify.mjs", duplicate: "docs/spec.md" },
+    gates: ["tests/gate.mjs", "docs/spec.md", "tests/gate.mjs"],
+  };
+  const readFile = (path) => path === "contracts/contract.json" ? JSON.stringify(contract) : undefined;
+  const trackedFiles = ["docs/spec.md", "tests/verify.mjs", "tests/gate.mjs"];
+  const passing = runEquivalentInput({ policy: relationPolicy, readFile, trackedFiles });
+  const ownersPass = passing.ruleResults.find((item) => item.rule === "document-relation:owners-exist");
+  const gatesPass = passing.ruleResults.find((item) => item.rule === "document-relation:gates-exist");
+  expect("object_values path references pass", ownersPass?.ok, true);
+  expect("array_items path references pass", gatesPass?.ok, true);
+  expect("repository path set normalizes and deduplicates object values", ownersPass?.data?.referenced_paths, ["docs/spec.md", "tests/verify.mjs"]);
+  expect("repository path set normalizes and deduplicates array items", gatesPass?.data?.referenced_paths, ["docs/spec.md", "tests/gate.mjs"]);
+
+  const missing = runEquivalentInput({ policy: relationPolicy, readFile, trackedFiles: ["docs/spec.md"] });
+  expect("missing object reference fails", missing.violations.find((item) => item.rule === "document-relation:owners-exist")?.data?.missing_paths, ["tests/verify.mjs"]);
+  expect("missing array reference fails", missing.violations.find((item) => item.rule === "document-relation:gates-exist")?.data?.missing_paths, ["tests/gate.mjs"]);
+
+  const invalidContract = { ...contract, gates: ["../escape.mjs"] };
+  const invalid = runEquivalentInput({
+    policy: relationPolicy,
+    readFile: (path) => path === "contracts/contract.json" ? JSON.stringify(invalidContract) : undefined,
+    trackedFiles,
+  });
+  expect("invalid repository path stays a structured R1 failure", invalid.violations.find((item) => item.rule === "document-relation:gates-exist")?.data?.source?.error?.code, "invalid_repository_path");
+
+  const noTrackedFacts = runEquivalentInput({ policy: relationPolicy, readFile, trackedFiles: undefined });
+  const noTrackedViolation = noTrackedFacts.violations.find((item) => item.rule === "document-relation:owners-exist");
+  expect("missing tracked repository facts fail closed", Boolean(noTrackedViolation), true);
+  expect("missing tracked repository facts are explicit", noTrackedViolation?.data?.tracked_repository_available, false);
+}
+
 console.log(`\n${failures === 0 ? "All tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-policy-compiler-boundary.mjs
+++ b/tests/test-policy-compiler-boundary.mjs
@@ -29,6 +29,11 @@ const scalarLiteral = {
   source: { document: "contract", pointer: "/root", type: "string" },
   value: "∞",
 };
+const referencedPaths = {
+  id: "owners-exist",
+  kind: "referenced_paths_exist",
+  source: { document: "contract", pointer: "/owners", projection: "object_values", type: "repository_path_set" },
+};
 const relationPolicy = (overrides = {}) => ({
   document_relations: { documents: structuredClone(documents), rules: [structuredClone(scalarEqual), structuredClone(scalarLiteral)], ...overrides },
 });
@@ -46,6 +51,15 @@ describe("semantic policy compiler boundary", () => {
 
   it("accepts semantically consistent scalar document relations", () => {
     assert.deepEqual(compileDocumentRelationsPolicy(relationPolicy()), []);
+  });
+
+  it("accepts a referenced path selector as a used document relation", () => {
+    assert.deepEqual(compileDocumentRelationsPolicy({
+      document_relations: {
+        documents: { contract: structuredClone(documents.contract) },
+        rules: [structuredClone(referencedPaths)],
+      },
+    }), []);
   });
 
   it("rejects duplicate ids, unknown references and unused documents", () => {
@@ -87,12 +101,16 @@ describe("document relation public schema boundary", () => {
     { quiet: true },
   );
 
-  it("accepts only the executable R2a scalar relation kinds", () => {
+  it("accepts only executable scalar and referenced-path relation kinds", () => {
     assert.equal(validate(relationPolicy().document_relations).ok, true);
+    assert.equal(validate({
+      documents: { contract: structuredClone(documents.contract) },
+      rules: [structuredClone(referencedPaths)],
+    }).ok, true);
     assert.equal(validate({ documents, rules: [{ ...scalarEqual, kind: "set_equal" }] }).ok, false);
   });
 
-  it("rejects collection projections and unsupported document formats in R2a schema", () => {
+  it("keeps scalar selectors free of collection projections and unsupported document formats", () => {
     assert.equal(validate({
       documents,
       rules: [{ ...scalarEqual, left: { ...scalarEqual.left, projection: "array_items" } }],
@@ -101,5 +119,20 @@ describe("document relation public schema boundary", () => {
       documents: { contract: { path: "contracts/contract.md", format: "markdown" } },
       rules: [{ ...scalarLiteral, source: { ...scalarLiteral.source, document: "contract" } }],
     }).ok, false);
+  });
+
+  it("restricts referenced path selectors to collection projection plus repository_path_set", () => {
+    assert.equal(validate({
+      documents: { contract: structuredClone(documents.contract) },
+      rules: [{ ...structuredClone(referencedPaths), source: { ...referencedPaths.source, projection: "value" } }],
+    }).ok, false);
+    assert.equal(validate({
+      documents: { contract: structuredClone(documents.contract) },
+      rules: [{ ...structuredClone(referencedPaths), source: { ...referencedPaths.source, type: "string_set" } }],
+    }).ok, false);
+    assert.equal(validate({
+      documents: { contract: structuredClone(documents.contract) },
+      rules: [{ ...structuredClone(referencedPaths), source: { ...referencedPaths.source, projection: "array_items" } }],
+    }).ok, true);
   });
 });

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -42,6 +42,11 @@ const literalRule = {
   source: { document: "contract", pointer: "/root", type: "string" },
   value: "∞",
 };
+const referencedPathsRule = {
+  id: "owners-exist",
+  kind: "referenced_paths_exist",
+  source: { document: "contract", pointer: "/owners", projection: "object_values", type: "repository_path_set" },
+};
 
 describe("Constraint Program strictness projection", () => {
   const cases = [
@@ -91,6 +96,14 @@ describe("document relation strictness projection", () => {
     assert.ok(delta.relaxations.some((item) => item.kind === "document_relation_removed" && item.rule_id === "root-is-infinity"));
   });
 
+  it("treats referenced path relation addition as stricter and removal as weaker", () => {
+    const base = relationPolicy(), head = structuredClone(base);
+    head.document_relations.rules.push(structuredClone(referencedPathsRule));
+    assert.equal(compareConstraintPrograms(base, head).relation, "stricter");
+    const delta = computePolicyDelta(head, base);
+    assert.ok(delta.relaxations.some((item) => item.kind === "document_relation_removed" && item.rule_id === "owners-exist"));
+  });
+
   for (const [name, edit] of [
     ["selector", (policy) => { policy.document_relations.rules[0].left.pointer = "/other"; }],
     ["literal", (policy) => { policy.document_relations.rules[1].value = "R"; }],
@@ -104,6 +117,20 @@ describe("document relation strictness projection", () => {
     const comparison = compareConstraintPrograms(base, head);
     assert.equal(comparison.relation, "incomparable");
     assert.ok(comparison.incomparable.some((item) => item.pointer === "/document_relations/rules/contract-id-matches" || item.pointer === "/document_relations/rules/root-is-infinity"));
+  });
+
+  for (const [name, edit] of [
+    ["pointer", (policy) => { policy.document_relations.rules[1].source.pointer = "/other"; }],
+    ["projection", (policy) => { policy.document_relations.rules[1].source.projection = "array_items"; }],
+    ["document path", (policy) => { policy.document_relations.documents.contract.path = "contracts/other.json"; }],
+  ]) it(`treats referenced path ${name} edit as incomparable`, () => {
+    const base = relationPolicy();
+    base.document_relations.rules.push(structuredClone(referencedPathsRule));
+    const head = structuredClone(base);
+    edit(head);
+    const comparison = compareConstraintPrograms(base, head);
+    assert.equal(comparison.relation, "incomparable");
+    assert.ok(comparison.incomparable.some((item) => item.pointer === "/document_relations/rules/owners-exist"));
   });
 });
 


### PR DESCRIPTION
Fixes #285

Adds the narrow generic `referenced_paths_exist` document relation on top of the existing R1 DocumentFacts and R2a Constraint Program path.

- public schema accepts only `array_items|object_values` projected as `repository_path_set`;
- runtime reuses `readDocumentFact` normalization and compares only against canonical tracked repository facts;
- absent tracked facts fail closed; no filesystem/network probe is introduced;
- relation strictness reuses required-entity + exact/incomparable semantics;
- scalar R2a relations remain unchanged;
- generated `dist` was produced by compiler emit after byte-for-byte baseline proof and will be independently checked by pinned CI.

This PR intentionally does not add generic set relations, `document_exists`, JSONPath/wildcards, a new evaluator, or domain-specific semantics.