### PR TITLE
Contract governance R3a: expand current contract/conformance macro

### DIFF
--- a/dist/policy-profiles.mjs
+++ b/dist/policy-profiles.mjs
@@ -1,3 +1,5 @@
+import { normalizeDocumentFact } from "./document-facts.mjs";
+import { matchesAny } from "./utils/path-patterns.mjs";
 const REQUIREMENT_ID = "(?:BR|SR|FR|NFR|CR|IR)-[0-9]{3}";
 const PACKS = {
     "requirements-strict": {
@@ -41,9 +43,23 @@ const OVERRIDE_FIELDS = new Set([
     ...Object.keys(PACKS["requirements-strict"].defaults),
     "changed_requirement_evidence_surfaces", "affected_evidence_surfaces",
 ]);
+const CONTRACT_ROLES = new Set(["current.contract", "current.conformance"]);
+const GENERATED_DOCUMENTS = {
+    "current.contract": "contract-conformance.current.contract",
+    "current.conformance": "contract-conformance.current.conformance",
+};
+const GENERATED_RULE_IDS = [
+    "contract-conformance:current-id",
+    "contract-conformance:current-conformance-path",
+    "contract-conformance:current-contract-status",
+    "contract-conformance:current-conformance-status",
+    "contract-conformance:current-contract-accepted",
+    "contract-conformance:current-conformance-accepted",
+];
 const clone = (value) => structuredClone(value);
 const isObject = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
 const ref = (value, config) => typeof value === "string" && value.startsWith("$") ? clone(config[value.slice(1)]) : clone(value);
+const stringList = (value) => Array.isArray(value) ? value.filter((item) => typeof item === "string") : [];
 function configFor(spec, overrides = {}) {
     const config = clone(spec.defaults);
     for (const [key, value] of Object.entries(overrides))
@@ -62,6 +78,30 @@ function materializePack(spec, overrides) {
     }
     const trace_rules = spec.trace_rules.map((rule) => Object.fromEntries(Object.entries(rule).map(([key, value]) => [key, ref(value, config)])));
     return { anchors: { types }, trace_rules };
+}
+function contractMacro(policy) {
+    return isObject(policy.contract_conformance) ? policy.contract_conformance : null;
+}
+function currentRoleDocuments(macro) {
+    const current = isObject(macro.current) ? macro.current : {};
+    return {
+        "current.contract": isObject(current.contract) ? current.contract : {},
+        "current.conformance": isObject(current.conformance) ? current.conformance : {},
+    };
+}
+function normalizeDocumentPath(value) {
+    try {
+        return normalizeDocumentFact(value, "repository_path");
+    }
+    catch {
+        return null;
+    }
+}
+function generatedRuleIds(macro) {
+    return [
+        ...GENERATED_RULE_IDS,
+        ...((Array.isArray(macro.required_paths) ? macro.required_paths : []).map((_, index) => `contract-conformance:required-path:${index}`)),
+    ];
 }
 export const listBuiltInProfiles = () => Object.keys(PACKS).sort();
 export function compileProfilePolicy(policy) {
@@ -84,6 +124,75 @@ export function compileProfilePolicy(policy) {
     }
     return errors;
 }
+export function compileContractConformancePolicy(policy) {
+    const source = policy;
+    if (source?.contract_conformance === undefined)
+        return [];
+    if (!isObject(source.contract_conformance))
+        return [{ field: "contract_conformance", message: "contract_conformance must be an object" }];
+    const macro = source.contract_conformance, errors = [];
+    const roles = currentRoleDocuments(macro), paths = new Map();
+    for (const role of CONTRACT_ROLES) {
+        const definition = roles[role], path = normalizeDocumentPath(definition.path), format = definition.format;
+        if (!path)
+            errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.path`, message: `${role} path must be a canonical repository path` });
+        else
+            paths.set(role, path);
+        if (format !== "json" && format !== "yaml")
+            errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.format`, message: `${role} format must be json or yaml` });
+    }
+    if (paths.get("current.contract") && paths.get("current.contract") === paths.get("current.conformance")) {
+        errors.push({ field: "contract_conformance.current", message: "current contract and conformance paths must be distinct" });
+    }
+    const pairFields = isObject(macro.pair_fields) ? macro.pair_fields : {};
+    for (const field of ["contract_id", "conformance_contract_id", "contract_conformance_path", "contract_status", "conformance_status", "contract_accepted", "conformance_accepted"]) {
+        if (typeof pairFields[field] !== "string")
+            errors.push({ field: `contract_conformance.pair_fields.${field}`, message: `${field} must be a JSON Pointer string` });
+    }
+    const acceptedState = isObject(macro.accepted_state) ? macro.accepted_state : {};
+    if (typeof acceptedState.status !== "string")
+        errors.push({ field: "contract_conformance.accepted_state.status", message: "accepted_state.status must be a string" });
+    if (typeof acceptedState.accepted !== "boolean")
+        errors.push({ field: "contract_conformance.accepted_state.accepted", message: "accepted_state.accepted must be a boolean" });
+    const selectors = Array.isArray(macro.required_paths) ? macro.required_paths : [], selectorKeys = new Set();
+    for (const [index, rawSelector] of selectors.entries()) {
+        const selector = isObject(rawSelector) ? rawSelector : {}, role = selector.document;
+        if (!CONTRACT_ROLES.has(role))
+            errors.push({ field: `contract_conformance.required_paths[${index}].document`, message: `required_paths[${index}] references unknown role "${selector.document}"` });
+        const key = `${selector.document}|${selector.pointer}|${selector.projection}`;
+        if (selectorKeys.has(key))
+            errors.push({ field: `contract_conformance.required_paths[${index}]`, message: `required_paths[${index}] duplicates selector ${key}` });
+        selectorKeys.add(key);
+    }
+    const cochange = stringList(macro.cochange), seenRoles = new Set();
+    for (const [index, role] of cochange.entries()) {
+        if (!CONTRACT_ROLES.has(role))
+            errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange references unknown role "${role}"` });
+        if (seenRoles.has(role))
+            errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange duplicates role "${role}"` });
+        seenRoles.add(role);
+    }
+    if (cochange.length < 2)
+        errors.push({ field: "contract_conformance.cochange", message: "cochange must contain at least two distinct roles" });
+    const controlPaths = stringList(macro.control_paths).map((item) => item.trim()).filter(Boolean);
+    if (!controlPaths.length)
+        errors.push({ field: "contract_conformance.control_paths", message: "control_paths must contain at least one non-empty pattern" });
+    for (const [role, path] of paths)
+        if (controlPaths.length && !matchesAny(path, controlPaths)) {
+            errors.push({ field: "contract_conformance.control_paths", message: `control_paths do not cover ${role} path "${path}"` });
+        }
+    const explicitRelations = isObject(source.document_relations) ? source.document_relations : {}, explicitDocuments = isObject(explicitRelations.documents) ? explicitRelations.documents : {};
+    for (const name of Object.values(GENERATED_DOCUMENTS))
+        if (Object.hasOwn(explicitDocuments, name)) {
+            errors.push({ field: "document_relations.documents", message: `contract_conformance generated document "${name}" collides with explicit document_relations` });
+        }
+    const explicitRuleIds = new Set((Array.isArray(explicitRelations.rules) ? explicitRelations.rules : []).map((rule) => isObject(rule) ? rule.id : undefined));
+    for (const id of generatedRuleIds(macro))
+        if (explicitRuleIds.has(id)) {
+            errors.push({ field: "document_relations.rules", message: `contract_conformance generated rule "${id}" collides with explicit document_relations` });
+        }
+    return errors;
+}
 export function expandPolicyProfile(policy) {
     const base = clone(policy), spec = PACKS[base.profile];
     if (!spec)
@@ -91,7 +200,39 @@ export function expandPolicyProfile(policy) {
     const patch = materializePack(spec, base.profile_overrides || {});
     return { ...base, anchors: base.anchors || patch.anchors, trace_rules: base.trace_rules || patch.trace_rules };
 }
+export function expandContractConformancePolicy(policy) {
+    const base = clone(policy), macro = contractMacro(base);
+    if (!macro)
+        return base;
+    delete base.contract_conformance;
+    const roleDefinitions = currentRoleDocuments(macro);
+    const rolePaths = Object.fromEntries(Object.entries(roleDefinitions).map(([role, definition]) => [role, normalizeDocumentPath(definition.path)]));
+    const relations = isObject(base.document_relations) ? clone(base.document_relations) : {}, documents = isObject(relations.documents) ? clone(relations.documents) : {};
+    const rules = Array.isArray(relations.rules) ? clone(relations.rules) : [], pairFields = macro.pair_fields, acceptedState = macro.accepted_state;
+    for (const role of CONTRACT_ROLES) {
+        documents[GENERATED_DOCUMENTS[role]] = { path: rolePaths[role], format: roleDefinitions[role].format };
+    }
+    const selector = (role, pointer, type) => ({ document: GENERATED_DOCUMENTS[role], pointer, type });
+    rules.push({ id: GENERATED_RULE_IDS[0], kind: "scalar_equal", left: selector("current.conformance", pairFields.conformance_contract_id, "string"), right: selector("current.contract", pairFields.contract_id, "string") }, { id: GENERATED_RULE_IDS[1], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_conformance_path, "string"), value: rolePaths["current.conformance"] }, { id: GENERATED_RULE_IDS[2], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_status, "string"), value: acceptedState.status }, { id: GENERATED_RULE_IDS[3], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_status, "string"), value: acceptedState.status }, { id: GENERATED_RULE_IDS[4], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_accepted, "boolean"), value: acceptedState.accepted }, { id: GENERATED_RULE_IDS[5], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_accepted, "boolean"), value: acceptedState.accepted });
+    for (const [index, rawSelector] of (macro.required_paths || []).entries()) {
+        const source = rawSelector;
+        rules.push({ id: `contract-conformance:required-path:${index}`, kind: "referenced_paths_exist", source: { document: GENERATED_DOCUMENTS[source.document], pointer: source.pointer, projection: source.projection, type: "repository_path_set" } });
+    }
+    base.document_relations = { ...relations, documents, rules };
+    const cochange = macro.cochange, cochangeRules = Array.isArray(base.cochange_rules) ? clone(base.cochange_rules) : [];
+    for (const role of cochange)
+        for (const peer of cochange)
+            if (peer !== role)
+                cochangeRules.push({ if_changed: [rolePaths[role]], must_change_any: [rolePaths[peer]] });
+    base.cochange_rules = cochangeRules;
+    const paths = isObject(base.paths) ? clone(base.paths) : {}, governance = stringList(paths.governance_paths), controlPaths = stringList(macro.control_paths);
+    paths.governance_paths = [...new Set([...governance, ...controlPaths])].sort();
+    base.paths = paths;
+    return base;
+}
 export function resolvePolicyProfile(policy) {
-    const errors = compileProfilePolicy(policy);
-    return { ok: !errors.length, policy: errors.length ? clone(policy) : expandPolicyProfile(policy), errors };
+    const errors = [...compileProfilePolicy(policy), ...compileContractConformancePolicy(policy)];
+    if (errors.length)
+        return { ok: false, policy: clone(policy), errors };
+    return { ok: true, policy: expandContractConformancePolicy(expandPolicyProfile(policy)), errors };
 }

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -242,6 +242,9 @@
     "document_relations": {
       "$ref": "#/definitions/document_relations"
     },
+    "contract_conformance": {
+      "$ref": "#/definitions/contract_conformance"
+    },
     "advisory_text_rules": {
       "type": "object",
       "description": "Optional heuristic markdown duplication advisories. These warnings never block the PR in v1.",
@@ -367,6 +370,73 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 },
       "minItems": 1
+    },
+    "contract_conformance": {
+      "type": "object",
+      "required": ["current", "pair_fields", "accepted_state", "required_paths", "cochange", "control_paths"],
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "type": "object",
+          "required": ["contract", "conformance"],
+          "additionalProperties": false,
+          "properties": {
+            "contract": { "$ref": "#/definitions/document_relation_document" },
+            "conformance": { "$ref": "#/definitions/document_relation_document" }
+          }
+        },
+        "pair_fields": {
+          "type": "object",
+          "required": ["contract_id", "conformance_contract_id", "contract_conformance_path", "contract_status", "conformance_status", "contract_accepted", "conformance_accepted"],
+          "additionalProperties": false,
+          "properties": {
+            "contract_id": { "type": "string" },
+            "conformance_contract_id": { "type": "string" },
+            "contract_conformance_path": { "type": "string" },
+            "contract_status": { "type": "string" },
+            "conformance_status": { "type": "string" },
+            "contract_accepted": { "type": "string" },
+            "conformance_accepted": { "type": "string" }
+          }
+        },
+        "accepted_state": {
+          "type": "object",
+          "required": ["status", "accepted"],
+          "additionalProperties": false,
+          "properties": {
+            "status": { "type": "string", "minLength": 1 },
+            "accepted": { "type": "boolean" }
+          }
+        },
+        "required_paths": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": ["document", "pointer", "projection"],
+            "additionalProperties": false,
+            "properties": {
+              "document": { "type": "string", "enum": ["current.contract", "current.conformance"] },
+              "pointer": { "type": "string" },
+              "projection": { "type": "string", "enum": ["array_items", "object_values"] }
+            }
+          }
+        },
+        "cochange": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": { "type": "string", "enum": ["current.contract", "current.conformance"] }
+        },
+        "control_paths": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
     },
     "document_relations": {
       "type": "object",
@@ -613,7 +683,7 @@
         "path": { "$ref": "#/definitions/non_empty_string" },
         "requires_change_intent_block": {
           "type": "boolean",
-          "description": "Whether the template is expected to include a repo-guard ChangeIntent block."
+          "description": "Whether the template is expected to include repo-guard ChangeIntent blocks."
         },
         "optional": {
           "type": "boolean",

--- a/src/policy-profiles.mts
+++ b/src/policy-profiles.mts
@@ -1,3 +1,6 @@
+import { normalizeDocumentFact } from "./document-facts.mjs";
+import { matchesAny } from "./utils/path-patterns.mjs";
+
 const REQUIREMENT_ID = "(?:BR|SR|FR|NFR|CR|IR)-[0-9]{3}";
 
 const PACKS = {
@@ -47,11 +50,16 @@ interface ProfileSpec {
   trace_rules: ProfileRule[];
 }
 type ProfileConfig = Record<string, unknown>;
+type ContractRole = "current.contract" | "current.conformance";
 interface PolicyProjection extends Record<string, unknown> {
   profile?: string;
   profile_overrides?: unknown;
   anchors?: unknown;
   trace_rules?: unknown;
+  contract_conformance?: unknown;
+  document_relations?: unknown;
+  cochange_rules?: unknown;
+  paths?: Record<string, unknown>;
 }
 interface ProfileValidationError {
   field: string;
@@ -63,9 +71,23 @@ const OVERRIDE_FIELDS = new Set([
   ...Object.keys(PACKS["requirements-strict"].defaults),
   "changed_requirement_evidence_surfaces", "affected_evidence_surfaces",
 ]);
+const CONTRACT_ROLES = new Set<ContractRole>(["current.contract", "current.conformance"]);
+const GENERATED_DOCUMENTS = {
+  "current.contract": "contract-conformance.current.contract",
+  "current.conformance": "contract-conformance.current.conformance",
+} as const;
+const GENERATED_RULE_IDS = [
+  "contract-conformance:current-id",
+  "contract-conformance:current-conformance-path",
+  "contract-conformance:current-contract-status",
+  "contract-conformance:current-conformance-status",
+  "contract-conformance:current-contract-accepted",
+  "contract-conformance:current-conformance-accepted",
+];
 const clone = <T,>(value: T): T => structuredClone(value);
 const isObject = (value: unknown): value is Record<string, unknown> => value !== null && typeof value === "object" && !Array.isArray(value);
 const ref = (value: unknown, config: ProfileConfig): unknown => typeof value === "string" && value.startsWith("$") ? clone(config[value.slice(1)]) : clone(value);
+const stringList = (value: unknown): string[] => Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 
 function configFor(spec: ProfileSpec, overrides: Record<string, unknown> = {}): ProfileConfig {
   const config: ProfileConfig = clone(spec.defaults);
@@ -89,6 +111,30 @@ function materializePack(spec: ProfileSpec, overrides: Record<string, unknown>) 
   return { anchors: { types }, trace_rules };
 }
 
+function contractMacro(policy: PolicyProjection) {
+  return isObject(policy.contract_conformance) ? policy.contract_conformance : null;
+}
+
+function currentRoleDocuments(macro: Record<string, unknown>) {
+  const current = isObject(macro.current) ? macro.current : {};
+  return {
+    "current.contract": isObject(current.contract) ? current.contract : {},
+    "current.conformance": isObject(current.conformance) ? current.conformance : {},
+  } satisfies Record<ContractRole, Record<string, unknown>>;
+}
+
+function normalizeDocumentPath(value: unknown): string | null {
+  try { return normalizeDocumentFact(value, "repository_path") as string; }
+  catch { return null; }
+}
+
+function generatedRuleIds(macro: Record<string, unknown>): string[] {
+  return [
+    ...GENERATED_RULE_IDS,
+    ...((Array.isArray(macro.required_paths) ? macro.required_paths : []).map((_, index) => `contract-conformance:required-path:${index}`)),
+  ];
+}
+
 export const listBuiltInProfiles = (): string[] => Object.keys(PACKS).sort();
 
 export function compileProfilePolicy(policy: unknown): ProfileValidationError[] {
@@ -107,6 +153,65 @@ export function compileProfilePolicy(policy: unknown): ProfileValidationError[] 
   return errors;
 }
 
+export function compileContractConformancePolicy(policy: unknown): ProfileValidationError[] {
+  const source = policy as PolicyProjection | null | undefined;
+  if (source?.contract_conformance === undefined) return [];
+  if (!isObject(source.contract_conformance)) return [{ field: "contract_conformance", message: "contract_conformance must be an object" }];
+
+  const macro = source.contract_conformance, errors: ProfileValidationError[] = [];
+  const roles = currentRoleDocuments(macro), paths = new Map<ContractRole, string>();
+  for (const role of CONTRACT_ROLES) {
+    const definition = roles[role], path = normalizeDocumentPath(definition.path), format = definition.format;
+    if (!path) errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.path`, message: `${role} path must be a canonical repository path` });
+    else paths.set(role, path);
+    if (format !== "json" && format !== "yaml") errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.format`, message: `${role} format must be json or yaml` });
+  }
+  if (paths.get("current.contract") && paths.get("current.contract") === paths.get("current.conformance")) {
+    errors.push({ field: "contract_conformance.current", message: "current contract and conformance paths must be distinct" });
+  }
+
+  const pairFields = isObject(macro.pair_fields) ? macro.pair_fields : {};
+  for (const field of ["contract_id", "conformance_contract_id", "contract_conformance_path", "contract_status", "conformance_status", "contract_accepted", "conformance_accepted"]) {
+    if (typeof pairFields[field] !== "string") errors.push({ field: `contract_conformance.pair_fields.${field}`, message: `${field} must be a JSON Pointer string` });
+  }
+  const acceptedState = isObject(macro.accepted_state) ? macro.accepted_state : {};
+  if (typeof acceptedState.status !== "string") errors.push({ field: "contract_conformance.accepted_state.status", message: "accepted_state.status must be a string" });
+  if (typeof acceptedState.accepted !== "boolean") errors.push({ field: "contract_conformance.accepted_state.accepted", message: "accepted_state.accepted must be a boolean" });
+
+  const selectors = Array.isArray(macro.required_paths) ? macro.required_paths : [], selectorKeys = new Set<string>();
+  for (const [index, rawSelector] of selectors.entries()) {
+    const selector = isObject(rawSelector) ? rawSelector : {}, role = selector.document as ContractRole;
+    if (!CONTRACT_ROLES.has(role)) errors.push({ field: `contract_conformance.required_paths[${index}].document`, message: `required_paths[${index}] references unknown role "${selector.document}"` });
+    const key = `${selector.document}|${selector.pointer}|${selector.projection}`;
+    if (selectorKeys.has(key)) errors.push({ field: `contract_conformance.required_paths[${index}]`, message: `required_paths[${index}] duplicates selector ${key}` });
+    selectorKeys.add(key);
+  }
+
+  const cochange = stringList(macro.cochange), seenRoles = new Set<string>();
+  for (const [index, role] of cochange.entries()) {
+    if (!CONTRACT_ROLES.has(role as ContractRole)) errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange references unknown role "${role}"` });
+    if (seenRoles.has(role)) errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange duplicates role "${role}"` });
+    seenRoles.add(role);
+  }
+  if (cochange.length < 2) errors.push({ field: "contract_conformance.cochange", message: "cochange must contain at least two distinct roles" });
+
+  const controlPaths = stringList(macro.control_paths).map((item) => item.trim()).filter(Boolean);
+  if (!controlPaths.length) errors.push({ field: "contract_conformance.control_paths", message: "control_paths must contain at least one non-empty pattern" });
+  for (const [role, path] of paths) if (controlPaths.length && !matchesAny(path, controlPaths)) {
+    errors.push({ field: "contract_conformance.control_paths", message: `control_paths do not cover ${role} path "${path}"` });
+  }
+
+  const explicitRelations = isObject(source.document_relations) ? source.document_relations : {}, explicitDocuments = isObject(explicitRelations.documents) ? explicitRelations.documents : {};
+  for (const name of Object.values(GENERATED_DOCUMENTS)) if (Object.hasOwn(explicitDocuments, name)) {
+    errors.push({ field: "document_relations.documents", message: `contract_conformance generated document "${name}" collides with explicit document_relations` });
+  }
+  const explicitRuleIds = new Set((Array.isArray(explicitRelations.rules) ? explicitRelations.rules : []).map((rule) => isObject(rule) ? rule.id : undefined));
+  for (const id of generatedRuleIds(macro)) if (explicitRuleIds.has(id)) {
+    errors.push({ field: "document_relations.rules", message: `contract_conformance generated rule "${id}" collides with explicit document_relations` });
+  }
+  return errors;
+}
+
 export function expandPolicyProfile(policy: unknown) {
   const base: PolicyProjection = clone(policy as PolicyProjection), spec = (PACKS as unknown as Record<string, ProfileSpec>)[base.profile as string];
   if (!spec) return base;
@@ -114,7 +219,45 @@ export function expandPolicyProfile(policy: unknown) {
   return { ...base, anchors: base.anchors || patch.anchors, trace_rules: base.trace_rules || patch.trace_rules };
 }
 
+export function expandContractConformancePolicy(policy: unknown) {
+  const base = clone(policy as PolicyProjection), macro = contractMacro(base);
+  if (!macro) return base;
+  delete base.contract_conformance;
+
+  const roleDefinitions = currentRoleDocuments(macro);
+  const rolePaths = Object.fromEntries(Object.entries(roleDefinitions).map(([role, definition]) => [role, normalizeDocumentPath(definition.path)!])) as Record<ContractRole, string>;
+  const relations = isObject(base.document_relations) ? clone(base.document_relations) : {}, documents = isObject(relations.documents) ? clone(relations.documents) : {};
+  const rules = Array.isArray(relations.rules) ? clone(relations.rules) : [], pairFields = macro.pair_fields as Record<string, string>, acceptedState = macro.accepted_state as { status: string; accepted: boolean };
+  for (const role of CONTRACT_ROLES) {
+    documents[GENERATED_DOCUMENTS[role]] = { path: rolePaths[role], format: roleDefinitions[role].format };
+  }
+  const selector = (role: ContractRole, pointer: string, type: "string" | "boolean") => ({ document: GENERATED_DOCUMENTS[role], pointer, type });
+  rules.push(
+    { id: GENERATED_RULE_IDS[0], kind: "scalar_equal", left: selector("current.conformance", pairFields.conformance_contract_id, "string"), right: selector("current.contract", pairFields.contract_id, "string") },
+    { id: GENERATED_RULE_IDS[1], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_conformance_path, "string"), value: rolePaths["current.conformance"] },
+    { id: GENERATED_RULE_IDS[2], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_status, "string"), value: acceptedState.status },
+    { id: GENERATED_RULE_IDS[3], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_status, "string"), value: acceptedState.status },
+    { id: GENERATED_RULE_IDS[4], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_accepted, "boolean"), value: acceptedState.accepted },
+    { id: GENERATED_RULE_IDS[5], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_accepted, "boolean"), value: acceptedState.accepted },
+  );
+  for (const [index, rawSelector] of (macro.required_paths as Array<Record<string, unknown>> || []).entries()) {
+    const source = rawSelector as { document: ContractRole; pointer: string; projection: "array_items" | "object_values" };
+    rules.push({ id: `contract-conformance:required-path:${index}`, kind: "referenced_paths_exist", source: { document: GENERATED_DOCUMENTS[source.document], pointer: source.pointer, projection: source.projection, type: "repository_path_set" } });
+  }
+  base.document_relations = { ...relations, documents, rules };
+
+  const cochange = macro.cochange as ContractRole[], cochangeRules = Array.isArray(base.cochange_rules) ? clone(base.cochange_rules) : [];
+  for (const role of cochange) for (const peer of cochange) if (peer !== role) cochangeRules.push({ if_changed: [rolePaths[role]], must_change_any: [rolePaths[peer]] });
+  base.cochange_rules = cochangeRules;
+
+  const paths = isObject(base.paths) ? clone(base.paths) : {}, governance = stringList(paths.governance_paths), controlPaths = stringList(macro.control_paths);
+  paths.governance_paths = [...new Set([...governance, ...controlPaths])].sort();
+  base.paths = paths;
+  return base;
+}
+
 export function resolvePolicyProfile(policy: unknown) {
-  const errors = compileProfilePolicy(policy);
-  return { ok: !errors.length, policy: errors.length ? clone(policy) : expandPolicyProfile(policy), errors };
+  const errors = [...compileProfilePolicy(policy), ...compileContractConformancePolicy(policy)];
+  if (errors.length) return { ok: false, policy: clone(policy), errors };
+  return { ok: true, policy: expandContractConformancePolicy(expandPolicyProfile(policy)), errors };
 }

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import { compareConstraintPrograms } from "../dist/checks/constraint-program.mjs";
 import { checkPolicyRelaxation, classifyChangedFiles, computePolicyDelta, policyRelaxationRuleFamily } from "../dist/checks/rules/policy-delta-rules.mjs";
+import { resolvePolicyProfile } from "../dist/policy-profiles.mjs";
 
 const file = (path, extra = {}) => ({ path, status: "modified", addedLines: [], deletedLines: [], ...extra });
 const TRUSTED = { issue_author_permission_trusted: true };
@@ -47,6 +48,29 @@ const referencedPathsRule = {
   kind: "referenced_paths_exist",
   source: { document: "contract", pointer: "/owners", projection: "object_values", type: "repository_path_set" },
 };
+const macroPolicy = () => ({
+  ...structuredClone(BASE),
+  cochange_rules: [],
+  contract_conformance: {
+    current: {
+      contract: { path: "contracts/spec-v2.json", format: "json" },
+      conformance: { path: "contracts/checks-v2.json", format: "json" },
+    },
+    pair_fields: {
+      contract_id: "/schema",
+      conformance_contract_id: "/contract",
+      contract_conformance_path: "/conformanceCorpus",
+      contract_status: "/status",
+      conformance_status: "/status",
+      contract_accepted: "/accepted",
+      conformance_accepted: "/accepted",
+    },
+    accepted_state: { status: "accepted", accepted: true },
+    required_paths: [{ document: "current.contract", pointer: "/owners", projection: "object_values" }],
+    cochange: ["current.contract", "current.conformance"],
+    control_paths: ["contracts/**"],
+  },
+});
 
 describe("Constraint Program strictness projection", () => {
   const cases = [
@@ -131,6 +155,25 @@ describe("document relation strictness projection", () => {
     const comparison = compareConstraintPrograms(base, head);
     assert.equal(comparison.relation, "incomparable");
     assert.ok(comparison.incomparable.some((item) => item.pointer === "/document_relations/rules/owners-exist"));
+  });
+});
+
+describe("contract/conformance macro strictness", () => {
+  it("compares only expanded ordinary policy", () => {
+    const source = macroPolicy(), resolved = resolvePolicyProfile(source);
+    assert.equal(resolved.ok, true);
+    assert.equal(resolved.policy.contract_conformance, undefined);
+
+    const baseline = structuredClone(source);
+    delete baseline.contract_conformance;
+    const adoption = compareConstraintPrograms(baseline, resolved.policy);
+    assert.notEqual(adoption.relation, "equal");
+    assert.notEqual(adoption.relation, "weaker");
+    assert.ok(adoption.incomparable.every((item) => !JSON.stringify(item).includes("contract_conformance")));
+
+    const removal = compareConstraintPrograms(resolved.policy, baseline);
+    assert.equal(removal.relation, "weaker");
+    assert.ok(removal.relaxations.some((item) => item.kind === "document_relation_removed" && item.rule_id === "contract-conformance:current-id"));
   });
 });
 

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -1,8 +1,10 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
+import Ajv from "ajv";
 import { compareConstraintPrograms } from "../dist/checks/constraint-program.mjs";
 import { checkPolicyRelaxation, classifyChangedFiles, computePolicyDelta, policyRelaxationRuleFamily } from "../dist/checks/rules/policy-delta-rules.mjs";
 import { resolvePolicyProfile } from "../dist/policy-profiles.mjs";
+import { loadJSON } from "../dist/runtime/validation.mjs";
 
 const file = (path, extra = {}) => ({ path, status: "modified", addedLines: [], deletedLines: [], ...extra });
 const TRUSTED = { issue_author_permission_trusted: true };
@@ -70,6 +72,15 @@ const macroPolicy = () => ({
     cochange: ["current.contract", "current.conformance"],
     control_paths: ["contracts/**"],
   },
+});
+const macroSchemaPolicy = () => ({
+  policy_format_version: "0.3.0",
+  repository_kind: "tooling",
+  paths: { forbidden: [], canonical_docs: [], governance_paths: ["repo-policy.json"] },
+  diff_rules: { max_new_files: 5, max_new_docs: 2 },
+  content_rules: [],
+  cochange_rules: [],
+  contract_conformance: structuredClone(macroPolicy().contract_conformance),
 });
 
 describe("Constraint Program strictness projection", () => {
@@ -155,6 +166,23 @@ describe("document relation strictness projection", () => {
     const comparison = compareConstraintPrograms(base, head);
     assert.equal(comparison.relation, "incomparable");
     assert.ok(comparison.incomparable.some((item) => item.pointer === "/document_relations/rules/owners-exist"));
+  });
+});
+
+describe("contract/conformance macro source schema", () => {
+  const validate = new Ajv({ allErrors: true }).compile(loadJSON(new URL("../schemas/repo-policy.schema.json", import.meta.url)));
+
+  it("accepts the current-pair R3a source shape", () => {
+    assert.equal(validate(macroSchemaPolicy()), true);
+  });
+
+  it("rejects future previous-pair syntax in R3a", () => {
+    const source = macroSchemaPolicy();
+    source.contract_conformance.previous = {
+      contract: { path: "contracts/spec-v1.json", format: "json" },
+      conformance: { path: "contracts/checks-v1.json", format: "json" },
+    };
+    assert.equal(validate(source), false);
   });
 });
 

--- a/tests/test-policy-profiles.mjs
+++ b/tests/test-policy-profiles.mjs
@@ -4,7 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { strict as assert } from "node:assert";
 import Ajv from "ajv";
-import { compileProfilePolicy } from "../dist/policy-profiles.mjs";
+import { compileContractConformancePolicy, compileProfilePolicy, resolvePolicyProfile } from "../dist/policy-profiles.mjs";
 import { loadJSON, loadPolicyRuntime } from "../dist/runtime/validation.mjs";
 import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
@@ -86,6 +86,43 @@ const pjsonEvidenceSurfaces = [
 
 function traceRule(policy, id) {
   return policy.trace_rules?.find((rule) => rule.id === id);
+}
+
+function contractConformanceMacro(overrides = {}) {
+  return {
+    current: {
+      contract: { path: "contracts/spec-v2.json", format: "json" },
+      conformance: { path: "contracts/checks-v2.yaml", format: "yaml" },
+    },
+    pair_fields: {
+      contract_id: "/schema",
+      conformance_contract_id: "/contract",
+      contract_conformance_path: "/conformanceCorpus",
+      contract_status: "/status",
+      conformance_status: "/status",
+      contract_accepted: "/accepted",
+      conformance_accepted: "/accepted",
+    },
+    accepted_state: { status: "accepted", accepted: true },
+    required_paths: [
+      { document: "current.contract", pointer: "/owners", projection: "object_values" },
+      { document: "current.conformance", pointer: "/requiredGates", projection: "array_items" },
+    ],
+    cochange: ["current.contract", "current.conformance"],
+    control_paths: ["contracts/**"],
+    ...overrides,
+  };
+}
+
+function contractPolicy(overrides = {}) {
+  return {
+    ...basePolicy(),
+    profile: undefined,
+    profile_overrides: undefined,
+    paths: { ...basePolicy().paths, governance_paths: ["repo-policy.json", "schemas/**"] },
+    contract_conformance: contractConformanceMacro(),
+    ...overrides,
+  };
 }
 
 console.log("\n--- profile compiler runtime narrowing ---");
@@ -253,6 +290,134 @@ console.log("\n--- profile trace rules enforce changed requirement evidence ---"
     result.violations.find((item) => item.data?.trace_rule === "changed-requirements-need-evidence")?.message,
     "missing evidence"
   );
+}
+
+console.log("\n--- current contract/conformance macro semantic boundary ---");
+{
+  expect("valid current macro compiles without semantic errors", compileContractConformancePolicy(contractPolicy()), []);
+
+  const samePath = contractPolicy();
+  samePath.contract_conformance.current.conformance.path = samePath.contract_conformance.current.contract.path;
+  expect("macro rejects identical current pair paths", compileContractConformancePolicy(samePath).some((item) => item.field === "contract_conformance.current"), true);
+
+  const uncovered = contractPolicy();
+  uncovered.contract_conformance.control_paths = ["other/**"];
+  expect("macro rejects control paths that do not cover pair", compileContractConformancePolicy(uncovered).some((item) => /do not cover/.test(item.message)), true);
+
+  const duplicateSelector = contractPolicy();
+  duplicateSelector.contract_conformance.required_paths.push(structuredClone(duplicateSelector.contract_conformance.required_paths[0]));
+  expect("macro rejects duplicate required path selectors", compileContractConformancePolicy(duplicateSelector).some((item) => /duplicates selector/.test(item.message)), true);
+
+  const collision = contractPolicy({
+    document_relations: {
+      documents: { "contract-conformance.current.contract": { path: "explicit.json", format: "json" } },
+      rules: [],
+    },
+  });
+  expect("macro rejects generated namespace collisions", compileContractConformancePolicy(collision).some((item) => /collides/.test(item.message)), true);
+}
+
+console.log("\n--- current macro expands to ordinary policy only ---");
+{
+  const source = contractPolicy({
+    document_relations: {
+      documents: { explicit: { path: "contracts/extra.json", format: "json" } },
+      rules: [{ id: "explicit-state", kind: "scalar_equals_literal", source: { document: "explicit", pointer: "/state", type: "string" }, value: "ok" }],
+    },
+    cochange_rules: [{ if_changed: ["docs/**"], must_change_any: ["tests/**"] }],
+  });
+  const resolved = resolvePolicyProfile(source);
+  expect("macro resolves", resolved.ok, true);
+  expect("macro source field disappears after expansion", resolved.policy.contract_conformance, undefined);
+  expect("explicit document relation composes", resolved.policy.document_relations.documents.explicit.path, "contracts/extra.json");
+  expect("current contract generated document path", resolved.policy.document_relations.documents["contract-conformance.current.contract"].path, "contracts/spec-v2.json");
+  expect("current conformance generated document path", resolved.policy.document_relations.documents["contract-conformance.current.conformance"].path, "contracts/checks-v2.yaml");
+  expect("explicit relation remains first", resolved.policy.document_relations.rules[0].id, "explicit-state");
+  expect("macro emits six scalar relations plus required-path relations", resolved.policy.document_relations.rules.length, 9);
+  expect("existing cochange rule composes", resolved.policy.cochange_rules[0], { if_changed: ["docs/**"], must_change_any: ["tests/**"] });
+  expect("macro adds bidirectional current pair cochange", resolved.policy.cochange_rules.slice(1), [
+    { if_changed: ["contracts/spec-v2.json"], must_change_any: ["contracts/checks-v2.yaml"] },
+    { if_changed: ["contracts/checks-v2.yaml"], must_change_any: ["contracts/spec-v2.json"] },
+  ]);
+  expect("control paths compose into stable governance paths", resolved.policy.paths.governance_paths, ["contracts/**", "repo-policy.json", "schemas/**"]);
+}
+
+console.log("\n--- synthetic current macro executes through ordinary R2 constraints ---");
+{
+  const source = contractPolicy();
+  const resolved = resolvePolicyProfile(source);
+  const files = {
+    "contracts/spec-v2.json": JSON.stringify({
+      schema: "spec-v2",
+      status: "accepted",
+      accepted: true,
+      conformanceCorpus: "contracts/checks-v2.yaml",
+      owners: { spec: "docs/spec.md", tests: "tests/spec.test.mjs" },
+    }),
+    "contracts/checks-v2.yaml": [
+      "contract: spec-v2",
+      "status: accepted",
+      "accepted: true",
+      "requiredGates:",
+      "  - tests/gate.mjs",
+    ].join("\n"),
+    "docs/spec.md": "# Spec\n",
+    "tests/spec.test.mjs": "export {};\n",
+    "tests/gate.mjs": "export {};\n",
+  };
+  const run = (trackedFiles = Object.keys(files), diffText = "") => runPolicyPipeline({
+    mode: "check-diff",
+    repositoryRoot: "/tmp/contract-pack-test",
+    policy: resolved.policy,
+    changeIntent: null,
+    changeIntentSource: "none",
+    enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+    diffText,
+    trackedFiles,
+    readFile: (file) => files[file],
+    initialChecks: [],
+  }, { quiet: true });
+
+  const passing = run();
+  expect("synthetic current topology passes ordinary R2 relations", passing.violations.filter((item) => item.rule.startsWith("document-relation:")).length, 0);
+
+  const missing = run(Object.keys(files).filter((path) => path !== "tests/gate.mjs"));
+  expect("required path failure is ordinary referenced_paths_exist", missing.violations.find((item) => item.rule === "document-relation:contract-conformance:required-path:1")?.data?.missing_paths, ["tests/gate.mjs"]);
+
+  const contractOnlyDiff = [
+    "diff --git a/contracts/spec-v2.json b/contracts/spec-v2.json",
+    "--- a/contracts/spec-v2.json",
+    "+++ b/contracts/spec-v2.json",
+    "+{}",
+  ].join("\n");
+  expect("current pair cochange uses ordinary cochange rule", run(Object.keys(files), contractOnlyDiff).violations.some((item) => item.rule.startsWith("cochange:")), true);
+}
+
+console.log("\n--- anum_docs-shaped current topology is data only ---");
+{
+  const source = contractPolicy({
+    contract_conformance: contractConformanceMacro({
+      current: {
+        contract: { path: "contracts/mts-contract-v0.7.json", format: "json" },
+        conformance: { path: "contracts/mts-conformance-v0.7.json", format: "json" },
+      },
+      required_paths: [
+        { document: "current.contract", pointer: "/owners", projection: "object_values" },
+        { document: "current.conformance", pointer: "/requiredExecutableGates", projection: "array_items" },
+      ],
+    }),
+  });
+  const resolved = resolvePolicyProfile(source);
+  expect("anum_docs-shaped macro resolves without domain-specific implementation", resolved.ok, true);
+  expect("anum_docs contract/conformance cross-link uses configured pointers", resolved.policy.document_relations.rules[0], {
+    id: "contract-conformance:current-id",
+    kind: "scalar_equal",
+    left: { document: "contract-conformance.current.conformance", pointer: "/contract", type: "string" },
+    right: { document: "contract-conformance.current.contract", pointer: "/schema", type: "string" },
+  });
+  expect("anum_docs current conformance path is a literal relation", resolved.policy.document_relations.rules[1].value, "contracts/mts-conformance-v0.7.json");
+  expect("anum_docs owners use generic object_values path projection", resolved.policy.document_relations.rules[6].source.projection, "object_values");
+  expect("anum_docs executable gates use generic array_items path projection", resolved.policy.document_relations.rules[7].source.projection, "array_items");
 }
 
 console.log(`\n${failures === 0 ? "All policy profile tests passed" : `${failures} test(s) failed`}`);


### PR DESCRIPTION
Fixes #287

Implements the first R3 contract/conformance governance slice as a **pure current-pair policy macro**.

- `contract_conformance` source config is JSON Schema validated and limited to current contract/conformance roles;
- semantic compilation validates repository paths, pair roles, stable control-path coverage, duplicate selectors/roles and generated namespace collisions;
- successful expansion removes `contract_conformance` completely and emits only existing R2 `document_relations`, existing `cochange_rules`, and `paths.governance_paths`;
- current pair checks cover id cross-link, declared conformance artifact path, accepted status/boolean state and generic required repository-path collections;
- explicit R2 relations/cochange/governance paths compose with generated constraints;
- strictness tests compare only the expanded ordinary policy; no pack-specific comparison/runtime evaluator was added;
- regressions include a synthetic non-domain pair and the real `anum_docs` v0.7 path/pointer topology without embedding MTS semantics in production code;
- previous-release and acceptance-document roles remain deliberately deferred to the next R3 slice.

Generated `dist/policy-profiles.mjs` was produced by TypeScript compiler emit from a source blob matching GitHub exactly; its blob `46a13236d22a406d41d417920f16297bb030e66b` matches the target emitted by pinned CI. Full draft CI must be green before this PR is marked ready.