### PR TITLE
Contract governance R3b: add previous pair and acceptance pointer

### DIFF
--- a/dist/policy-profiles.mjs
+++ b/dist/policy-profiles.mjs
@@ -43,18 +43,24 @@ const OVERRIDE_FIELDS = new Set([
     ...Object.keys(PACKS["requirements-strict"].defaults),
     "changed_requirement_evidence_surfaces", "affected_evidence_surfaces",
 ]);
-const CONTRACT_ROLES = new Set(["current.contract", "current.conformance"]);
 const GENERATED_DOCUMENTS = {
     "current.contract": "contract-conformance.current.contract",
     "current.conformance": "contract-conformance.current.conformance",
+    "previous.contract": "contract-conformance.previous.contract",
+    "previous.conformance": "contract-conformance.previous.conformance",
+    acceptance: "contract-conformance.acceptance",
 };
-const GENERATED_RULE_IDS = [
-    "contract-conformance:current-id",
-    "contract-conformance:current-conformance-path",
-    "contract-conformance:current-contract-status",
-    "contract-conformance:current-conformance-status",
-    "contract-conformance:current-contract-accepted",
-    "contract-conformance:current-conformance-accepted",
+const pairRuleIds = (prefix) => [
+    `contract-conformance:${prefix}-id`,
+    `contract-conformance:${prefix}-conformance-path`,
+    `contract-conformance:${prefix}-contract-status`,
+    `contract-conformance:${prefix}-conformance-status`,
+    `contract-conformance:${prefix}-contract-accepted`,
+    `contract-conformance:${prefix}-conformance-accepted`,
+];
+const ACCEPTANCE_RULE_IDS = [
+    "contract-conformance:acceptance-current-contract",
+    "contract-conformance:acceptance-current-conformance",
 ];
 const clone = (value) => structuredClone(value);
 const isObject = (value) => value !== null && typeof value === "object" && !Array.isArray(value);
@@ -82,12 +88,22 @@ function materializePack(spec, overrides) {
 function contractMacro(policy) {
     return isObject(policy.contract_conformance) ? policy.contract_conformance : null;
 }
-function currentRoleDocuments(macro) {
-    const current = isObject(macro.current) ? macro.current : {};
+function pairDocuments(value, prefix) {
+    const pair = isObject(value) ? value : {};
     return {
-        "current.contract": isObject(current.contract) ? current.contract : {},
-        "current.conformance": isObject(current.conformance) ? current.conformance : {},
+        [`${prefix}.contract`]: isObject(pair.contract) ? pair.contract : {},
+        [`${prefix}.conformance`]: isObject(pair.conformance) ? pair.conformance : {},
     };
+}
+function configuredRoleDocuments(macro) {
+    const roles = { ...pairDocuments(macro.current, "current") };
+    if (isObject(macro.previous))
+        Object.assign(roles, pairDocuments(macro.previous, "previous"));
+    if (isObject(macro.acceptance)) {
+        const acceptance = macro.acceptance;
+        roles.acceptance = isObject(acceptance.document) ? acceptance.document : {};
+    }
+    return roles;
 }
 function normalizeDocumentPath(value) {
     try {
@@ -99,7 +115,9 @@ function normalizeDocumentPath(value) {
 }
 function generatedRuleIds(macro) {
     return [
-        ...GENERATED_RULE_IDS,
+        ...pairRuleIds("current"),
+        ...(isObject(macro.previous) ? pairRuleIds("previous") : []),
+        ...(isObject(macro.acceptance) ? ACCEPTANCE_RULE_IDS : []),
         ...((Array.isArray(macro.required_paths) ? macro.required_paths : []).map((_, index) => `contract-conformance:required-path:${index}`)),
     ];
 }
@@ -131,18 +149,23 @@ export function compileContractConformancePolicy(policy) {
     if (!isObject(source.contract_conformance))
         return [{ field: "contract_conformance", message: "contract_conformance must be an object" }];
     const macro = source.contract_conformance, errors = [];
-    const roles = currentRoleDocuments(macro), paths = new Map();
-    for (const role of CONTRACT_ROLES) {
-        const definition = roles[role], path = normalizeDocumentPath(definition.path), format = definition.format;
+    const roles = configuredRoleDocuments(macro), paths = new Map();
+    for (const [role, definition] of Object.entries(roles)) {
+        const path = normalizeDocumentPath(definition.path), format = definition.format;
         if (!path)
-            errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.path`, message: `${role} path must be a canonical repository path` });
+            errors.push({ field: `contract_conformance.${role}.path`, message: `${role} path must be a canonical repository path` });
         else
             paths.set(role, path);
         if (format !== "json" && format !== "yaml")
-            errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.format`, message: `${role} format must be json or yaml` });
+            errors.push({ field: `contract_conformance.${role}.format`, message: `${role} format must be json or yaml` });
     }
-    if (paths.get("current.contract") && paths.get("current.contract") === paths.get("current.conformance")) {
-        errors.push({ field: "contract_conformance.current", message: "current contract and conformance paths must be distinct" });
+    const pathOwners = new Map();
+    for (const [role, path] of paths) {
+        const previousOwner = pathOwners.get(path);
+        if (previousOwner)
+            errors.push({ field: "contract_conformance", message: `${role} path duplicates ${previousOwner} path "${path}"` });
+        else
+            pathOwners.set(path, role);
     }
     const pairFields = isObject(macro.pair_fields) ? macro.pair_fields : {};
     for (const field of ["contract_id", "conformance_contract_id", "contract_conformance_path", "contract_status", "conformance_status", "contract_accepted", "conformance_accepted"]) {
@@ -154,11 +177,18 @@ export function compileContractConformancePolicy(policy) {
         errors.push({ field: "contract_conformance.accepted_state.status", message: "accepted_state.status must be a string" });
     if (typeof acceptedState.accepted !== "boolean")
         errors.push({ field: "contract_conformance.accepted_state.accepted", message: "accepted_state.accepted must be a boolean" });
+    if (isObject(macro.acceptance)) {
+        if (typeof macro.acceptance.current_contract_path !== "string")
+            errors.push({ field: "contract_conformance.acceptance.current_contract_path", message: "acceptance.current_contract_path must be a JSON Pointer string" });
+        if (typeof macro.acceptance.current_conformance_path !== "string")
+            errors.push({ field: "contract_conformance.acceptance.current_conformance_path", message: "acceptance.current_conformance_path must be a JSON Pointer string" });
+    }
+    const availableRoles = new Set(Object.keys(roles));
     const selectors = Array.isArray(macro.required_paths) ? macro.required_paths : [], selectorKeys = new Set();
     for (const [index, rawSelector] of selectors.entries()) {
         const selector = isObject(rawSelector) ? rawSelector : {}, role = selector.document;
-        if (!CONTRACT_ROLES.has(role))
-            errors.push({ field: `contract_conformance.required_paths[${index}].document`, message: `required_paths[${index}] references unknown role "${selector.document}"` });
+        if (!availableRoles.has(role))
+            errors.push({ field: `contract_conformance.required_paths[${index}].document`, message: `required_paths[${index}] references unavailable role "${selector.document}"` });
         const key = `${selector.document}|${selector.pointer}|${selector.projection}`;
         if (selectorKeys.has(key))
             errors.push({ field: `contract_conformance.required_paths[${index}]`, message: `required_paths[${index}] duplicates selector ${key}` });
@@ -166,8 +196,8 @@ export function compileContractConformancePolicy(policy) {
     }
     const cochange = stringList(macro.cochange), seenRoles = new Set();
     for (const [index, role] of cochange.entries()) {
-        if (!CONTRACT_ROLES.has(role))
-            errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange references unknown role "${role}"` });
+        if (!availableRoles.has(role))
+            errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange references unavailable role "${role}"` });
         if (seenRoles.has(role))
             errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange duplicates role "${role}"` });
         seenRoles.add(role);
@@ -182,10 +212,11 @@ export function compileContractConformancePolicy(policy) {
             errors.push({ field: "contract_conformance.control_paths", message: `control_paths do not cover ${role} path "${path}"` });
         }
     const explicitRelations = isObject(source.document_relations) ? source.document_relations : {}, explicitDocuments = isObject(explicitRelations.documents) ? explicitRelations.documents : {};
-    for (const name of Object.values(GENERATED_DOCUMENTS))
-        if (Object.hasOwn(explicitDocuments, name)) {
+    for (const role of availableRoles) {
+        const name = GENERATED_DOCUMENTS[role];
+        if (Object.hasOwn(explicitDocuments, name))
             errors.push({ field: "document_relations.documents", message: `contract_conformance generated document "${name}" collides with explicit document_relations` });
-        }
+    }
     const explicitRuleIds = new Set((Array.isArray(explicitRelations.rules) ? explicitRelations.rules : []).map((rule) => isObject(rule) ? rule.id : undefined));
     for (const id of generatedRuleIds(macro))
         if (explicitRuleIds.has(id)) {
@@ -205,15 +236,25 @@ export function expandContractConformancePolicy(policy) {
     if (!macro)
         return base;
     delete base.contract_conformance;
-    const roleDefinitions = currentRoleDocuments(macro);
+    const roleDefinitions = configuredRoleDocuments(macro);
     const rolePaths = Object.fromEntries(Object.entries(roleDefinitions).map(([role, definition]) => [role, normalizeDocumentPath(definition.path)]));
     const relations = isObject(base.document_relations) ? clone(base.document_relations) : {}, documents = isObject(relations.documents) ? clone(relations.documents) : {};
     const rules = Array.isArray(relations.rules) ? clone(relations.rules) : [], pairFields = macro.pair_fields, acceptedState = macro.accepted_state;
-    for (const role of CONTRACT_ROLES) {
-        documents[GENERATED_DOCUMENTS[role]] = { path: rolePaths[role], format: roleDefinitions[role].format };
+    for (const [role, definition] of Object.entries(roleDefinitions)) {
+        documents[GENERATED_DOCUMENTS[role]] = { path: rolePaths[role], format: definition.format };
     }
     const selector = (role, pointer, type) => ({ document: GENERATED_DOCUMENTS[role], pointer, type });
-    rules.push({ id: GENERATED_RULE_IDS[0], kind: "scalar_equal", left: selector("current.conformance", pairFields.conformance_contract_id, "string"), right: selector("current.contract", pairFields.contract_id, "string") }, { id: GENERATED_RULE_IDS[1], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_conformance_path, "string"), value: rolePaths["current.conformance"] }, { id: GENERATED_RULE_IDS[2], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_status, "string"), value: acceptedState.status }, { id: GENERATED_RULE_IDS[3], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_status, "string"), value: acceptedState.status }, { id: GENERATED_RULE_IDS[4], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_accepted, "boolean"), value: acceptedState.accepted }, { id: GENERATED_RULE_IDS[5], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_accepted, "boolean"), value: acceptedState.accepted });
+    const addPair = (prefix) => {
+        const contractRole = `${prefix}.contract`, conformanceRole = `${prefix}.conformance`, ids = pairRuleIds(prefix);
+        rules.push({ id: ids[0], kind: "scalar_equal", left: selector(conformanceRole, pairFields.conformance_contract_id, "string"), right: selector(contractRole, pairFields.contract_id, "string") }, { id: ids[1], kind: "scalar_equals_literal", source: selector(contractRole, pairFields.contract_conformance_path, "string"), value: rolePaths[conformanceRole] }, { id: ids[2], kind: "scalar_equals_literal", source: selector(contractRole, pairFields.contract_status, "string"), value: acceptedState.status }, { id: ids[3], kind: "scalar_equals_literal", source: selector(conformanceRole, pairFields.conformance_status, "string"), value: acceptedState.status }, { id: ids[4], kind: "scalar_equals_literal", source: selector(contractRole, pairFields.contract_accepted, "boolean"), value: acceptedState.accepted }, { id: ids[5], kind: "scalar_equals_literal", source: selector(conformanceRole, pairFields.conformance_accepted, "boolean"), value: acceptedState.accepted });
+    };
+    addPair("current");
+    if (roleDefinitions["previous.contract"] && roleDefinitions["previous.conformance"])
+        addPair("previous");
+    if (isObject(macro.acceptance)) {
+        const acceptance = macro.acceptance;
+        rules.push({ id: ACCEPTANCE_RULE_IDS[0], kind: "scalar_equals_literal", source: selector("acceptance", acceptance.current_contract_path, "string"), value: rolePaths["current.contract"] }, { id: ACCEPTANCE_RULE_IDS[1], kind: "scalar_equals_literal", source: selector("acceptance", acceptance.current_conformance_path, "string"), value: rolePaths["current.conformance"] });
+    }
     for (const [index, rawSelector] of (macro.required_paths || []).entries()) {
         const source = rawSelector;
         rules.push({ id: `contract-conformance:required-path:${index}`, kind: "referenced_paths_exist", source: { document: GENERATED_DOCUMENTS[source.document], pointer: source.pointer, projection: source.projection, type: "repository_path_set" } });

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -385,6 +385,15 @@
             "conformance": { "$ref": "#/definitions/document_relation_document" }
           }
         },
+        "previous": {
+          "type": "object",
+          "required": ["contract", "conformance"],
+          "additionalProperties": false,
+          "properties": {
+            "contract": { "$ref": "#/definitions/document_relation_document" },
+            "conformance": { "$ref": "#/definitions/document_relation_document" }
+          }
+        },
         "pair_fields": {
           "type": "object",
           "required": ["contract_id", "conformance_contract_id", "contract_conformance_path", "contract_status", "conformance_status", "contract_accepted", "conformance_accepted"],
@@ -408,6 +417,16 @@
             "accepted": { "type": "boolean" }
           }
         },
+        "acceptance": {
+          "type": "object",
+          "required": ["document", "current_contract_path", "current_conformance_path"],
+          "additionalProperties": false,
+          "properties": {
+            "document": { "$ref": "#/definitions/document_relation_document" },
+            "current_contract_path": { "type": "string" },
+            "current_conformance_path": { "type": "string" }
+          }
+        },
         "required_paths": {
           "type": "array",
           "minItems": 1,
@@ -417,7 +436,7 @@
             "required": ["document", "pointer", "projection"],
             "additionalProperties": false,
             "properties": {
-              "document": { "type": "string", "enum": ["current.contract", "current.conformance"] },
+              "document": { "type": "string", "enum": ["current.contract", "current.conformance", "previous.contract", "previous.conformance", "acceptance"] },
               "pointer": { "type": "string" },
               "projection": { "type": "string", "enum": ["array_items", "object_values"] }
             }
@@ -426,9 +445,9 @@
         "cochange": {
           "type": "array",
           "minItems": 2,
-          "maxItems": 2,
+          "maxItems": 5,
           "uniqueItems": true,
-          "items": { "type": "string", "enum": ["current.contract", "current.conformance"] }
+          "items": { "type": "string", "enum": ["current.contract", "current.conformance", "previous.contract", "previous.conformance", "acceptance"] }
         },
         "control_paths": {
           "type": "array",

--- a/src/policy-profiles.mts
+++ b/src/policy-profiles.mts
@@ -50,7 +50,8 @@ interface ProfileSpec {
   trace_rules: ProfileRule[];
 }
 type ProfileConfig = Record<string, unknown>;
-type ContractRole = "current.contract" | "current.conformance";
+type PairRole = "current.contract" | "current.conformance" | "previous.contract" | "previous.conformance";
+type ContractRole = PairRole | "acceptance";
 interface PolicyProjection extends Record<string, unknown> {
   profile?: string;
   profile_overrides?: unknown;
@@ -71,18 +72,24 @@ const OVERRIDE_FIELDS = new Set([
   ...Object.keys(PACKS["requirements-strict"].defaults),
   "changed_requirement_evidence_surfaces", "affected_evidence_surfaces",
 ]);
-const CONTRACT_ROLES = new Set<ContractRole>(["current.contract", "current.conformance"]);
-const GENERATED_DOCUMENTS = {
+const GENERATED_DOCUMENTS: Record<ContractRole, string> = {
   "current.contract": "contract-conformance.current.contract",
   "current.conformance": "contract-conformance.current.conformance",
-} as const;
-const GENERATED_RULE_IDS = [
-  "contract-conformance:current-id",
-  "contract-conformance:current-conformance-path",
-  "contract-conformance:current-contract-status",
-  "contract-conformance:current-conformance-status",
-  "contract-conformance:current-contract-accepted",
-  "contract-conformance:current-conformance-accepted",
+  "previous.contract": "contract-conformance.previous.contract",
+  "previous.conformance": "contract-conformance.previous.conformance",
+  acceptance: "contract-conformance.acceptance",
+};
+const pairRuleIds = (prefix: "current" | "previous") => [
+  `contract-conformance:${prefix}-id`,
+  `contract-conformance:${prefix}-conformance-path`,
+  `contract-conformance:${prefix}-contract-status`,
+  `contract-conformance:${prefix}-conformance-status`,
+  `contract-conformance:${prefix}-contract-accepted`,
+  `contract-conformance:${prefix}-conformance-accepted`,
+];
+const ACCEPTANCE_RULE_IDS = [
+  "contract-conformance:acceptance-current-contract",
+  "contract-conformance:acceptance-current-conformance",
 ];
 const clone = <T,>(value: T): T => structuredClone(value);
 const isObject = (value: unknown): value is Record<string, unknown> => value !== null && typeof value === "object" && !Array.isArray(value);
@@ -115,12 +122,22 @@ function contractMacro(policy: PolicyProjection) {
   return isObject(policy.contract_conformance) ? policy.contract_conformance : null;
 }
 
-function currentRoleDocuments(macro: Record<string, unknown>) {
-  const current = isObject(macro.current) ? macro.current : {};
+function pairDocuments(value: unknown, prefix: "current" | "previous") {
+  const pair = isObject(value) ? value : {};
   return {
-    "current.contract": isObject(current.contract) ? current.contract : {},
-    "current.conformance": isObject(current.conformance) ? current.conformance : {},
-  } satisfies Record<ContractRole, Record<string, unknown>>;
+    [`${prefix}.contract`]: isObject(pair.contract) ? pair.contract : {},
+    [`${prefix}.conformance`]: isObject(pair.conformance) ? pair.conformance : {},
+  } as Record<PairRole, Record<string, unknown>>;
+}
+
+function configuredRoleDocuments(macro: Record<string, unknown>): Partial<Record<ContractRole, Record<string, unknown>>> {
+  const roles: Partial<Record<ContractRole, Record<string, unknown>>> = { ...pairDocuments(macro.current, "current") };
+  if (isObject(macro.previous)) Object.assign(roles, pairDocuments(macro.previous, "previous"));
+  if (isObject(macro.acceptance)) {
+    const acceptance = macro.acceptance;
+    roles.acceptance = isObject(acceptance.document) ? acceptance.document : {};
+  }
+  return roles;
 }
 
 function normalizeDocumentPath(value: unknown): string | null {
@@ -130,7 +147,9 @@ function normalizeDocumentPath(value: unknown): string | null {
 
 function generatedRuleIds(macro: Record<string, unknown>): string[] {
   return [
-    ...GENERATED_RULE_IDS,
+    ...pairRuleIds("current"),
+    ...(isObject(macro.previous) ? pairRuleIds("previous") : []),
+    ...(isObject(macro.acceptance) ? ACCEPTANCE_RULE_IDS : []),
     ...((Array.isArray(macro.required_paths) ? macro.required_paths : []).map((_, index) => `contract-conformance:required-path:${index}`)),
   ];
 }
@@ -159,15 +178,18 @@ export function compileContractConformancePolicy(policy: unknown): ProfileValida
   if (!isObject(source.contract_conformance)) return [{ field: "contract_conformance", message: "contract_conformance must be an object" }];
 
   const macro = source.contract_conformance, errors: ProfileValidationError[] = [];
-  const roles = currentRoleDocuments(macro), paths = new Map<ContractRole, string>();
-  for (const role of CONTRACT_ROLES) {
-    const definition = roles[role], path = normalizeDocumentPath(definition.path), format = definition.format;
-    if (!path) errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.path`, message: `${role} path must be a canonical repository path` });
+  const roles = configuredRoleDocuments(macro), paths = new Map<ContractRole, string>();
+  for (const [role, definition] of Object.entries(roles) as Array<[ContractRole, Record<string, unknown>]>) {
+    const path = normalizeDocumentPath(definition.path), format = definition.format;
+    if (!path) errors.push({ field: `contract_conformance.${role}.path`, message: `${role} path must be a canonical repository path` });
     else paths.set(role, path);
-    if (format !== "json" && format !== "yaml") errors.push({ field: `contract_conformance.current.${role.split(".")[1]}.format`, message: `${role} format must be json or yaml` });
+    if (format !== "json" && format !== "yaml") errors.push({ field: `contract_conformance.${role}.format`, message: `${role} format must be json or yaml` });
   }
-  if (paths.get("current.contract") && paths.get("current.contract") === paths.get("current.conformance")) {
-    errors.push({ field: "contract_conformance.current", message: "current contract and conformance paths must be distinct" });
+  const pathOwners = new Map<string, ContractRole>();
+  for (const [role, path] of paths) {
+    const previousOwner = pathOwners.get(path);
+    if (previousOwner) errors.push({ field: "contract_conformance", message: `${role} path duplicates ${previousOwner} path "${path}"` });
+    else pathOwners.set(path, role);
   }
 
   const pairFields = isObject(macro.pair_fields) ? macro.pair_fields : {};
@@ -178,10 +200,16 @@ export function compileContractConformancePolicy(policy: unknown): ProfileValida
   if (typeof acceptedState.status !== "string") errors.push({ field: "contract_conformance.accepted_state.status", message: "accepted_state.status must be a string" });
   if (typeof acceptedState.accepted !== "boolean") errors.push({ field: "contract_conformance.accepted_state.accepted", message: "accepted_state.accepted must be a boolean" });
 
+  if (isObject(macro.acceptance)) {
+    if (typeof macro.acceptance.current_contract_path !== "string") errors.push({ field: "contract_conformance.acceptance.current_contract_path", message: "acceptance.current_contract_path must be a JSON Pointer string" });
+    if (typeof macro.acceptance.current_conformance_path !== "string") errors.push({ field: "contract_conformance.acceptance.current_conformance_path", message: "acceptance.current_conformance_path must be a JSON Pointer string" });
+  }
+
+  const availableRoles = new Set(Object.keys(roles) as ContractRole[]);
   const selectors = Array.isArray(macro.required_paths) ? macro.required_paths : [], selectorKeys = new Set<string>();
   for (const [index, rawSelector] of selectors.entries()) {
     const selector = isObject(rawSelector) ? rawSelector : {}, role = selector.document as ContractRole;
-    if (!CONTRACT_ROLES.has(role)) errors.push({ field: `contract_conformance.required_paths[${index}].document`, message: `required_paths[${index}] references unknown role "${selector.document}"` });
+    if (!availableRoles.has(role)) errors.push({ field: `contract_conformance.required_paths[${index}].document`, message: `required_paths[${index}] references unavailable role "${selector.document}"` });
     const key = `${selector.document}|${selector.pointer}|${selector.projection}`;
     if (selectorKeys.has(key)) errors.push({ field: `contract_conformance.required_paths[${index}]`, message: `required_paths[${index}] duplicates selector ${key}` });
     selectorKeys.add(key);
@@ -189,7 +217,7 @@ export function compileContractConformancePolicy(policy: unknown): ProfileValida
 
   const cochange = stringList(macro.cochange), seenRoles = new Set<string>();
   for (const [index, role] of cochange.entries()) {
-    if (!CONTRACT_ROLES.has(role as ContractRole)) errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange references unknown role "${role}"` });
+    if (!availableRoles.has(role as ContractRole)) errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange references unavailable role "${role}"` });
     if (seenRoles.has(role)) errors.push({ field: `contract_conformance.cochange[${index}]`, message: `cochange duplicates role "${role}"` });
     seenRoles.add(role);
   }
@@ -202,8 +230,9 @@ export function compileContractConformancePolicy(policy: unknown): ProfileValida
   }
 
   const explicitRelations = isObject(source.document_relations) ? source.document_relations : {}, explicitDocuments = isObject(explicitRelations.documents) ? explicitRelations.documents : {};
-  for (const name of Object.values(GENERATED_DOCUMENTS)) if (Object.hasOwn(explicitDocuments, name)) {
-    errors.push({ field: "document_relations.documents", message: `contract_conformance generated document "${name}" collides with explicit document_relations` });
+  for (const role of availableRoles) {
+    const name = GENERATED_DOCUMENTS[role];
+    if (Object.hasOwn(explicitDocuments, name)) errors.push({ field: "document_relations.documents", message: `contract_conformance generated document "${name}" collides with explicit document_relations` });
   }
   const explicitRuleIds = new Set((Array.isArray(explicitRelations.rules) ? explicitRelations.rules : []).map((rule) => isObject(rule) ? rule.id : undefined));
   for (const id of generatedRuleIds(macro)) if (explicitRuleIds.has(id)) {
@@ -224,22 +253,34 @@ export function expandContractConformancePolicy(policy: unknown) {
   if (!macro) return base;
   delete base.contract_conformance;
 
-  const roleDefinitions = currentRoleDocuments(macro);
-  const rolePaths = Object.fromEntries(Object.entries(roleDefinitions).map(([role, definition]) => [role, normalizeDocumentPath(definition.path)!])) as Record<ContractRole, string>;
+  const roleDefinitions = configuredRoleDocuments(macro);
+  const rolePaths = Object.fromEntries(Object.entries(roleDefinitions).map(([role, definition]) => [role, normalizeDocumentPath(definition!.path)!])) as Record<ContractRole, string>;
   const relations = isObject(base.document_relations) ? clone(base.document_relations) : {}, documents = isObject(relations.documents) ? clone(relations.documents) : {};
   const rules = Array.isArray(relations.rules) ? clone(relations.rules) : [], pairFields = macro.pair_fields as Record<string, string>, acceptedState = macro.accepted_state as { status: string; accepted: boolean };
-  for (const role of CONTRACT_ROLES) {
-    documents[GENERATED_DOCUMENTS[role]] = { path: rolePaths[role], format: roleDefinitions[role].format };
+  for (const [role, definition] of Object.entries(roleDefinitions) as Array<[ContractRole, Record<string, unknown>]>) {
+    documents[GENERATED_DOCUMENTS[role]] = { path: rolePaths[role], format: definition.format };
   }
   const selector = (role: ContractRole, pointer: string, type: "string" | "boolean") => ({ document: GENERATED_DOCUMENTS[role], pointer, type });
-  rules.push(
-    { id: GENERATED_RULE_IDS[0], kind: "scalar_equal", left: selector("current.conformance", pairFields.conformance_contract_id, "string"), right: selector("current.contract", pairFields.contract_id, "string") },
-    { id: GENERATED_RULE_IDS[1], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_conformance_path, "string"), value: rolePaths["current.conformance"] },
-    { id: GENERATED_RULE_IDS[2], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_status, "string"), value: acceptedState.status },
-    { id: GENERATED_RULE_IDS[3], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_status, "string"), value: acceptedState.status },
-    { id: GENERATED_RULE_IDS[4], kind: "scalar_equals_literal", source: selector("current.contract", pairFields.contract_accepted, "boolean"), value: acceptedState.accepted },
-    { id: GENERATED_RULE_IDS[5], kind: "scalar_equals_literal", source: selector("current.conformance", pairFields.conformance_accepted, "boolean"), value: acceptedState.accepted },
-  );
+  const addPair = (prefix: "current" | "previous") => {
+    const contractRole = `${prefix}.contract` as PairRole, conformanceRole = `${prefix}.conformance` as PairRole, ids = pairRuleIds(prefix);
+    rules.push(
+      { id: ids[0], kind: "scalar_equal", left: selector(conformanceRole, pairFields.conformance_contract_id, "string"), right: selector(contractRole, pairFields.contract_id, "string") },
+      { id: ids[1], kind: "scalar_equals_literal", source: selector(contractRole, pairFields.contract_conformance_path, "string"), value: rolePaths[conformanceRole] },
+      { id: ids[2], kind: "scalar_equals_literal", source: selector(contractRole, pairFields.contract_status, "string"), value: acceptedState.status },
+      { id: ids[3], kind: "scalar_equals_literal", source: selector(conformanceRole, pairFields.conformance_status, "string"), value: acceptedState.status },
+      { id: ids[4], kind: "scalar_equals_literal", source: selector(contractRole, pairFields.contract_accepted, "boolean"), value: acceptedState.accepted },
+      { id: ids[5], kind: "scalar_equals_literal", source: selector(conformanceRole, pairFields.conformance_accepted, "boolean"), value: acceptedState.accepted },
+    );
+  };
+  addPair("current");
+  if (roleDefinitions["previous.contract"] && roleDefinitions["previous.conformance"]) addPair("previous");
+  if (isObject(macro.acceptance)) {
+    const acceptance = macro.acceptance;
+    rules.push(
+      { id: ACCEPTANCE_RULE_IDS[0], kind: "scalar_equals_literal", source: selector("acceptance", acceptance.current_contract_path as string, "string"), value: rolePaths["current.contract"] },
+      { id: ACCEPTANCE_RULE_IDS[1], kind: "scalar_equals_literal", source: selector("acceptance", acceptance.current_conformance_path as string, "string"), value: rolePaths["current.conformance"] },
+    );
+  }
   for (const [index, rawSelector] of (macro.required_paths as Array<Record<string, unknown>> || []).entries()) {
     const source = rawSelector as { document: ContractRole; pointer: string; projection: "array_items" | "object_values" };
     rules.push({ id: `contract-conformance:required-path:${index}`, kind: "referenced_paths_exist", source: { document: GENERATED_DOCUMENTS[source.document], pointer: source.pointer, projection: source.projection, type: "repository_path_set" } });

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import Ajv from "ajv";
 import { compareConstraintPrograms } from "../dist/checks/constraint-program.mjs";
 import { checkPolicyRelaxation, classifyChangedFiles, computePolicyDelta, policyRelaxationRuleFamily } from "../dist/checks/rules/policy-delta-rules.mjs";
-import { resolvePolicyProfile } from "../dist/policy-profiles.mjs";
+import { compileContractConformancePolicy, resolvePolicyProfile } from "../dist/policy-profiles.mjs";
 import { loadJSON } from "../dist/runtime/validation.mjs";
 
 const file = (path, extra = {}) => ({ path, status: "modified", addedLines: [], deletedLines: [], ...extra });
@@ -73,14 +73,29 @@ const macroPolicy = () => ({
     control_paths: ["contracts/**"],
   },
 });
-const macroSchemaPolicy = () => ({
+const historyMacroPolicy = () => {
+  const policy = macroPolicy();
+  policy.contract_conformance.previous = {
+    contract: { path: "contracts/spec-v1.json", format: "json" },
+    conformance: { path: "contracts/checks-v1.json", format: "json" },
+  };
+  policy.contract_conformance.acceptance = {
+    document: { path: "cutover/acceptance.json", format: "json" },
+    current_contract_path: "/current/contract",
+    current_conformance_path: "/current/conformance",
+  };
+  policy.contract_conformance.cochange = ["current.contract", "current.conformance", "previous.contract", "previous.conformance", "acceptance"];
+  policy.contract_conformance.control_paths = ["contracts/**", "cutover/**"];
+  return policy;
+};
+const macroSchemaPolicy = (contractConformance = macroPolicy().contract_conformance) => ({
   policy_format_version: "0.3.0",
   repository_kind: "tooling",
   paths: { forbidden: [], canonical_docs: [], governance_paths: ["repo-policy.json"] },
   diff_rules: { max_new_files: 5, max_new_docs: 2 },
   content_rules: [],
   cochange_rules: [],
-  contract_conformance: structuredClone(macroPolicy().contract_conformance),
+  contract_conformance: structuredClone(contractConformance),
 });
 
 describe("Constraint Program strictness projection", () => {
@@ -176,13 +191,44 @@ describe("contract/conformance macro source schema", () => {
     assert.equal(validate(macroSchemaPolicy()), true);
   });
 
-  it("rejects future previous-pair syntax in R3a", () => {
-    const source = macroSchemaPolicy();
-    source.contract_conformance.previous = {
-      contract: { path: "contracts/spec-v1.json", format: "json" },
-      conformance: { path: "contracts/checks-v1.json", format: "json" },
-    };
+  it("accepts a complete previous pair plus optional acceptance pointer", () => {
+    assert.equal(validate(macroSchemaPolicy(historyMacroPolicy().contract_conformance)), true);
+  });
+
+  it("rejects an incomplete previous pair", () => {
+    const source = macroSchemaPolicy(historyMacroPolicy().contract_conformance);
+    delete source.contract_conformance.previous.conformance;
     assert.equal(validate(source), false);
+  });
+
+  it("rejects an incomplete acceptance pointer", () => {
+    const source = macroSchemaPolicy(historyMacroPolicy().contract_conformance);
+    delete source.contract_conformance.acceptance.current_conformance_path;
+    assert.equal(validate(source), false);
+  });
+});
+
+describe("contract/conformance macro semantic boundary", () => {
+  it("accepts complete configured history roles", () => {
+    assert.deepEqual(compileContractConformancePolicy(historyMacroPolicy()), []);
+  });
+
+  it("rejects duplicate artifact paths across current, previous and acceptance", () => {
+    const source = historyMacroPolicy();
+    source.contract_conformance.previous.contract.path = source.contract_conformance.current.contract.path;
+    assert.ok(compileContractConformancePolicy(source).some((item) => /duplicates current\.contract/.test(item.message)));
+  });
+
+  it("rejects cochange roles that are not configured", () => {
+    const source = macroPolicy();
+    source.contract_conformance.cochange = ["current.contract", "acceptance"];
+    assert.ok(compileContractConformancePolicy(source).some((item) => /unavailable role "acceptance"/.test(item.message)));
+  });
+
+  it("requires control paths to cover previous and acceptance artifacts", () => {
+    const source = historyMacroPolicy();
+    source.contract_conformance.control_paths = ["contracts/**"];
+    assert.ok(compileContractConformancePolicy(source).some((item) => /do not cover acceptance path/.test(item.message)));
   });
 });
 
@@ -202,6 +248,50 @@ describe("contract/conformance macro strictness", () => {
     const removal = compareConstraintPrograms(resolved.policy, baseline);
     assert.equal(removal.relation, "weaker");
     assert.ok(removal.relaxations.some((item) => item.kind === "document_relation_removed" && item.rule_id === "contract-conformance:current-id"));
+  });
+
+  it("expands history and acceptance only into ordinary constraints", () => {
+    const source = historyMacroPolicy();
+    source.document_relations = {
+      documents: {},
+      rules: [{
+        id: "historical-runtime-not-selectable",
+        kind: "scalar_equals_literal",
+        source: { document: "contract-conformance.acceptance", pointer: "/previousReleaseEvidence/liveRuntimeSelectable", type: "boolean" },
+        value: false,
+      }],
+    };
+    const resolved = resolvePolicyProfile(source);
+    assert.equal(resolved.ok, true);
+    assert.equal(resolved.policy.contract_conformance, undefined);
+    assert.equal(resolved.policy.document_relations.documents["contract-conformance.previous.contract"].path, "contracts/spec-v1.json");
+    assert.equal(resolved.policy.document_relations.documents["contract-conformance.previous.conformance"].path, "contracts/checks-v1.json");
+    assert.equal(resolved.policy.document_relations.documents["contract-conformance.acceptance"].path, "cutover/acceptance.json");
+    assert.ok(resolved.policy.document_relations.rules.some((rule) => rule.id === "contract-conformance:previous-id"));
+    assert.ok(resolved.policy.document_relations.rules.some((rule) => rule.id === "contract-conformance:acceptance-current-contract"));
+    assert.ok(resolved.policy.document_relations.rules.some((rule) => rule.id === "historical-runtime-not-selectable"));
+    assert.equal(resolved.policy.document_relations.rules.filter((rule) => rule.kind === "referenced_paths_exist").length, 1);
+    assert.ok(resolved.policy.cochange_rules.some((rule) => rule.if_changed[0] === "cutover/acceptance.json"));
+
+    const currentOnly = resolvePolicyProfile(macroPolicy()).policy;
+    const historyComparison = compareConstraintPrograms(currentOnly, resolved.policy);
+    assert.notEqual(historyComparison.relation, "weaker");
+    assert.ok(historyComparison.incomparable.every((item) => !JSON.stringify(item).includes("contract_conformance")));
+  });
+
+  it("represents the anum_docs v0.6/v0.7 acceptance topology without domain fields", () => {
+    const source = historyMacroPolicy();
+    source.contract_conformance.current.contract.path = "contracts/mts-contract-v0.7.json";
+    source.contract_conformance.current.conformance.path = "contracts/mts-conformance-v0.7.json";
+    source.contract_conformance.previous.contract.path = "contracts/mts-contract-v0.6.json";
+    source.contract_conformance.previous.conformance.path = "contracts/mts-conformance-v0.6.json";
+    source.contract_conformance.acceptance.document.path = "cutover/foundation-v2-c9-acceptance-v0.1.json";
+    source.contract_conformance.control_paths = ["contracts/**", "cutover/**"];
+    const resolved = resolvePolicyProfile(source);
+    assert.equal(resolved.ok, true);
+    assert.equal(resolved.policy.document_relations.documents["contract-conformance.current.contract"].path, "contracts/mts-contract-v0.7.json");
+    assert.equal(resolved.policy.document_relations.documents["contract-conformance.previous.contract"].path, "contracts/mts-contract-v0.6.json");
+    assert.equal(resolved.policy.document_relations.documents["contract-conformance.acceptance"].path, "cutover/foundation-v2-c9-acceptance-v0.1.json");
   });
 });
 

--- a/tests/test-policy-profiles.mjs
+++ b/tests/test-policy-profiles.mjs
@@ -114,6 +114,23 @@ function contractConformanceMacro(overrides = {}) {
   };
 }
 
+function historyContractConformanceMacro(overrides = {}) {
+  return contractConformanceMacro({
+    previous: {
+      contract: { path: "contracts/spec-v1.json", format: "json" },
+      conformance: { path: "contracts/checks-v1.json", format: "json" },
+    },
+    acceptance: {
+      document: { path: "cutover/acceptance.json", format: "json" },
+      current_contract_path: "/current/contract",
+      current_conformance_path: "/current/conformance",
+    },
+    cochange: ["current.contract", "current.conformance", "previous.contract", "previous.conformance", "acceptance"],
+    control_paths: ["contracts/**", "cutover/**"],
+    ...overrides,
+  });
+}
+
 function contractPolicy(overrides = {}) {
   return {
     ...basePolicy(),
@@ -298,7 +315,7 @@ console.log("\n--- current contract/conformance macro semantic boundary ---");
 
   const samePath = contractPolicy();
   samePath.contract_conformance.current.conformance.path = samePath.contract_conformance.current.contract.path;
-  expect("macro rejects identical current pair paths", compileContractConformancePolicy(samePath).some((item) => item.field === "contract_conformance.current"), true);
+  expect("macro rejects identical current pair paths", compileContractConformancePolicy(samePath).some((item) => /duplicates current\.contract/.test(item.message)), true);
 
   const uncovered = contractPolicy();
   uncovered.contract_conformance.control_paths = ["other/**"];
@@ -391,6 +408,85 @@ console.log("\n--- synthetic current macro executes through ordinary R2 constrai
     "+{}",
   ].join("\n");
   expect("current pair cochange uses ordinary cochange rule", run(Object.keys(files), contractOnlyDiff).violations.some((item) => item.rule.startsWith("cochange:")), true);
+}
+
+console.log("\n--- synthetic previous pair and acceptance execute through ordinary R2 constraints ---");
+{
+  const source = contractPolicy({
+    contract_conformance: historyContractConformanceMacro(),
+    document_relations: {
+      documents: { "consumer-context": { path: "cutover/acceptance.json", format: "json" } },
+      rules: [{
+        id: "historical-runtime-not-selectable",
+        kind: "scalar_equals_literal",
+        source: { document: "contract-conformance.acceptance", pointer: "/previousReleaseEvidence/liveRuntimeSelectable", type: "boolean" },
+        value: false,
+      }],
+    },
+  });
+  const resolved = resolvePolicyProfile(source);
+  const files = {
+    "contracts/spec-v2.json": JSON.stringify({
+      schema: "spec-v2",
+      status: "accepted",
+      accepted: true,
+      conformanceCorpus: "contracts/checks-v2.yaml",
+      owners: { spec: "docs/spec.md" },
+    }),
+    "contracts/checks-v2.yaml": [
+      "contract: spec-v2",
+      "status: accepted",
+      "accepted: true",
+      "requiredGates:",
+      "  - tests/gate.mjs",
+    ].join("\n"),
+    "contracts/spec-v1.json": JSON.stringify({ schema: "spec-v1", status: "accepted", accepted: true, conformanceCorpus: "contracts/checks-v1.json" }),
+    "contracts/checks-v1.json": JSON.stringify({ contract: "spec-v1", status: "accepted", accepted: true }),
+    "cutover/acceptance.json": JSON.stringify({
+      current: { contract: "contracts/spec-v2.json", conformance: "contracts/checks-v2.yaml" },
+      previousReleaseEvidence: { liveRuntimeSelectable: false },
+    }),
+    "docs/spec.md": "# Spec\n",
+    "tests/gate.mjs": "export {};\n",
+  };
+  const run = (overrides = {}) => {
+    const activeFiles = { ...files, ...overrides };
+    return runPolicyPipeline({
+      mode: "check-diff",
+      repositoryRoot: "/tmp/contract-pack-history-test",
+      policy: resolved.policy,
+      changeIntent: null,
+      changeIntentSource: "none",
+      enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+      diffText: "",
+      trackedFiles: Object.keys(activeFiles),
+      readFile: (file) => activeFiles[file],
+      initialChecks: [],
+    }, { quiet: true });
+  };
+
+  const passing = run();
+  expect("synthetic history topology passes ordinary R2 relations", passing.violations.filter((item) => item.rule.startsWith("document-relation:")).length, 0);
+  expect("current-only required path selectors are not copied to previous pair", resolved.policy.document_relations.rules.filter((rule) => rule.kind === "referenced_paths_exist").map((rule) => rule.id), ["contract-conformance:required-path:0", "contract-conformance:required-path:1"]);
+
+  const brokenPrevious = run({ "contracts/checks-v1.json": JSON.stringify({ contract: "wrong-spec", status: "accepted", accepted: true }) });
+  expect("broken previous cross-link fails through ordinary scalar relation", brokenPrevious.violations.some((item) => item.rule === "document-relation:contract-conformance:previous-id"), true);
+
+  const stalePointer = run({
+    "cutover/acceptance.json": JSON.stringify({
+      current: { contract: "contracts/spec-v1.json", conformance: "contracts/checks-v1.json" },
+      previousReleaseEvidence: { liveRuntimeSelectable: false },
+    }),
+  });
+  expect("stale acceptance current pointer fails through ordinary literal relation", stalePointer.violations.some((item) => item.rule === "document-relation:contract-conformance:acceptance-current-contract"), true);
+
+  const consumerVeto = run({
+    "cutover/acceptance.json": JSON.stringify({
+      current: { contract: "contracts/spec-v2.json", conformance: "contracts/checks-v2.yaml" },
+      previousReleaseEvidence: { liveRuntimeSelectable: true },
+    }),
+  });
+  expect("consumer-specific historical veto remains an explicit R2 relation", consumerVeto.violations.some((item) => item.rule === "document-relation:historical-runtime-not-selectable"), true);
 }
 
 console.log("\n--- anum_docs-shaped current topology is data only ---");


### PR DESCRIPTION
Fixes #289

R3b completes the release-topology part of the pure `contract_conformance` macro with optional previous release evidence and an optional acceptance/current-pointer document.

Implemented:
- optional complete `previous` contract/conformance pair emits the same six stable pair checks as `current`, using ordinary R2 document relations only;
- optional `acceptance` document emits ordinary scalar-literal checks for the configured current contract/conformance repository paths;
- optional roles participate in path normalization, collision detection, required-path selector validation, cochange and stable control-path coverage;
- incomplete previous/acceptance shapes fail schema validation;
- stale acceptance pointer and broken previous cross-link fail through ordinary R2 relations;
- current-only `required_paths` selectors are not copied to previous artifacts unless previous is explicitly selected;
- consumer-specific historical veto fields are intentionally not pack fields; regressions prove ordinary explicit R2 relations can reference the macro-generated acceptance document;
- actual `anum_docs` v0.6/v0.7 + Foundation-v2 acceptance path topology is represented as data without MTS-specific core semantics;
- `contract_conformance` disappears after expansion, so strictness remains derived only from ordinary expanded constraints;
- generated `dist/policy-profiles.mjs` remains compiler-produced and passes freshness.

Draft CI #692 is fully green: generated dist freshness, architecture metrics, schema validation, self-integration, doctor, discovered tests, advisory mode and packaged smoke all passed. PR policy is intentionally skipped only while draft.

Diff: 5 files, net +287 lines, no new files/docs; branch is `behind_by=0` and mergeable. No R4 CI/evidence wiring, set relations, SemVer semantics, consumer-specific fields, filesystem/network callbacks or command execution are added.