### PR TITLE
Contract governance R4a: bind path evidence to blocking CI

### DIFF
--- a/dist/checks/constraint-program.mjs
+++ b/dist/checks/constraint-program.mjs
@@ -107,6 +107,18 @@ export function compileConstraintProgram(policy = {}, changeIntent = null) {
             removeBefore: shape, removeAfter: { present: false }, removeMessage: `document_relations rule "${id}" removed` }));
         add(`${owner}:shape`, null, exact(shape, { owner, pointer, rule_id: id, incomparableMessage: `document_relations rule "${id}" changed semantics` }));
     }
+    for (const binding of array(policy.evidence_bindings)) {
+        const id = String(binding.id ?? ""), owner = `evidence-binding:${id}`, pointer = `/evidence_bindings/${id}`;
+        const source = compileDocumentSelector(binding.source, documents);
+        const shape = { kind: binding.kind, source, workflow: binding.workflow, covers: binding.covers };
+        const runtime = binding.kind === "workflow_path_coverage" ? {
+            kind: "evidence_workflow_path_coverage", name: owner, binding_id: id, source,
+            workflow: binding.workflow, covers: array(binding.covers),
+        } : null;
+        add(owner, runtime, entity({ owner, pointer, removeKind: "evidence_binding_removed", evidence_binding_id: id,
+            removeBefore: shape, removeAfter: { present: false }, removeMessage: `evidence binding "${id}" removed` }));
+        add(`${owner}:shape`, null, exact(shape, { owner, pointer, evidence_binding_id: id, incomparableMessage: `evidence binding "${id}" changed semantics` }));
+    }
     if (array(policy.size_rules).length)
         add("runtime:size-rules", { kind: "size_rules", name: "size-rules", rules: policy.size_rules });
     if (array(policy.registry_rules).length)
@@ -139,6 +151,7 @@ function unknownProjection(policy = {}) {
     delete copy.diff_rules;
     delete copy.size_rules;
     delete copy.document_relations;
+    delete copy.evidence_bindings;
     if (copy.paths) {
         for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"])
             delete copy.paths[field];
@@ -153,7 +166,7 @@ function unknownProjection(policy = {}) {
     return copy;
 }
 const relaxation = (entry, before, after = null, kind = entry.weakenKind, message = null, extra = {}) => ({
-    kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}), ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
+    kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}), ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), ...(entry.evidence_binding_id ? { evidence_binding_id: entry.evidence_binding_id } : {}), pointer: entry.pointer, before, after,
     message: message || entry.message?.(before, after) || entry.removeMessage, ...extra,
 });
 const incomparable = (entry, before, after) => ({ kind: "policy_incomparable", pointer: entry.pointer, before, after, message: entry.incomparableMessage || `policy constraint ${entry.key} changed with no proven monotonic ordering` });

--- a/dist/checks/integration-constraints.mjs
+++ b/dist/checks/integration-constraints.mjs
@@ -1,4 +1,5 @@
 import { compareSets } from "./relation-kernel.mjs";
+import { matchesAny } from "../utils/path-patterns.mjs";
 const object = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
 const array = (value) => Array.isArray(value) ? value : [];
 const lower = (value) => String(value || "").toLowerCase();
@@ -53,25 +54,53 @@ const detail = (workflow, fact, message) => `${location(workflow, fact)}: ${mess
 const truthy = (value) => !["", "false", "0", "null"].includes(lower(value).trim());
 const manualClone = (run) => /\bgit\s+clone\b/i.test(String(run || "")) && /repo-guard/i.test(String(run || ""));
 const tempCli = (run) => String(run || "").split(/\r?\n/).some((line) => /RUNNER_TEMP|TMPDIR|\/tmp|\btemp\b/i.test(line) && /src\/repo-guard\.mjs|repo-guard\.mjs/i.test(line));
+function workflowEventDetails(workflow, role) {
+    const details = [], expect = workflow.expect || {}, events = expect.events?.length ? expect.events : ["pull_request"];
+    for (const event of compareSets(events, workflow.triggerEvents, "left_subset").missing)
+        details.push(`${workflow.path}: ${role} workflow missing required event ${event}`);
+    if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target"))
+        details.push(`${workflow.path}: ${role} workflow must run on pull_request or pull_request_target`);
+    if (expect.event_types?.length) {
+        const event = workflow.triggerEvents.includes("pull_request") ? "pull_request" : workflow.triggerEvents.includes("pull_request_target") ? "pull_request_target" : events[0];
+        const actual = workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
+        for (const type of compareSets(expect.event_types, actual, "left_subset").missing)
+            details.push(`${workflow.path}: ${role} workflow missing required ${event} type ${type}`);
+    }
+    return details;
+}
+function commonWorkflowExpectationDetails(workflow, role) {
+    const details = [], expect = workflow.expect || {};
+    for (const [permission, wanted] of Object.entries(expect.permissions || {}))
+        if (!hasPermission(workflow, permission, wanted))
+            details.push(`${workflow.path}: ${role} workflow must declare permission ${permission}: ${wanted}`);
+    if (expect.token_env?.length && !hasEnv(workflow, expect.token_env))
+        details.push(`${workflow.path}: ${role} workflow should provide one of ${expect.token_env.join(", ")}`);
+    if (expect.required_env?.length && !hasAllEnv(workflow, expect.required_env)) {
+        const actual = new Set(workflow.envVars.map((fact) => fact.name));
+        details.push(`${workflow.path}: ${role} workflow missing required env ${expect.required_env.filter((name) => !actual.has(name)).join(", ")}`);
+    }
+    if (expect.summary === true && !workflow.summaryPublishing.length)
+        details.push(`${workflow.path}: ${role} workflow must publish to GITHUB_STEP_SUMMARY`);
+    return details;
+}
+function ciGateDetails(workflow) {
+    const details = [...workflowEventDetails(workflow, "ci_gate"), ...commonWorkflowExpectationDetails(workflow, "ci_gate")], expect = workflow.expect || {};
+    if (expect.enforcement === "blocking" || (expect.disallow || []).includes("continue_on_error"))
+        for (const fact of workflow.continueOnError || [])
+            if (truthy(fact.value))
+                details.push(detail(workflow, fact, "blocking ci_gate step must not set continue-on-error"));
+    return details;
+}
 function workflowDetails(workflow) {
     const details = [], expect = workflow.expect || {};
+    if (workflow.role === "ci_gate")
+        return ciGateDetails(workflow);
     if (workflow.role !== "repo_guard_pr_gate") {
         if (!referencesRepoGuard(workflow))
             details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
         return details;
     }
-    const events = expect.events?.length ? expect.events : ["pull_request"];
-    for (const event of compareSets(events, workflow.triggerEvents, "left_subset").missing)
-        details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required event ${event}`);
-    if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target")) {
-        details.push(`${workflow.path}: repo_guard_pr_gate workflow must run on pull_request or pull_request_target`);
-    }
-    if (expect.event_types?.length) {
-        const event = workflow.triggerEvents.includes("pull_request") ? "pull_request" : "pull_request_target";
-        const actual = workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
-        for (const type of compareSets(expect.event_types, actual, "left_subset").missing)
-            details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required ${event} type ${type}`);
-    }
+    details.push(...workflowEventDetails(workflow, "repo_guard_pr_gate"));
     if (!hasFetchDepthZero(workflow))
         details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
     const actions = repoGuardActions(workflow, expect.action || {});
@@ -81,29 +110,19 @@ function workflowDetails(workflow) {
         details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
     if (actions.length && expect.action) {
         const strategy = expect.action.ref_pinning || "ref";
-        if (!actions.some((fact) => (!expect.action.ref || fact.parsed.ref === expect.action.ref) && pinned(fact.parsed, strategy))) {
+        if (!actions.some((fact) => (!expect.action.ref || fact.parsed.ref === expect.action.ref) && pinned(fact.parsed, strategy)))
             details.push(`${workflow.path}: repo_guard_pr_gate action must satisfy ref_pinning ${strategy}${expect.action.ref ? ` at ref ${expect.action.ref}` : ""}; actual uses: ${actions.map((fact) => fact.uses).join(", ")}`);
-        }
     }
     const mode = expect.mode || "check-pr";
-    for (const [field, wanted] of [["mode", mode], ["enforcement", expect.enforcement]]) {
+    for (const [field, wanted] of [["mode", mode], ["enforcement", expect.enforcement]])
         if (wanted && actions.length && !actions.some((fact) => stepInputs(workflow, fact)[field] === wanted))
             details.push(detail(workflow, actions[0], `repo_guard_pr_gate action must set ${field}: ${wanted}`));
-    }
     if (!actions.length && mode === "check-pr" && !workflow.runCommands.some((fact) => String(fact.run || "").includes("check-pr")))
         details.push(`${workflow.path}: repo_guard_pr_gate workflow must run check-pr`);
-    for (const [permission, wanted] of Object.entries(expect.permissions || {}))
-        if (!hasPermission(workflow, permission, wanted))
-            details.push(`${workflow.path}: repo_guard_pr_gate workflow must declare permission ${permission}: ${wanted}`);
+    details.push(...commonWorkflowExpectationDetails(workflow, "repo_guard_pr_gate"));
     const tokenEnv = expect.token_env || (mode === "check-pr" ? ["GH_TOKEN", "GITHUB_TOKEN"] : []);
-    if (tokenEnv.length && !hasEnv(workflow, tokenEnv))
+    if (!expect.token_env?.length && tokenEnv.length && !hasEnv(workflow, tokenEnv))
         details.push(`${workflow.path}: check-pr workflow should provide one of ${tokenEnv.join(", ")}`);
-    if (expect.required_env?.length && !hasAllEnv(workflow, expect.required_env)) {
-        const actual = new Set(workflow.envVars.map((fact) => fact.name));
-        details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required env ${expect.required_env.filter((name) => !actual.has(name)).join(", ")}`);
-    }
-    if (expect.summary === true && !workflow.summaryPublishing.length)
-        details.push(`${workflow.path}: repo_guard_pr_gate workflow must publish to GITHUB_STEP_SUMMARY`);
     const disallow = new Set(expect.disallow || ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]);
     if (disallow.has("continue_on_error"))
         for (const fact of workflow.continueOnError || [])
@@ -118,6 +137,15 @@ function workflowDetails(workflow) {
             if (tempCli(fact.run))
                 details.push(detail(workflow, fact, "repo_guard_pr_gate workflow must not run repo-guard directly from a temporary clone"));
     return details;
+}
+export function checkWorkflowPathCoverage(integration, binding, referencedPaths) {
+    const workflow = array(integration.workflows).find((item) => item.id === binding.workflow);
+    if (!workflow)
+        return { ok: false, message: `evidence workflow "${binding.workflow}" is unavailable in extracted integration facts`, data: { workflow: binding.workflow, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: referencedPaths } };
+    if (workflow.expect?.enforcement !== "blocking")
+        return { ok: false, message: `evidence workflow "${binding.workflow}" is not configured as blocking`, data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: [] } };
+    const uncoveredPaths = referencedPaths.filter((path) => !matchesAny(path, binding.covers)).sort();
+    return { ok: uncoveredPaths.length === 0, message: uncoveredPaths.length ? `evidence workflow "${binding.workflow}" does not cover all declared repository paths` : undefined, data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: uncoveredPaths } };
 }
 function templateDetails(template) {
     if (template.present === false && template.optional)
@@ -134,22 +162,17 @@ function templateDetails(template) {
             details.push(`${template.path}: ${template.id} ChangeIntent block missing required field "${field}"`);
     return details;
 }
-function missingMentions(doc, facts, label) {
-    return (facts || []).filter((mention) => !mention.present).map((mention) => `${doc.path}: missing required ${label} "${mention.term}"`);
-}
+function missingMentions(doc, facts, label) { return (facts || []).filter((mention) => !mention.present).map((mention) => `${doc.path}: missing required ${label} "${mention.term}"`); }
 export function integrationConstraintEntries(integration = {}) {
     const artifacts = array(integration.errors).map((error) => `${error.section}${error.id ? `:${error.id}` : ""}${error.path ? ` (${error.path})` : ""}: ${error.message}`);
     const workflows = array(integration.workflows).flatMap(workflowDetails);
     const templates = array(integration.templates).flatMap(templateDetails);
-    const docs = array(integration.docs).flatMap((doc) => [
-        ...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"),
-        ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention"),
-    ]);
+    const docs = array(integration.docs).flatMap((doc) => [...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"), ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention")]);
     const profiles = array(integration.profiles).flatMap((profile) => profile.profileNameReferences?.length ? [] : [`${profile.docPath}: profile "${profile.id}" is not mentioned`]);
     const entry = (name, details, pass, fail, hint) => ({ name, check: details.length ? { ok: false, message: fail, details, hint } : { ok: true, message: pass } });
     return [
         entry("integration-artifacts", artifacts, "All declared integration artifacts were read and parsed", "Integration artifact extraction failed", "Fix missing files, malformed workflow YAML, malformed ChangeIntent blocks, or Markdown fences"),
-        entry("integration-workflows", workflows, "Workflow integration wiring is valid", "Workflow integration wiring has issues", "Compare declared repo-guard workflows with templates/example-workflow.yml"),
+        entry("integration-workflows", workflows, "Workflow integration wiring is valid", "Workflow integration wiring has issues", "Compare declared workflows with their configured integration expectations"),
         entry("integration-templates", templates, "Template integration wiring is valid", "Template integration wiring has issues", "Add repo-guard-yaml or repo-guard-json fenced ChangeIntent blocks to required templates"),
         entry("integration-docs", docs, "Documentation integration wiring is valid", "Documentation integration wiring has issues", "Update declared docs so every must_mention term appears"),
         entry("integration-profiles", profiles, "Profile documentation wiring is valid", "Profile documentation wiring has issues", "Mention each integration profile id in its declared profile document"),

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -3,7 +3,7 @@ import { selectPaths } from "../../diff/classification.mjs";
 import { readDocumentFact } from "../../document-facts.mjs";
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
-import { integrationConstraintEntries } from "../integration-constraints.mjs";
+import { checkWorkflowPathCoverage, integrationConstraintEntries } from "../integration-constraints.mjs";
 import { checkTraceRuleResult } from "../trace-rules.mjs";
 import { checkChangeProfile } from "./change-profiles.mjs";
 import { checkRegistryRules } from "./registry-rules.mjs";
@@ -116,6 +116,26 @@ function checkDocumentReferencedPathsExist(facts, constraint) {
         data: { kind: "referenced_paths_exist", source, referenced_paths: referencedPaths, missing_paths: missingPaths },
     };
 }
+function checkEvidenceWorkflowPathCoverage(facts, constraint) {
+    const source = factOperand(facts.documents, constraint.source);
+    if (!source.ok)
+        return {
+            ok: false,
+            message: `evidence binding "${constraint.binding_id}" could not read repository path references`,
+            data: { kind: "workflow_path_coverage", binding_id: constraint.binding_id, source },
+        };
+    if (!Array.isArray(source.value))
+        return {
+            ok: false,
+            message: `evidence binding "${constraint.binding_id}" did not produce a repository path set`,
+            data: { kind: "workflow_path_coverage", binding_id: constraint.binding_id, source },
+        };
+    const coverage = checkWorkflowPathCoverage(facts.integration, { workflow: constraint.workflow || "", covers: constraint.covers || [] }, source.value);
+    return {
+        ...coverage,
+        data: { kind: "workflow_path_coverage", binding_id: constraint.binding_id, source, ...coverage.data },
+    };
+}
 export function evaluateConstraintIR(facts, context = {}) {
     const { files, constraints } = compileConstraintIR(facts), results = [], cochange = [];
     for (const constraint of constraints) {
@@ -170,6 +190,8 @@ export function evaluateConstraintIR(facts, context = {}) {
             check = checkDocumentScalarLiteral(facts, constraint);
         else if (constraint.kind === "document_referenced_paths_exist")
             check = checkDocumentReferencedPathsExist(facts, constraint);
+        else if (constraint.kind === "evidence_workflow_path_coverage")
+            check = checkEvidenceWorkflowPathCoverage(facts, constraint);
         else
             continue;
         results.push({ name: constraint.name, check });

--- a/dist/policy-compiler.mjs
+++ b/dist/policy-compiler.mjs
@@ -84,6 +84,17 @@ export function compileIntegrationPolicy(policy = {}) {
             if (section === "profiles")
                 profileIds.add(id);
         }
+        if (section === "workflows" && entry.role === "ci_gate") {
+            const expect = object(entry.expect);
+            for (const field of ["action", "mode"])
+                if (expect[field] !== undefined) {
+                    errors.push({ section, id, index, field, message: `integration.workflows[${index}].expect.${field} is not supported for ci_gate` });
+                }
+            for (const disallowed of list(expect.disallow))
+                if (disallowed !== "continue_on_error") {
+                    errors.push({ section, id, index, field: "disallow", message: `integration.workflows[${index}].expect.disallow value "${disallowed}" is repo-guard-specific and not supported for ci_gate` });
+                }
+        }
         for (const profileId of list(entry.profiles))
             references.push({ section, index, field: "profiles", profileId });
         if (section === "docs")
@@ -115,6 +126,10 @@ function normalizeDeclaredDocumentPath(name, definition, errors) {
         errors.push({ document: name, path: definition.path, message: `document_relations.documents["${name}"].path is invalid: ${error.message}` });
         return null;
     }
+}
+function documentSelectorKey(value) {
+    const selector = object(value);
+    return JSON.stringify({ document: selector.document, pointer: selector.pointer, projection: selector.projection, type: selector.type });
 }
 export function compileDocumentRelationsPolicy(policy = {}) {
     if (!policy.document_relations)
@@ -155,6 +170,42 @@ export function compileDocumentRelationsPolicy(policy = {}) {
         if (!usedDocuments.has(name)) {
             errors.push({ document: name, message: `document_relations.documents["${name}"] is declared but unused` });
         }
+    return errors;
+}
+export function compileEvidenceBindingsPolicy(policy = {}) {
+    const bindings = list(policy.evidence_bindings);
+    if (!bindings.length)
+        return [];
+    const errors = [], seenIds = new Set();
+    const relationSection = object(policy.document_relations), documents = object(relationSection.documents), relationRules = list(relationSection.rules);
+    const pathExistenceSelectors = new Set(relationRules.filter((rule) => rule.kind === "referenced_paths_exist").map((rule) => documentSelectorKey(rule.source)));
+    const workflows = new Map();
+    for (const workflow of list(object(policy.integration).workflows))
+        if (typeof workflow.id === "string" && workflow.id)
+            workflows.set(workflow.id, workflow);
+    for (const [index, binding] of bindings.entries()) {
+        const id = binding.id;
+        if (seenIds.has(id))
+            errors.push({ evidence_binding: id, index, message: `evidence_bindings[${index}].id duplicates binding "${id}"` });
+        seenIds.add(id);
+        if (binding.kind !== "workflow_path_coverage")
+            continue;
+        const source = object(binding.source), document = source.document;
+        if (typeof document !== "string" || !Object.hasOwn(documents, document)) {
+            errors.push({ evidence_binding: id, document, message: `evidence binding "${id}" source references unknown document "${document}"` });
+        }
+        const workflowId = binding.workflow;
+        const workflow = typeof workflowId === "string" ? workflows.get(workflowId) : undefined;
+        if (!workflow) {
+            errors.push({ evidence_binding: id, workflow: workflowId, message: `evidence binding "${id}" references unknown integration workflow "${workflowId}"` });
+        }
+        else if (object(workflow.expect).enforcement !== "blocking") {
+            errors.push({ evidence_binding: id, workflow: workflowId, message: `evidence binding "${id}" requires integration workflow "${workflowId}" to declare expect.enforcement "blocking"` });
+        }
+        if (!pathExistenceSelectors.has(documentSelectorKey(source))) {
+            errors.push({ evidence_binding: id, message: `evidence binding "${id}" requires an equivalent referenced_paths_exist relation for the same source selector` });
+        }
+    }
     return errors;
 }
 export function warnReservedPolicyFields(policy = {}) {

--- a/dist/runtime/validation.mjs
+++ b/dist/runtime/validation.mjs
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileEvidenceBindingsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
 import { resolvePolicyProfile } from "../policy-profiles.mjs";
 export const loadJSON = (path) => JSON.parse(readFileSync(path, "utf-8"));
 // Draft-07 разрешает массив типов. Оставляем Ajv strict mode включённым, но явно
@@ -34,6 +34,7 @@ export function loadPolicyRuntimeFromObject(roots, rawPolicy, options = {}) {
         ["anchor policy compilation", compileAnchorPolicy(policy), (error) => error.message],
         ["integration policy compilation", compileIntegrationPolicy(policy), (error) => error.message],
         ["document relation policy compilation", compileDocumentRelationsPolicy(policy), (error) => error.message],
+        ["evidence binding policy compilation", compileEvidenceBindingsPolicy(policy), (error) => error.message],
     ];
     for (const [group, errors, format] of semanticGroups)
         if (errors.length) {

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -49,12 +49,12 @@
     },
     "integration": {
       "type": "object",
-      "description": "Declarative downstream integration layer for documenting which workflows run repo-guard, which templates carry ChangeIntent blocks, which docs explain ChangeIntent, and which profiles are documented. Accepted as policy metadata; file parsing and enforcement are outside this schema layer.",
+      "description": "Declarative downstream integration layer for workflows, templates, documentation, and profiles. Accepted as policy metadata; file parsing and enforcement are outside this schema layer.",
       "additionalProperties": false,
       "properties": {
         "workflows": {
           "type": "array",
-          "description": "Expected automation entry points that invoke repo-guard.",
+          "description": "Expected automation entry points, including repo-guard workflows and generic CI gates.",
           "items": { "$ref": "#/definitions/integration_workflow" }
         },
         "templates": {
@@ -244,6 +244,9 @@
     },
     "contract_conformance": {
       "$ref": "#/definitions/contract_conformance"
+    },
+    "evidence_bindings": {
+      "$ref": "#/definitions/evidence_bindings"
     },
     "advisory_text_rules": {
       "type": "object",
@@ -540,6 +543,27 @@
         }
       ]
     },
+    "evidence_bindings": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/evidence_binding" }
+    },
+    "evidence_binding": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["id", "kind", "source", "workflow", "covers"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "$ref": "#/definitions/non_empty_string" },
+            "kind": { "const": "workflow_path_coverage" },
+            "source": { "$ref": "#/definitions/document_repository_path_set_selector" },
+            "workflow": { "$ref": "#/definitions/non_empty_string" },
+            "covers": { "$ref": "#/definitions/non_empty_string_array" }
+          }
+        }
+      ]
+    },
     "profile_overrides": {
       "type": "object",
       "additionalProperties": false,
@@ -632,8 +656,8 @@
         "path": { "$ref": "#/definitions/non_empty_string" },
         "role": {
           "type": "string",
-          "enum": ["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate"],
-          "description": "Supported repo-guard role for this workflow."
+          "enum": ["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate", "ci_gate"],
+          "description": "Supported integration role for this workflow."
         },
         "expect": { "$ref": "#/definitions/integration_workflow_expectation" },
         "profiles": { "$ref": "#/definitions/non_empty_string_array" }
@@ -642,7 +666,7 @@
     "integration_workflow_expectation": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Optional workflow expectations checked by validate-integration for repo-guard workflow roles.",
+      "description": "Optional workflow expectations checked by validate-integration.",
       "properties": {
         "events": { "$ref": "#/definitions/non_empty_string_array" },
         "event_types": { "$ref": "#/definitions/non_empty_string_array" },

--- a/src/checks/constraint-program.mts
+++ b/src/checks/constraint-program.mts
@@ -7,7 +7,7 @@ type SetRelation = "superset_stricter" | "subset_stricter";
 type StrictnessRelation = RankRelation | SetRelation | "equal_or_incomparable" | "required_entity";
 type ComparisonRelation = "equal" | "weaker" | "incomparable" | "stricter";
 type DiagnosticValue = string | number | boolean | null | undefined;
-type DocumentScalarType = "scalar" | "string" | "boolean";
+type DocumentFactType = "scalar" | "string" | "boolean" | "string_set" | "repository_path" | "repository_path_set";
 
 interface StrictnessMetadata {
   owner?: string;
@@ -18,6 +18,7 @@ interface StrictnessMetadata {
   field?: string;
   rule_id?: string;
   workflow_id?: string;
+  evidence_binding_id?: string;
   raw?: DiagnosticValue;
   removeBefore?: unknown;
   removeAfter?: unknown;
@@ -97,9 +98,10 @@ interface DocumentDefinitionProjection {
   format?: unknown;
 }
 
-interface DocumentScalarSelectorProjection {
+interface DocumentSelectorProjection {
   document?: unknown;
   pointer?: unknown;
+  projection?: unknown;
   type?: unknown;
 }
 
@@ -117,6 +119,14 @@ interface DocumentRelationsProjection {
   rules?: DocumentRelationRuleProjection[];
 }
 
+interface EvidenceBindingProjection {
+  id?: unknown;
+  kind?: unknown;
+  source?: DocumentSelectorProjection;
+  workflow?: unknown;
+  covers?: unknown;
+}
+
 export interface ConstraintPolicyProjection {
   diff_rules?: DiffRulesProjection;
   paths?: PathsProjection;
@@ -128,6 +138,7 @@ export interface ConstraintPolicyProjection {
   change_profiles?: unknown;
   cochange_rules?: CochangeRuleProjection[];
   document_relations?: DocumentRelationsProjection;
+  evidence_bindings?: EvidenceBindingProjection[];
 }
 
 interface ChangeIntentProjection {
@@ -147,6 +158,7 @@ export interface PolicyRelaxation {
   rule_id?: string;
   field?: string;
   workflow_id?: string;
+  evidence_binding_id?: string;
   [key: string]: unknown;
 }
 
@@ -192,7 +204,7 @@ function compileDocumentSelector(selectorValue: unknown, documents: Record<strin
     format: definition.format,
     pointer: typeof selector.pointer === "string" ? selector.pointer : "",
     projection: selector.projection,
-    type: selector.type as DocumentScalarType,
+    type: selector.type as DocumentFactType,
   };
 }
 
@@ -275,6 +287,19 @@ export function compileConstraintProgram(policy: ConstraintPolicyProjection = {}
     add(`${owner}:shape`, null, exact(shape, { owner, pointer, rule_id: id, incomparableMessage: `document_relations rule "${id}" changed semantics` }));
   }
 
+  for (const binding of array(policy.evidence_bindings)) {
+    const id = String(binding.id ?? ""), owner = `evidence-binding:${id}`, pointer = `/evidence_bindings/${id}`;
+    const source = compileDocumentSelector(binding.source, documents);
+    const shape = { kind: binding.kind, source, workflow: binding.workflow, covers: binding.covers };
+    const runtime = binding.kind === "workflow_path_coverage" ? {
+      kind: "evidence_workflow_path_coverage", name: owner, binding_id: id, source,
+      workflow: binding.workflow, covers: array(binding.covers as string[] | undefined),
+    } : null;
+    add(owner, runtime, entity({ owner, pointer, removeKind: "evidence_binding_removed", evidence_binding_id: id,
+      removeBefore: shape, removeAfter: { present: false }, removeMessage: `evidence binding "${id}" removed` }));
+    add(`${owner}:shape`, null, exact(shape, { owner, pointer, evidence_binding_id: id, incomparableMessage: `evidence binding "${id}" changed semantics` }));
+  }
+
   if (array(policy.size_rules).length) add("runtime:size-rules", { kind: "size_rules", name: "size-rules", rules: policy.size_rules });
   if (array(policy.registry_rules).length) add("runtime:registry-rules", { kind: "registry_rules", name: "registry-rules", rules: policy.registry_rules });
   if (array(policy.trace_rules).length) add("runtime:trace-rules", { kind: "trace_rules", name: "trace-rules" });
@@ -296,13 +321,13 @@ function canonical(value: unknown): unknown { if (Array.isArray(value)) return v
 const same = (a: unknown, b: unknown): boolean => JSON.stringify(canonical(a)) === JSON.stringify(canonical(b));
 const clone = <T,>(value: T): T | undefined => value === undefined ? undefined : structuredClone(value);
 function unknownProjection(policy: ConstraintPolicyProjection = {}): ConstraintPolicyProjection {
-  const copy = clone(policy) || {}; delete copy.enforcement; delete copy.diff_rules; delete copy.size_rules; delete copy.document_relations;
+  const copy = clone(policy) || {}; delete copy.enforcement; delete copy.diff_rules; delete copy.size_rules; delete copy.document_relations; delete copy.evidence_bindings;
   if (copy.paths) { for (const field of ["forbidden", "governance_paths", "operational_paths", "canonical_docs"]) delete copy.paths[field as keyof PathsProjection]; if (!Object.keys(copy.paths).length) delete copy.paths; }
   if (copy.integration) { delete copy.integration.workflows; if (!Object.keys(copy.integration).length) delete copy.integration; }
   return copy;
 }
 const relaxation = (entry: StrictnessProgramEntry, before: unknown, after: unknown = null, kind = entry.weakenKind as string, message: string | null = null, extra: Record<string, unknown> = {}): PolicyRelaxation => ({
-  kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}), ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), pointer: entry.pointer, before, after,
+  kind, ...(entry.rule_id ? { rule_id: entry.rule_id } : {}), ...(entry.field ? { field: entry.field } : {}), ...(entry.workflow_id ? { workflow_id: entry.workflow_id } : {}), ...(entry.evidence_binding_id ? { evidence_binding_id: entry.evidence_binding_id } : {}), pointer: entry.pointer, before, after,
   message: message || entry.message?.(before as string | number, after as string | number) || entry.removeMessage, ...extra,
 });
 const incomparable = (entry: StrictnessProgramEntry, before: unknown, after: unknown): PolicyIncomparableChange => ({ kind: "policy_incomparable", pointer: entry.pointer, before, after, message: entry.incomparableMessage || `policy constraint ${entry.key} changed with no proven monotonic ordering` });

--- a/src/checks/integration-constraints.mts
+++ b/src/checks/integration-constraints.mts
@@ -8,47 +8,15 @@ interface FactLocation {
   stepIndex?: number;
   stepName?: string;
 }
-
-interface ActionUseFact extends FactLocation {
-  uses: string;
-}
-
-interface StepInputFact extends ActionUseFact {
-  inputs?: Record<string, string>;
-}
-
-interface RunCommandFact extends FactLocation {
-  run?: unknown;
-}
-
-interface EnvVarFact {
-  name: string;
-}
-
-interface ContinueOnErrorFact extends FactLocation {
-  value?: unknown;
-}
-
-interface JobPermissionFact {
-  permissions?: unknown;
-}
-
-interface WorkflowPermissions {
-  workflow?: unknown;
-  jobs: JobPermissionFact[];
-}
-
-interface TriggerEventTypeFact {
-  event: string;
-  types?: string[];
-}
-
-interface ExpectedActionUse {
-  uses?: string;
-  ref_pinning?: RefPinning;
-  ref?: string;
-}
-
+interface ActionUseFact extends FactLocation { uses: string; }
+interface StepInputFact extends ActionUseFact { inputs?: Record<string, string>; }
+interface RunCommandFact extends FactLocation { run?: unknown; }
+interface EnvVarFact { name: string; }
+interface ContinueOnErrorFact extends FactLocation { value?: unknown; }
+interface JobPermissionFact { permissions?: unknown; }
+interface WorkflowPermissions { workflow?: unknown; jobs: JobPermissionFact[]; }
+interface TriggerEventTypeFact { event: string; types?: string[]; }
+interface ExpectedActionUse { uses?: string; ref_pinning?: RefPinning; ref?: string; }
 interface WorkflowExpectation {
   events?: string[];
   event_types?: string[];
@@ -61,7 +29,6 @@ interface WorkflowExpectation {
   summary?: boolean;
   disallow?: string[];
 }
-
 interface WorkflowFact {
   id: string;
   path: string;
@@ -77,21 +44,10 @@ interface WorkflowFact {
   summaryPublishing: unknown[];
   continueOnError?: ContinueOnErrorFact[];
 }
-
 interface ActionUse extends ActionUseFact {
-  parsed: {
-    raw: string;
-    target: string;
-    ref: string;
-    local: boolean;
-  };
+  parsed: { raw: string; target: string; ref: string; local: boolean };
 }
-
-interface ChangeIntentBlockFact {
-  format?: string;
-  fieldPaths?: string[];
-}
-
+interface ChangeIntentBlockFact { format?: string; fieldPaths?: string[]; }
 interface TemplateFact {
   id: string;
   path: string;
@@ -104,12 +60,7 @@ interface TemplateFact {
   hasRepoGuardJsonBlock?: boolean;
   requiredChangeIntentFields?: string[];
 }
-
-interface MentionFact {
-  present?: boolean;
-  term: string;
-}
-
+interface MentionFact { present?: boolean; term: string; }
 interface DocFact {
   path: string;
   mentions?: MentionFact[];
@@ -117,20 +68,8 @@ interface DocFact {
   profileMentions?: MentionFact[];
   changeIntentFieldMentions?: MentionFact[];
 }
-
-interface ProfileFact {
-  id: string;
-  docPath: string;
-  profileNameReferences?: unknown[];
-}
-
-interface IntegrationErrorFact {
-  section: string;
-  id?: string;
-  path?: string;
-  message: string;
-}
-
+interface ProfileFact { id: string; docPath: string; profileNameReferences?: unknown[]; }
+interface IntegrationErrorFact { section: string; id?: string; path?: string; message: string; }
 export interface IntegrationFacts {
   errors?: IntegrationErrorFact[];
   workflows?: WorkflowFact[];
@@ -138,21 +77,11 @@ export interface IntegrationFacts {
   docs?: DocFact[];
   profiles?: ProfileFact[];
 }
-
 export interface IntegrationCheckEntry {
   name: string;
-  check: {
-    ok: boolean;
-    message: string;
-    details?: string[];
-    hint?: string;
-  };
+  check: { ok: boolean; message: string; details?: string[]; hint?: string };
 }
-
-export interface WorkflowPathCoverageBinding {
-  workflow: string;
-  covers: string[];
-}
+export interface WorkflowPathCoverageBinding { workflow: string; covers: string[]; }
 
 const object = (value: unknown): Record<string, unknown> => value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 const array = <T,>(value: T[] | null | undefined): T[] => Array.isArray(value) ? value : [];
@@ -178,8 +107,7 @@ function pinned(use: ReturnType<typeof actionUse>, strategy: RefPinning = "ref")
   return use.ref.length > 0;
 }
 const stepInputs = (workflow: WorkflowFact, action: ActionUseFact): Record<string, string> => workflow.stepInputs.find((fact) => fact.jobId === action.jobId && fact.stepIndex === action.stepIndex && fact.uses === action.uses)?.inputs || {};
-const repoGuardActions = (workflow: WorkflowFact, expected: ExpectedActionUse = {}): ActionUse[] => workflow.actionUses.map((fact) => ({ ...fact, parsed: actionUse(fact.uses) })).filter((fact) =>
-  expected.uses ? fact.parsed.target === expected.uses || fact.uses === expected.uses : repoGuardUse(fact.uses));
+const repoGuardActions = (workflow: WorkflowFact, expected: ExpectedActionUse = {}): ActionUse[] => workflow.actionUses.map((fact) => ({ ...fact, parsed: actionUse(fact.uses) })).filter((fact) => expected.uses ? fact.parsed.target === expected.uses || fact.uses === expected.uses : repoGuardUse(fact.uses));
 const referencesRepoGuard = (workflow: WorkflowFact): boolean => workflow.actionUses.some((fact) => repoGuardUse(fact.uses)) || workflow.runCommands.some((fact) => /repo-guard|src\/repo-guard\.mjs/i.test(String(fact.run || "")));
 const hasFetchDepthZero = (workflow: WorkflowFact): boolean => workflow.stepInputs.some((fact) => lower(fact.uses).startsWith("actions/checkout") && fact.inputs?.["fetch-depth"] === "0");
 const hasEnv = (workflow: WorkflowFact, names: string[]): boolean => { const actual = new Set(workflow.envVars.map((fact) => fact.name)); return names.some((name) => actual.has(name)); };
@@ -203,9 +131,7 @@ const tempCli = (run: unknown): boolean => String(run || "").split(/\r?\n/).some
 function workflowEventDetails(workflow: WorkflowFact, role: string): string[] {
   const details: string[] = [], expect = workflow.expect || {}, events = expect.events?.length ? expect.events : ["pull_request"];
   for (const event of compareSets(events, workflow.triggerEvents, "left_subset").missing) details.push(`${workflow.path}: ${role} workflow missing required event ${event}`);
-  if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target")) {
-    details.push(`${workflow.path}: ${role} workflow must run on pull_request or pull_request_target`);
-  }
+  if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target")) details.push(`${workflow.path}: ${role} workflow must run on pull_request or pull_request_target`);
   if (expect.event_types?.length) {
     const event = workflow.triggerEvents.includes("pull_request") ? "pull_request" : workflow.triggerEvents.includes("pull_request_target") ? "pull_request_target" : events[0];
     const actual = workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
@@ -214,12 +140,21 @@ function workflowEventDetails(workflow: WorkflowFact, role: string): string[] {
   return details;
 }
 
-function ciGateDetails(workflow: WorkflowFact): string[] {
-  const details = workflowEventDetails(workflow, "ci_gate"), expect = workflow.expect || {};
-  const disallowContinueOnError = expect.enforcement === "blocking" || (expect.disallow || []).includes("continue_on_error");
-  if (disallowContinueOnError) for (const fact of workflow.continueOnError || []) if (truthy(fact.value)) {
-    details.push(detail(workflow, fact, "blocking ci_gate step must not set continue-on-error"));
+function commonWorkflowExpectationDetails(workflow: WorkflowFact, role: string): string[] {
+  const details: string[] = [], expect = workflow.expect || {};
+  for (const [permission, wanted] of Object.entries(expect.permissions || {})) if (!hasPermission(workflow, permission, wanted)) details.push(`${workflow.path}: ${role} workflow must declare permission ${permission}: ${wanted}`);
+  if (expect.token_env?.length && !hasEnv(workflow, expect.token_env)) details.push(`${workflow.path}: ${role} workflow should provide one of ${expect.token_env.join(", ")}`);
+  if (expect.required_env?.length && !hasAllEnv(workflow, expect.required_env)) {
+    const actual = new Set(workflow.envVars.map((fact) => fact.name));
+    details.push(`${workflow.path}: ${role} workflow missing required env ${expect.required_env.filter((name) => !actual.has(name)).join(", ")}`);
   }
+  if (expect.summary === true && !workflow.summaryPublishing.length) details.push(`${workflow.path}: ${role} workflow must publish to GITHUB_STEP_SUMMARY`);
+  return details;
+}
+
+function ciGateDetails(workflow: WorkflowFact): string[] {
+  const details = [...workflowEventDetails(workflow, "ci_gate"), ...commonWorkflowExpectationDetails(workflow, "ci_gate")], expect = workflow.expect || {};
+  if (expect.enforcement === "blocking" || (expect.disallow || []).includes("continue_on_error")) for (const fact of workflow.continueOnError || []) if (truthy(fact.value)) details.push(detail(workflow, fact, "blocking ci_gate step must not set continue-on-error"));
   return details;
 }
 
@@ -233,29 +168,19 @@ function workflowDetails(workflow: WorkflowFact): string[] {
 
   details.push(...workflowEventDetails(workflow, "repo_guard_pr_gate"));
   if (!hasFetchDepthZero(workflow)) details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
-
   const actions = repoGuardActions(workflow, expect.action || {});
   if (expect.action && !actions.length) details.push(`${workflow.path}: repo_guard_pr_gate workflow must use ${expect.action.uses || "a repo-guard action"} via uses`);
   if (!expect.action && !referencesRepoGuard(workflow)) details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
   if (actions.length && expect.action) {
     const strategy = expect.action.ref_pinning || "ref";
-    if (!actions.some((fact) => (!expect.action!.ref || fact.parsed.ref === expect.action!.ref) && pinned(fact.parsed, strategy))) {
-      details.push(`${workflow.path}: repo_guard_pr_gate action must satisfy ref_pinning ${strategy}${expect.action.ref ? ` at ref ${expect.action.ref}` : ""}; actual uses: ${actions.map((fact) => fact.uses).join(", ")}`);
-    }
+    if (!actions.some((fact) => (!expect.action!.ref || fact.parsed.ref === expect.action!.ref) && pinned(fact.parsed, strategy))) details.push(`${workflow.path}: repo_guard_pr_gate action must satisfy ref_pinning ${strategy}${expect.action.ref ? ` at ref ${expect.action.ref}` : ""}; actual uses: ${actions.map((fact) => fact.uses).join(", ")}`);
   }
   const mode = expect.mode || "check-pr";
-  for (const [field, wanted] of [["mode", mode], ["enforcement", expect.enforcement]]) {
-    if (wanted && actions.length && !actions.some((fact) => stepInputs(workflow, fact)[field!] === wanted)) details.push(detail(workflow, actions[0], `repo_guard_pr_gate action must set ${field}: ${wanted}`));
-  }
+  for (const [field, wanted] of [["mode", mode], ["enforcement", expect.enforcement]]) if (wanted && actions.length && !actions.some((fact) => stepInputs(workflow, fact)[field!] === wanted)) details.push(detail(workflow, actions[0], `repo_guard_pr_gate action must set ${field}: ${wanted}`));
   if (!actions.length && mode === "check-pr" && !workflow.runCommands.some((fact) => String(fact.run || "").includes("check-pr"))) details.push(`${workflow.path}: repo_guard_pr_gate workflow must run check-pr`);
-  for (const [permission, wanted] of Object.entries(expect.permissions || {})) if (!hasPermission(workflow, permission, wanted)) details.push(`${workflow.path}: repo_guard_pr_gate workflow must declare permission ${permission}: ${wanted}`);
+  details.push(...commonWorkflowExpectationDetails(workflow, "repo_guard_pr_gate"));
   const tokenEnv = expect.token_env || (mode === "check-pr" ? ["GH_TOKEN", "GITHUB_TOKEN"] : []);
-  if (tokenEnv.length && !hasEnv(workflow, tokenEnv)) details.push(`${workflow.path}: check-pr workflow should provide one of ${tokenEnv.join(", ")}`);
-  if (expect.required_env?.length && !hasAllEnv(workflow, expect.required_env)) {
-    const actual = new Set(workflow.envVars.map((fact) => fact.name));
-    details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required env ${expect.required_env.filter((name) => !actual.has(name)).join(", ")}`);
-  }
-  if (expect.summary === true && !workflow.summaryPublishing.length) details.push(`${workflow.path}: repo_guard_pr_gate workflow must publish to GITHUB_STEP_SUMMARY`);
+  if (!expect.token_env?.length && tokenEnv.length && !hasEnv(workflow, tokenEnv)) details.push(`${workflow.path}: check-pr workflow should provide one of ${tokenEnv.join(", ")}`);
 
   const disallow = new Set(expect.disallow || ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]);
   if (disallow.has("continue_on_error")) for (const fact of workflow.continueOnError || []) if (truthy(fact.value)) details.push(detail(workflow, fact, "repo_guard_pr_gate step must not set continue-on-error"));
@@ -266,22 +191,10 @@ function workflowDetails(workflow: WorkflowFact): string[] {
 
 export function checkWorkflowPathCoverage(integration: IntegrationFacts, binding: WorkflowPathCoverageBinding, referencedPaths: string[]) {
   const workflow = array(integration.workflows).find((item) => item.id === binding.workflow);
-  if (!workflow) return {
-    ok: false,
-    message: `evidence workflow "${binding.workflow}" is unavailable in extracted integration facts`,
-    data: { workflow: binding.workflow, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: referencedPaths },
-  };
-  if (workflow.expect?.enforcement !== "blocking") return {
-    ok: false,
-    message: `evidence workflow "${binding.workflow}" is not configured as blocking`,
-    data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: [] },
-  };
+  if (!workflow) return { ok: false, message: `evidence workflow "${binding.workflow}" is unavailable in extracted integration facts`, data: { workflow: binding.workflow, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: referencedPaths } };
+  if (workflow.expect?.enforcement !== "blocking") return { ok: false, message: `evidence workflow "${binding.workflow}" is not configured as blocking`, data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: [] } };
   const uncoveredPaths = referencedPaths.filter((path) => !matchesAny(path, binding.covers)).sort();
-  return {
-    ok: uncoveredPaths.length === 0,
-    message: uncoveredPaths.length ? `evidence workflow "${binding.workflow}" does not cover all declared repository paths` : undefined,
-    data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: uncoveredPaths },
-  };
+  return { ok: uncoveredPaths.length === 0, message: uncoveredPaths.length ? `evidence workflow "${binding.workflow}" does not cover all declared repository paths` : undefined, data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: uncoveredPaths } };
 }
 
 function templateDetails(template: TemplateFact): string[] {
@@ -294,18 +207,13 @@ function templateDetails(template: TemplateFact): string[] {
   for (const field of template.requiredChangeIntentFields || []) if (!fields.has(field)) details.push(`${template.path}: ${template.id} ChangeIntent block missing required field "${field}"`);
   return details;
 }
-function missingMentions(doc: DocFact, facts: MentionFact[] | undefined, label: string): string[] {
-  return (facts || []).filter((mention) => !mention.present).map((mention) => `${doc.path}: missing required ${label} "${mention.term}"`);
-}
+function missingMentions(doc: DocFact, facts: MentionFact[] | undefined, label: string): string[] { return (facts || []).filter((mention) => !mention.present).map((mention) => `${doc.path}: missing required ${label} "${mention.term}"`); }
 
 export function integrationConstraintEntries(integration: IntegrationFacts = {}): IntegrationCheckEntry[] {
   const artifacts = array(integration.errors).map((error) => `${error.section}${error.id ? `:${error.id}` : ""}${error.path ? ` (${error.path})` : ""}: ${error.message}`);
   const workflows = array(integration.workflows).flatMap(workflowDetails);
   const templates = array(integration.templates).flatMap(templateDetails);
-  const docs = array(integration.docs).flatMap((doc) => [
-    ...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"),
-    ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention"),
-  ]);
+  const docs = array(integration.docs).flatMap((doc) => [...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"), ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention")]);
   const profiles = array(integration.profiles).flatMap((profile) => profile.profileNameReferences?.length ? [] : [`${profile.docPath}: profile "${profile.id}" is not mentioned`]);
   const entry = (name: string, details: string[], pass: string, fail: string, hint: string): IntegrationCheckEntry => ({ name, check: details.length ? { ok: false, message: fail, details, hint } : { ok: true, message: pass } });
   return [

--- a/src/checks/integration-constraints.mts
+++ b/src/checks/integration-constraints.mts
@@ -1,4 +1,5 @@
 import { compareSets } from "./relation-kernel.mjs";
+import { matchesAny } from "../utils/path-patterns.mjs";
 
 type RefPinning = "any" | "local" | "sha" | "semver" | "tag" | "ref" | string;
 
@@ -62,6 +63,7 @@ interface WorkflowExpectation {
 }
 
 interface WorkflowFact {
+  id: string;
   path: string;
   role?: string;
   expect?: WorkflowExpectation;
@@ -147,6 +149,11 @@ export interface IntegrationCheckEntry {
   };
 }
 
+export interface WorkflowPathCoverageBinding {
+  workflow: string;
+  covers: string[];
+}
+
 const object = (value: unknown): Record<string, unknown> => value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
 const array = <T,>(value: T[] | null | undefined): T[] => Array.isArray(value) ? value : [];
 const lower = (value: unknown): string => String(value || "").toLowerCase();
@@ -193,23 +200,38 @@ const truthy = (value: unknown): boolean => !["", "false", "0", "null"].includes
 const manualClone = (run: unknown): boolean => /\bgit\s+clone\b/i.test(String(run || "")) && /repo-guard/i.test(String(run || ""));
 const tempCli = (run: unknown): boolean => String(run || "").split(/\r?\n/).some((line) => /RUNNER_TEMP|TMPDIR|\/tmp|\btemp\b/i.test(line) && /src\/repo-guard\.mjs|repo-guard\.mjs/i.test(line));
 
+function workflowEventDetails(workflow: WorkflowFact, role: string): string[] {
+  const details: string[] = [], expect = workflow.expect || {}, events = expect.events?.length ? expect.events : ["pull_request"];
+  for (const event of compareSets(events, workflow.triggerEvents, "left_subset").missing) details.push(`${workflow.path}: ${role} workflow missing required event ${event}`);
+  if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target")) {
+    details.push(`${workflow.path}: ${role} workflow must run on pull_request or pull_request_target`);
+  }
+  if (expect.event_types?.length) {
+    const event = workflow.triggerEvents.includes("pull_request") ? "pull_request" : workflow.triggerEvents.includes("pull_request_target") ? "pull_request_target" : events[0];
+    const actual = workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
+    for (const type of compareSets(expect.event_types, actual, "left_subset").missing) details.push(`${workflow.path}: ${role} workflow missing required ${event} type ${type}`);
+  }
+  return details;
+}
+
+function ciGateDetails(workflow: WorkflowFact): string[] {
+  const details = workflowEventDetails(workflow, "ci_gate"), expect = workflow.expect || {};
+  const disallowContinueOnError = expect.enforcement === "blocking" || (expect.disallow || []).includes("continue_on_error");
+  if (disallowContinueOnError) for (const fact of workflow.continueOnError || []) if (truthy(fact.value)) {
+    details.push(detail(workflow, fact, "blocking ci_gate step must not set continue-on-error"));
+  }
+  return details;
+}
+
 function workflowDetails(workflow: WorkflowFact): string[] {
   const details: string[] = [], expect = workflow.expect || {};
+  if (workflow.role === "ci_gate") return ciGateDetails(workflow);
   if (workflow.role !== "repo_guard_pr_gate") {
     if (!referencesRepoGuard(workflow)) details.push(`${workflow.path}: workflow does not reference repo-guard via uses or run`);
     return details;
   }
 
-  const events = expect.events?.length ? expect.events : ["pull_request"];
-  for (const event of compareSets(events, workflow.triggerEvents, "left_subset").missing) details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required event ${event}`);
-  if (!expect.events?.length && !workflow.triggerEvents.includes("pull_request") && !workflow.triggerEvents.includes("pull_request_target")) {
-    details.push(`${workflow.path}: repo_guard_pr_gate workflow must run on pull_request or pull_request_target`);
-  }
-  if (expect.event_types?.length) {
-    const event = workflow.triggerEvents.includes("pull_request") ? "pull_request" : "pull_request_target";
-    const actual = workflow.triggerEventTypes.find((fact) => fact.event === event)?.types || [];
-    for (const type of compareSets(expect.event_types, actual, "left_subset").missing) details.push(`${workflow.path}: repo_guard_pr_gate workflow missing required ${event} type ${type}`);
-  }
+  details.push(...workflowEventDetails(workflow, "repo_guard_pr_gate"));
   if (!hasFetchDepthZero(workflow)) details.push(`${workflow.path}: repo_guard_pr_gate workflow should checkout with fetch-depth: 0`);
 
   const actions = repoGuardActions(workflow, expect.action || {});
@@ -242,6 +264,26 @@ function workflowDetails(workflow: WorkflowFact): string[] {
   return details;
 }
 
+export function checkWorkflowPathCoverage(integration: IntegrationFacts, binding: WorkflowPathCoverageBinding, referencedPaths: string[]) {
+  const workflow = array(integration.workflows).find((item) => item.id === binding.workflow);
+  if (!workflow) return {
+    ok: false,
+    message: `evidence workflow "${binding.workflow}" is unavailable in extracted integration facts`,
+    data: { workflow: binding.workflow, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: referencedPaths },
+  };
+  if (workflow.expect?.enforcement !== "blocking") return {
+    ok: false,
+    message: `evidence workflow "${binding.workflow}" is not configured as blocking`,
+    data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: [] },
+  };
+  const uncoveredPaths = referencedPaths.filter((path) => !matchesAny(path, binding.covers)).sort();
+  return {
+    ok: uncoveredPaths.length === 0,
+    message: uncoveredPaths.length ? `evidence workflow "${binding.workflow}" does not cover all declared repository paths` : undefined,
+    data: { workflow: binding.workflow, workflow_role: workflow.role, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: uncoveredPaths },
+  };
+}
+
 function templateDetails(template: TemplateFact): string[] {
   if (template.present === false && template.optional) return [];
   const details: string[] = [], blocks = template.changeIntentBlocks || [];
@@ -268,7 +310,7 @@ export function integrationConstraintEntries(integration: IntegrationFacts = {})
   const entry = (name: string, details: string[], pass: string, fail: string, hint: string): IntegrationCheckEntry => ({ name, check: details.length ? { ok: false, message: fail, details, hint } : { ok: true, message: pass } });
   return [
     entry("integration-artifacts", artifacts, "All declared integration artifacts were read and parsed", "Integration artifact extraction failed", "Fix missing files, malformed workflow YAML, malformed ChangeIntent blocks, or Markdown fences"),
-    entry("integration-workflows", workflows, "Workflow integration wiring is valid", "Workflow integration wiring has issues", "Compare declared repo-guard workflows with templates/example-workflow.yml"),
+    entry("integration-workflows", workflows, "Workflow integration wiring is valid", "Workflow integration wiring has issues", "Compare declared workflows with their configured integration expectations"),
     entry("integration-templates", templates, "Template integration wiring is valid", "Template integration wiring has issues", "Add repo-guard-yaml or repo-guard-json fenced ChangeIntent blocks to required templates"),
     entry("integration-docs", docs, "Documentation integration wiring is valid", "Documentation integration wiring has issues", "Update declared docs so every must_mention term appears"),
     entry("integration-profiles", profiles, "Profile documentation wiring is valid", "Profile documentation wiring has issues", "Mention each integration profile id in its declared profile document"),

--- a/src/checks/rules/constraints.mts
+++ b/src/checks/rules/constraints.mts
@@ -4,7 +4,7 @@ import { selectPaths } from "../../diff/classification.mjs";
 import { readDocumentFact, type DocumentFactSelector, type DocumentReader } from "../../document-facts.mjs";
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
-import { integrationConstraintEntries } from "../integration-constraints.mjs";
+import { checkWorkflowPathCoverage, integrationConstraintEntries } from "../integration-constraints.mjs";
 import type { RuleFamily } from "../rule-registry.mjs";
 import { checkTraceRuleResult } from "../trace-rules.mjs";
 import { checkChangeProfile } from "./change-profiles.mjs";
@@ -39,7 +39,8 @@ type RuntimeConstraintKind =
   | "integration"
   | "document_scalar_equal"
   | "document_scalar_equals_literal"
-  | "document_referenced_paths_exist";
+  | "document_referenced_paths_exist"
+  | "evidence_workflow_path_coverage";
 
 interface RuntimeConstraint {
   kind: RuntimeConstraintKind;
@@ -53,10 +54,13 @@ interface RuntimeConstraint {
   must_change_any?: string[];
   rules?: unknown;
   relation_id?: string;
+  binding_id?: string;
   left?: DocumentFactSelector;
   right?: DocumentFactSelector;
   source?: DocumentFactSelector;
   value?: unknown;
+  workflow?: string;
+  covers?: string[];
 }
 
 interface ConstraintPolicyProjection {
@@ -187,6 +191,29 @@ function checkDocumentReferencedPathsExist(facts: ConstraintFacts, constraint: R
   };
 }
 
+function checkEvidenceWorkflowPathCoverage(facts: ConstraintFacts, constraint: RuntimeConstraint) {
+  const source = factOperand(facts.documents, constraint.source);
+  if (!source.ok) return {
+    ok: false,
+    message: `evidence binding "${constraint.binding_id}" could not read repository path references`,
+    data: { kind: "workflow_path_coverage", binding_id: constraint.binding_id, source },
+  };
+  if (!Array.isArray(source.value)) return {
+    ok: false,
+    message: `evidence binding "${constraint.binding_id}" did not produce a repository path set`,
+    data: { kind: "workflow_path_coverage", binding_id: constraint.binding_id, source },
+  };
+  const coverage = checkWorkflowPathCoverage(
+    facts.integration as Parameters<typeof checkWorkflowPathCoverage>[0],
+    { workflow: constraint.workflow || "", covers: constraint.covers || [] },
+    source.value,
+  );
+  return {
+    ...coverage,
+    data: { kind: "workflow_path_coverage", binding_id: constraint.binding_id, source, ...coverage.data },
+  };
+}
+
 export function evaluateConstraintIR(facts: ConstraintFacts, context: ConstraintContext = {}): RuleResult[] {
   const { files, constraints } = compileConstraintIR(facts), results: RuleResult[] = [], cochange: RuntimeConstraint[] = [];
   for (const constraint of constraints) {
@@ -220,6 +247,7 @@ export function evaluateConstraintIR(facts: ConstraintFacts, context: Constraint
     } else if (constraint.kind === "document_scalar_equal") check = checkDocumentScalarEqual(facts, constraint);
     else if (constraint.kind === "document_scalar_equals_literal") check = checkDocumentScalarLiteral(facts, constraint);
     else if (constraint.kind === "document_referenced_paths_exist") check = checkDocumentReferencedPathsExist(facts, constraint);
+    else if (constraint.kind === "evidence_workflow_path_coverage") check = checkEvidenceWorkflowPathCoverage(facts, constraint);
     else continue;
     results.push({ name: constraint.name, check });
   }

--- a/src/policy-compiler.mts
+++ b/src/policy-compiler.mts
@@ -111,6 +111,15 @@ export function compileIntegrationPolicy(policy: PolicyProjection = {}): Semanti
       } else seen.set(id, { section, index });
       if (section === "profiles") profileIds.add(id);
     }
+    if (section === "workflows" && entry.role === "ci_gate") {
+      const expect = object(entry.expect);
+      for (const field of ["action", "mode"] as const) if (expect[field] !== undefined) {
+        errors.push({ section, id, index, field, message: `integration.workflows[${index}].expect.${field} is not supported for ci_gate` });
+      }
+      for (const disallowed of list<string>(expect.disallow)) if (disallowed !== "continue_on_error") {
+        errors.push({ section, id, index, field: "disallow", message: `integration.workflows[${index}].expect.disallow value "${disallowed}" is repo-guard-specific and not supported for ci_gate` });
+      }
+    }
     for (const profileId of list(entry.profiles)) references.push({ section, index, field: "profiles", profileId });
     if (section === "docs") for (const profileId of list(entry.must_mention_profiles)) references.push({ section, index, field: "must_mention_profiles", profileId });
   }

--- a/src/policy-compiler.mts
+++ b/src/policy-compiler.mts
@@ -36,6 +36,7 @@ interface PolicyProjection {
   paths?: { public_api?: unknown };
   content_rules?: unknown;
   document_relations?: unknown;
+  evidence_bindings?: unknown;
 }
 interface IntegrationReference {
   section: IntegrationSection;
@@ -136,6 +137,11 @@ function normalizeDeclaredDocumentPath(name: string, definition: LooseObject, er
   }
 }
 
+function documentSelectorKey(value: unknown): string {
+  const selector = object(value);
+  return JSON.stringify({ document: selector.document, pointer: selector.pointer, projection: selector.projection, type: selector.type });
+}
+
 export function compileDocumentRelationsPolicy(policy: PolicyProjection = {}): SemanticDiagnostic[] {
   if (!policy.document_relations) return [];
   const section = object(policy.document_relations), documents = object(section.documents), rules = list<LooseObject>(section.rules);
@@ -172,6 +178,41 @@ export function compileDocumentRelationsPolicy(policy: PolicyProjection = {}): S
 
   for (const name of Object.keys(documents)) if (!usedDocuments.has(name)) {
     errors.push({ document: name, message: `document_relations.documents["${name}"] is declared but unused` });
+  }
+  return errors;
+}
+
+export function compileEvidenceBindingsPolicy(policy: PolicyProjection = {}): SemanticDiagnostic[] {
+  const bindings = list<LooseObject>(policy.evidence_bindings);
+  if (!bindings.length) return [];
+  const errors: SemanticDiagnostic[] = [], seenIds = new Set<unknown>();
+  const relationSection = object(policy.document_relations), documents = object(relationSection.documents), relationRules = list<LooseObject>(relationSection.rules);
+  const pathExistenceSelectors = new Set(relationRules.filter((rule) => rule.kind === "referenced_paths_exist").map((rule) => documentSelectorKey(rule.source)));
+  const workflows = new Map<string, LooseObject>();
+  for (const workflow of list<LooseObject>(object(policy.integration).workflows)) if (typeof workflow.id === "string" && workflow.id) workflows.set(workflow.id, workflow);
+
+  for (const [index, binding] of bindings.entries()) {
+    const id = binding.id;
+    if (seenIds.has(id)) errors.push({ evidence_binding: id, index, message: `evidence_bindings[${index}].id duplicates binding "${id}"` });
+    seenIds.add(id);
+    if (binding.kind !== "workflow_path_coverage") continue;
+
+    const source = object(binding.source), document = source.document;
+    if (typeof document !== "string" || !Object.hasOwn(documents, document)) {
+      errors.push({ evidence_binding: id, document, message: `evidence binding "${id}" source references unknown document "${document}"` });
+    }
+
+    const workflowId = binding.workflow;
+    const workflow = typeof workflowId === "string" ? workflows.get(workflowId) : undefined;
+    if (!workflow) {
+      errors.push({ evidence_binding: id, workflow: workflowId, message: `evidence binding "${id}" references unknown integration workflow "${workflowId}"` });
+    } else if (object(workflow.expect).enforcement !== "blocking") {
+      errors.push({ evidence_binding: id, workflow: workflowId, message: `evidence binding "${id}" requires integration workflow "${workflowId}" to declare expect.enforcement "blocking"` });
+    }
+
+    if (!pathExistenceSelectors.has(documentSelectorKey(source))) {
+      errors.push({ evidence_binding: id, message: `evidence binding "${id}" requires an equivalent referenced_paths_exist relation for the same source selector` });
+    }
   }
   return errors;
 }

--- a/src/runtime/validation.mts
+++ b/src/runtime/validation.mts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import Ajv from "ajv";
-import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
+import { compileAnchorPolicy, compileChangeProfiles, compileDocumentRelationsPolicy, compileEvidenceBindingsPolicy, compileForbidRegex, compileIntegrationPolicy, warnReservedPolicyFields } from "../policy-compiler.mjs";
 import { resolvePolicyProfile } from "../policy-profiles.mjs";
 
 type AjvErrorProjection = { instancePath?: string; message?: string };
@@ -47,6 +47,7 @@ export function loadPolicyRuntimeFromObject(roots: RuntimeRoots, rawPolicy: unkn
     ["anchor policy compilation", compileAnchorPolicy(policy), (error) => (error as { message: string }).message],
     ["integration policy compilation", compileIntegrationPolicy(policy), (error) => (error as { message: string }).message],
     ["document relation policy compilation", compileDocumentRelationsPolicy(policy), (error) => (error as { message: string }).message],
+    ["evidence binding policy compilation", compileEvidenceBindingsPolicy(policy), (error) => (error as { message: string }).message],
   ];
   for (const [group, errors, format] of semanticGroups) if (errors.length) {
     ok = false;

--- a/tests/test-integration-diagnostics.mjs
+++ b/tests/test-integration-diagnostics.mjs
@@ -35,19 +35,8 @@ function expectTrue(label, value) {
 }
 
 function runGuard(args) {
-  const result = spawnSync(process.execPath, [
-    resolve(projectRoot, "dist/repo-guard.mjs"),
-    ...args,
-  ], {
-    cwd: projectRoot,
-    encoding: "utf-8",
-  });
-  return {
-    code: result.status,
-    stdout: result.stdout || "",
-    stderr: result.stderr || "",
-    output: `${result.stdout || ""}${result.stderr || ""}`,
-  };
+  const result = spawnSync(process.execPath, [resolve(projectRoot, "dist/repo-guard.mjs"), ...args], { cwd: projectRoot, encoding: "utf-8" });
+  return { code: result.status, stdout: result.stdout || "", stderr: result.stderr || "", output: `${result.stdout || ""}${result.stderr || ""}` };
 }
 
 function writeJson(path, value) {
@@ -58,24 +47,14 @@ function prGateExpect(overrides = {}) {
   return {
     events: ["pull_request"],
     event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
-    action: {
-      uses: "netkeep80/repo-guard",
-      ref_pinning: "semver",
-      ...overrides.action,
-    },
+    action: { uses: "netkeep80/repo-guard", ref_pinning: "semver", ...overrides.action },
     mode: "check-pr",
     enforcement: "blocking",
-    permissions: {
-      contents: "read",
-      "pull-requests": "read",
-      ...overrides.permissions,
-    },
+    permissions: { contents: "read", "pull-requests": "read", ...overrides.permissions },
     token_env: ["GH_TOKEN"],
     summary: true,
     disallow: ["continue_on_error", "manual_clone", "direct_temp_cli_execution"],
-    ...Object.fromEntries(Object.entries(overrides).filter(([key]) =>
-      key !== "action" && key !== "permissions"
-    )),
+    ...Object.fromEntries(Object.entries(overrides).filter(([key]) => key !== "action" && key !== "permissions")),
   };
 }
 
@@ -85,65 +64,17 @@ function basePolicy(overrides = {}) {
     repository_kind: "tooling",
     enforcement: { mode: "blocking" },
     integration: {
-      workflows: [
-        {
-          id: "pr-gate",
-          kind: "github_actions",
-          path: ".github/workflows/repo-guard.yml",
-          role: "repo_guard_pr_gate",
-          profiles: ["self-hosting"],
-          expect: prGateExpect(),
-        },
-      ],
+      workflows: [{ id: "pr-gate", kind: "github_actions", path: ".github/workflows/repo-guard.yml", role: "repo_guard_pr_gate", profiles: ["self-hosting"], expect: prGateExpect() }],
       templates: [
-        {
-          id: "pull-request-template",
-          kind: "markdown",
-          path: ".github/PULL_REQUEST_TEMPLATE.md",
-          requires_change_intent_block: true,
-          required_block_kind: "repo-guard-yaml",
-          required_change_intent_fields: ["change_type", "scope"],
-        },
-        {
-          id: "change-intent-issue-form",
-          kind: "github_issue_form",
-          path: ".github/ISSUE_TEMPLATE/change-intent.yml",
-          requires_change_intent_block: true,
-          optional: true,
-          required_block_kind: "repo-guard-yaml",
-          required_change_intent_fields: ["change_type", "scope"],
-        },
+        { id: "pull-request-template", kind: "markdown", path: ".github/PULL_REQUEST_TEMPLATE.md", requires_change_intent_block: true, required_block_kind: "repo-guard-yaml", required_change_intent_fields: ["change_type", "scope"] },
+        { id: "change-intent-issue-form", kind: "github_issue_form", path: ".github/ISSUE_TEMPLATE/change-intent.yml", requires_change_intent_block: true, optional: true, required_block_kind: "repo-guard-yaml", required_change_intent_fields: ["change_type", "scope"] },
       ],
-      docs: [
-        {
-          id: "readme",
-          kind: "markdown",
-          path: "README.md",
-          must_mention: ["repo-guard", "ChangeIntent", "integration"],
-          must_reference_files: ["repo-policy.json", ".github/PULL_REQUEST_TEMPLATE.md"],
-          must_mention_profiles: ["self-hosting"],
-          must_mention_change_intent_fields: ["change_type", "scope"],
-          profiles: ["self-hosting"],
-        },
-      ],
-      profiles: [
-        {
-          id: "self-hosting",
-          doc_path: "README.md",
-        },
-      ],
+      docs: [{ id: "readme", kind: "markdown", path: "README.md", must_mention: ["repo-guard", "ChangeIntent", "integration"], must_reference_files: ["repo-policy.json", ".github/PULL_REQUEST_TEMPLATE.md"], must_mention_profiles: ["self-hosting"], must_mention_change_intent_fields: ["change_type", "scope"], profiles: ["self-hosting"] }],
+      profiles: [{ id: "self-hosting", doc_path: "README.md" }],
       ...overrides.integration,
     },
-    paths: {
-      forbidden: [],
-      canonical_docs: ["README.md"],
-      governance_paths: ["repo-policy.json"],
-    },
-    diff_rules: {
-      max_new_docs: 2,
-      max_new_files: 15,
-      max_net_added_lines: 2000,
-    },
+    paths: { forbidden: [], canonical_docs: ["README.md"], governance_paths: ["repo-policy.json"] },
+    diff_rules: { max_new_docs: 2, max_new_files: 15, max_net_added_lines: 2000 },
     content_rules: [],
     cochange_rules: [],
   };
@@ -156,132 +87,60 @@ function makeRepo() {
 
   writeJson(join(dir, "repo-policy.json"), basePolicy());
   writeFileSync(join(dir, ".github", "workflows", "repo-guard.yml"), [
-    "name: repo guard",
-    "on:",
-    "  pull_request:",
-    "    types: [opened, synchronize, reopened, ready_for_review]",
-    "  push:",
-    "permissions:",
-    "  contents: read",
-    "  pull-requests: read",
-    "jobs:",
-    "  validate:",
-    "    runs-on: ubuntu-latest",
-    "    steps:",
-    "      - uses: actions/checkout@v4",
-    "        with:",
-    "          fetch-depth: 0",
-    "      - name: Run repo-guard",
-    "        uses: netkeep80/repo-guard@v1.2.3",
-    "        with:",
-    "          mode: check-pr",
-    "          enforcement: blocking",
-    "        env:",
-    "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
-    "      - name: Publish repo-guard summary",
-    "        if: always()",
-    "        run: echo \"### repo-guard\" >> \"$GITHUB_STEP_SUMMARY\"",
-    "",
+    "name: repo guard", "on:", "  pull_request:", "    types: [opened, synchronize, reopened, ready_for_review]", "  push:",
+    "permissions:", "  contents: read", "  pull-requests: read", "jobs:", "  validate:", "    runs-on: ubuntu-latest", "    steps:",
+    "      - uses: actions/checkout@v4", "        with:", "          fetch-depth: 0", "      - name: Run repo-guard", "        uses: netkeep80/repo-guard@v1.2.3",
+    "        with:", "          mode: check-pr", "          enforcement: blocking", "        env:", "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+    "      - name: Publish repo-guard summary", "        if: always()", "        run: echo \"### repo-guard\" >> \"$GITHUB_STEP_SUMMARY\"", "",
   ].join("\n"));
-  writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), [
-    "## ChangeIntent",
-    "",
-    "```repo-guard-yaml",
-    "change_type: feature",
-    "scope:",
-    "  - src/**",
-    "```",
-    "",
-  ].join("\n"));
-  writeFileSync(join(dir, ".github", "ISSUE_TEMPLATE", "change-intent.yml"), [
-    "name: ChangeIntent",
-    "body:",
-    "  - type: textarea",
-    "    attributes:",
-    "      value: |",
-    "        ```repo-guard-yaml",
-    "        change_type: feature",
-    "        scope:",
-    "          - src/**",
-    "        ```",
-    "",
-  ].join("\n"));
-  writeFileSync(join(dir, "README.md"), [
-    "# Test Repo",
-    "",
-    "This repository documents repo-guard ChangeIntent integration for self-hosting.",
-    "The repo-policy.json file declares the .github/PULL_REQUEST_TEMPLATE.md ChangeIntent wiring.",
-    "Required ChangeIntent fields include change_type and scope.",
-    "Profile id: self-hosting",
-    "",
-  ].join("\n"));
+  writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), ["## ChangeIntent", "", "```repo-guard-yaml", "change_type: feature", "scope:", "  - src/**", "```", ""].join("\n"));
+  writeFileSync(join(dir, ".github", "ISSUE_TEMPLATE", "change-intent.yml"), ["name: ChangeIntent", "body:", "  - type: textarea", "    attributes:", "      value: |", "        ```repo-guard-yaml", "        change_type: feature", "        scope:", "          - src/**", "        ```", ""].join("\n"));
+  writeFileSync(join(dir, "README.md"), ["# Test Repo", "", "This repository documents repo-guard ChangeIntent integration for self-hosting.", "The repo-policy.json file declares the .github/PULL_REQUEST_TEMPLATE.md ChangeIntent wiring.", "Required ChangeIntent fields include change_type and scope.", "Profile id: self-hosting", ""].join("\n"));
   return dir;
 }
 
 function makeBrokenRepo() {
   const dir = makeRepo();
   writeFileSync(join(dir, ".github", "workflows", "repo-guard.yml"), [
-    "name: repo guard",
-    "on:",
-    "  pull_request:",
-    "    types: [opened]",
-    "permissions:",
-    "  contents: write",
-    "jobs:",
-    "  validate:",
-    "    runs-on: ubuntu-latest",
-    "    steps:",
-    "      - uses: actions/checkout@v4",
-    "      - name: Drifted repo-guard",
-    "        continue-on-error: true",
-    "        run: |",
-    "          git clone https://github.com/netkeep80/repo-guard \"$RUNNER_TEMP/repo-guard\"",
-    "          node \"$RUNNER_TEMP/repo-guard/dist/repo-guard.mjs\" check-diff",
-    "",
+    "name: repo guard", "on:", "  pull_request:", "    types: [opened]", "permissions:", "  contents: write", "jobs:", "  validate:", "    runs-on: ubuntu-latest", "    steps:",
+    "      - uses: actions/checkout@v4", "      - name: Drifted repo-guard", "        continue-on-error: true", "        run: |",
+    "          git clone https://github.com/netkeep80/repo-guard \"$RUNNER_TEMP/repo-guard\"", "          node \"$RUNNER_TEMP/repo-guard/dist/repo-guard.mjs\" check-diff", "",
   ].join("\n"));
   writeFileSync(join(dir, ".github", "PULL_REQUEST_TEMPLATE.md"), "## Missing ChangeIntent\n");
   writeFileSync(join(dir, "README.md"), "# Missing integration docs\n");
   return dir;
 }
 
+function configureCiGate(dir, broken = false) {
+  const policy = basePolicy({ integration: { workflows: [{
+    id: "project-ci", kind: "github_actions", path: ".github/workflows/ci.yml", role: "ci_gate",
+    expect: { events: ["pull_request"], enforcement: "blocking", disallow: ["continue_on_error"] },
+  }] } });
+  writeJson(join(dir, "repo-policy.json"), policy);
+  writeFileSync(join(dir, ".github", "workflows", "ci.yml"), [
+    "name: project ci", "on:", broken ? "  push:" : "  pull_request:", "jobs:", "  test:", "    runs-on: ubuntu-latest", "    steps:",
+    "      - uses: actions/checkout@v4", "      - name: Run tests", ...(broken ? ["        continue-on-error: true"] : []), "        run: npm test", "",
+  ].join("\n"));
+}
+
 console.log("\n--- validate-integration --format json emits normalized integration diagnostics ---");
 {
   const dir = makeRepo();
-  const result = runGuard([
-    "--repo-root", dir,
-    "validate-integration",
-    "--format", "json",
-  ]);
-
+  const result = runGuard(["--repo-root", dir, "validate-integration", "--format", "json"]);
   expect("valid integration exits 0", result.code, 0);
   expect("json stderr is empty", result.stderr, "");
-
   let parsed = null;
-  try {
-    parsed = JSON.parse(result.stdout);
-    expect("stdout is valid json", true, true);
-  } catch (e) {
-    expect("stdout is valid json", e.message, "valid json");
-  }
-
+  try { parsed = JSON.parse(result.stdout); expect("stdout is valid json", true, true); } catch (e) { expect("stdout is valid json", e.message, "valid json"); }
   expect("command name is stable", parsed?.command, "validate-integration");
   expect("mode is blocking", parsed?.mode, "blocking");
   expect("result passed", parsed?.result, "passed");
   expect("repository root is included", parsed?.repositoryRoot, dir);
   expect("workflow facts are emitted", parsed?.integration?.workflows?.[0]?.triggerEvents, ["pull_request", "push"]);
-  expect("workflow event types are emitted", parsed?.integration?.workflows?.[0]?.triggerEventTypes, [
-    {
-      event: "pull_request",
-      types: ["opened", "synchronize", "reopened", "ready_for_review"],
-    },
-  ]);
-  expect("action inputs are normalized facts",
-    parsed?.integration?.workflows?.[0]?.stepInputs?.find((fact) => fact.uses === "netkeep80/repo-guard@v1.2.3")?.inputs,
-    { enforcement: "blocking", mode: "check-pr" });
+  expect("workflow event types are emitted", parsed?.integration?.workflows?.[0]?.triggerEventTypes, [{ event: "pull_request", types: ["opened", "synchronize", "reopened", "ready_for_review"] }]);
+  expect("action inputs are normalized facts", parsed?.integration?.workflows?.[0]?.stepInputs?.find((fact) => fact.uses === "netkeep80/repo-guard@v1.2.3")?.inputs, { enforcement: "blocking", mode: "check-pr" });
   expect("template diagnostics pass", parsed?.ruleResults?.some((rule) => rule.rule === "integration-templates" && rule.ok), true);
   expect("doc diagnostics pass", parsed?.ruleResults?.some((rule) => rule.rule === "integration-docs" && rule.ok), true);
   expect("stats include declared templates", parsed?.diagnostics?.declared?.templates, 2);
-
   rmSync(dir, { recursive: true });
 }
 
@@ -289,49 +148,46 @@ console.log("\n--- optional issue-template fallback may be absent ---");
 {
   const dir = makeRepo();
   rmSync(join(dir, ".github", "ISSUE_TEMPLATE", "change-intent.yml"));
-  const result = runGuard([
-    "--repo-root", dir,
-    "validate-integration",
-    "--format", "json",
-  ]);
+  const result = runGuard(["--repo-root", dir, "validate-integration", "--format", "json"]);
   const parsed = JSON.parse(result.stdout);
-
   expect("missing optional issue template exits 0", result.code, 0);
-  expect("optional template fact is still emitted",
-    parsed.integration.templates.find((template) => template.id === "change-intent-issue-form")?.present,
-    false);
+  expect("optional template fact is still emitted", parsed.integration.templates.find((template) => template.id === "change-intent-issue-form")?.present, false);
   expect("optional template does not create artifact errors", parsed.diagnostics.artifactErrors, []);
-
   rmSync(dir, { recursive: true });
 }
 
 console.log("\n--- doctor --integration aliases validate-integration diagnostics ---");
 {
   const dir = makeRepo();
-  const result = runGuard([
-    "--repo-root", dir,
-    "doctor",
-    "--integration",
-    "--format", "json",
-  ]);
+  const result = runGuard(["--repo-root", dir, "doctor", "--integration", "--format", "json"]);
   const parsed = JSON.parse(result.stdout);
-
   expect("doctor integration alias exits 0", result.code, 0);
   expect("alias uses validate-integration command shape", parsed.command, "validate-integration");
   expect("alias emits integration facts", parsed.integration.workflows.length, 1);
+  rmSync(dir, { recursive: true });
+}
 
+console.log("\n--- generic ci_gate reuses workflow extraction without repo-guard invocation ---");
+{
+  const dir = makeRepo();
+  configureCiGate(dir, false);
+  const passing = runGuard(["--repo-root", dir, "validate-integration", "--format", "json"]);
+  const parsed = JSON.parse(passing.stdout);
+  expect("ordinary project CI passes as blocking ci_gate", passing.code, 0);
+  expect("ci_gate does not require a repo-guard action", parsed.ruleResults.some((rule) => rule.rule === "integration-workflows" && rule.ok), true);
+
+  configureCiGate(dir, true);
+  const broken = runGuard(["--repo-root", dir, "validate-integration", "--format", "summary"]);
+  expect("broken blocking ci_gate fails", broken.code, 1);
+  expectIncludes("ci_gate event mismatch is reported", broken.output, "ci_gate workflow missing required event pull_request");
+  expectIncludes("ci_gate continue-on-error is reported", broken.output, "blocking ci_gate step must not set continue-on-error");
   rmSync(dir, { recursive: true });
 }
 
 console.log("\n--- validate-integration --format summary reports CI-readable diagnostics ---");
 {
   const dir = makeBrokenRepo();
-  const result = runGuard([
-    "--repo-root", dir,
-    "validate-integration",
-    "--format", "summary",
-  ]);
-
+  const result = runGuard(["--repo-root", dir, "validate-integration", "--format", "summary"]);
   expect("broken integration blocks in blocking mode", result.code, 1);
   expectIncludes("summary heading", result.output, "## repo-guard integration summary");
   expectIncludes("summary result", result.output, "- Result: failed");
@@ -346,27 +202,19 @@ console.log("\n--- validate-integration --format summary reports CI-readable dia
   expectIncludes("doc file reference diagnostic appears", result.output, "missing required file reference");
   expectIncludes("doc profile mention diagnostic appears", result.output, "missing required profile mention");
   expectIncludes("doc ChangeIntent field diagnostic appears", result.output, "missing required ChangeIntent field mention");
-
   rmSync(dir, { recursive: true });
 }
 
 console.log("\n--- validate-integration advisory mode reports but does not block ---");
 {
   const dir = makeBrokenRepo();
-  const result = runGuard([
-    "--repo-root", dir,
-    "--enforcement", "advisory",
-    "validate-integration",
-    "--format", "json",
-  ]);
+  const result = runGuard(["--repo-root", dir, "--enforcement", "advisory", "validate-integration", "--format", "json"]);
   const parsed = JSON.parse(result.stdout);
-
   expect("advisory integration exits 0", result.code, 0);
   expect("advisory result still records failure", parsed.result, "failed");
   expect("advisory has zero enforced failures", parsed.failed, 0);
   expectTrue("advisory records violations", parsed.violationCount > 0);
   expectTrue("template violation is present", parsed.violations.some((violation) => violation.rule === "integration-templates"));
-
   rmSync(dir, { recursive: true });
 }
 

--- a/tests/test-policy-compiler-boundary.mjs
+++ b/tests/test-policy-compiler-boundary.mjs
@@ -1,7 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { resolve } from "node:path";
-import { compileDocumentRelationsPolicy, compileForbidRegex, compileIntegrationPolicy } from "../dist/policy-compiler.mjs";
+import { compileDocumentRelationsPolicy, compileEvidenceBindingsPolicy, compileForbidRegex, compileIntegrationPolicy } from "../dist/policy-compiler.mjs";
+import { evaluateConstraintIR } from "../dist/checks/rules/constraints.mjs";
+import { createDocumentReader } from "../dist/document-facts.mjs";
 import { loadPolicyRuntimeFromObject } from "../dist/runtime/validation.mjs";
 
 const projectRoot = resolve(new URL("..", import.meta.url).pathname);
@@ -36,6 +38,20 @@ const referencedPaths = {
 };
 const relationPolicy = (overrides = {}) => ({
   document_relations: { documents: structuredClone(documents), rules: [structuredClone(scalarEqual), structuredClone(scalarLiteral)], ...overrides },
+});
+const ciWorkflow = (enforcement = "blocking") => ({
+  id: "project-ci", kind: "github_actions", path: ".github/workflows/ci.yml", role: "ci_gate",
+  expect: { events: ["pull_request"], enforcement, disallow: ["continue_on_error"] },
+});
+const evidencePolicy = (overrides = {}) => ({
+  ...basePolicy,
+  integration: { workflows: [ciWorkflow()] },
+  document_relations: {
+    documents: { contract: structuredClone(documents.contract) },
+    rules: [structuredClone(referencedPaths)],
+  },
+  evidence_bindings: [{ id: "owners-covered", kind: "workflow_path_coverage", source: structuredClone(referencedPaths.source), workflow: "project-ci", covers: ["tests/**"] }],
+  ...overrides,
 });
 
 describe("semantic policy compiler boundary", () => {
@@ -92,6 +108,23 @@ describe("semantic policy compiler boundary", () => {
     assert.ok(messages.some((message) => /format "yaml" does not match path/.test(message)));
     assert.ok(messages.some((message) => /literal is incompatible/.test(message)));
   });
+
+  it("requires evidence bindings to reuse known blocking workflows and exact R2 existence selectors", () => {
+    assert.deepEqual(compileEvidenceBindingsPolicy(evidencePolicy()), []);
+    const missingWorkflow = evidencePolicy();
+    missingWorkflow.evidence_bindings[0].workflow = "missing";
+    assert.ok(compileEvidenceBindingsPolicy(missingWorkflow).some((error) => /unknown integration workflow/.test(error.message)));
+    const advisory = evidencePolicy({ integration: { workflows: [ciWorkflow("advisory")] } });
+    assert.ok(compileEvidenceBindingsPolicy(advisory).some((error) => /expect\.enforcement "blocking"/.test(error.message)));
+    const noExistence = evidencePolicy();
+    noExistence.document_relations.rules = [];
+    assert.ok(compileEvidenceBindingsPolicy(noExistence).some((error) => /equivalent referenced_paths_exist/.test(error.message)));
+  });
+
+  it("rejects repo-guard-specific expectations on generic ci_gate", () => {
+    assert.ok(compileIntegrationPolicy({ integration: { workflows: [{ ...ciWorkflow(), expect: { ...ciWorkflow().expect, mode: "check-pr" } }] } }).some((error) => /not supported for ci_gate/.test(error.message)));
+    assert.ok(compileIntegrationPolicy({ integration: { workflows: [{ ...ciWorkflow(), expect: { ...ciWorkflow().expect, disallow: ["manual_clone"] } }] } }).some((error) => /repo-guard-specific/.test(error.message)));
+  });
 });
 
 describe("document relation public schema boundary", () => {
@@ -134,5 +167,39 @@ describe("document relation public schema boundary", () => {
       documents: { contract: structuredClone(documents.contract) },
       rules: [{ ...structuredClone(referencedPaths), source: { ...referencedPaths.source, projection: "array_items" } }],
     }).ok, true);
+  });
+});
+
+describe("workflow path evidence public/runtime boundary", () => {
+  it("accepts the narrow binding schema and rejects executable fields", () => {
+    assert.equal(loadPolicyRuntimeFromObject({ packageRoot: projectRoot, repoRoot: projectRoot }, evidencePolicy(), { quiet: true }).ok, true);
+    const executable = evidencePolicy();
+    executable.evidence_bindings[0].command = "npm test";
+    assert.equal(loadPolicyRuntimeFromObject({ packageRoot: projectRoot, repoRoot: projectRoot }, executable, { quiet: true }).ok, false);
+  });
+
+  const integrationFacts = {
+    errors: [], templates: [], docs: [], profiles: [],
+    workflows: [{
+      id: "project-ci", path: ".github/workflows/ci.yml", role: "ci_gate", expect: { events: ["pull_request"], enforcement: "blocking", disallow: ["continue_on_error"] },
+      stepInputs: [], actionUses: [], runCommands: [], envVars: [], permissions: { jobs: [] },
+      triggerEvents: ["pull_request"], triggerEventTypes: [], summaryPublishing: [], continueOnError: [],
+    }],
+  };
+  const run = (owners, trackedFiles) => {
+    const policy = evidencePolicy();
+    const documentsReader = createDocumentReader({ readFile: (path) => path === "contracts/contract.json" ? JSON.stringify({ owners }) : "" });
+    return evaluateConstraintIR({ policy, changeIntent: null, diff: { files: { checked: [] } }, trackedFiles, documents: documentsReader, integration: integrationFacts });
+  };
+
+  it("keeps path existence and CI coverage as independent diagnostics", () => {
+    const uncovered = run({ gate: "tests/gate.mjs", doc: "docs/readme.md" }, ["tests/gate.mjs", "docs/readme.md"]);
+    assert.equal(uncovered.find((entry) => entry.name === "document-relation:owners-exist")?.check.ok, true);
+    assert.equal(uncovered.find((entry) => entry.name === "evidence-binding:owners-covered")?.check.ok, false);
+    assert.deepEqual(uncovered.find((entry) => entry.name === "evidence-binding:owners-covered")?.check.data.uncovered_paths, ["docs/readme.md"]);
+
+    const missing = run({ gate: "tests/missing.mjs" }, []);
+    assert.equal(missing.find((entry) => entry.name === "document-relation:owners-exist")?.check.ok, false);
+    assert.equal(missing.find((entry) => entry.name === "evidence-binding:owners-covered")?.check.ok, true);
   });
 });

--- a/tests/test-policy-delta-rules.mjs
+++ b/tests/test-policy-delta-rules.mjs
@@ -50,6 +50,12 @@ const referencedPathsRule = {
   kind: "referenced_paths_exist",
   source: { document: "contract", pointer: "/owners", projection: "object_values", type: "repository_path_set" },
 };
+const evidencePolicy = () => {
+  const policy = relationPolicy([structuredClone(referencedPathsRule)]);
+  policy.integration.workflows = [{ id: "project-ci", role: "ci_gate", path: ".github/workflows/ci.yml", expect: { enforcement: "blocking", events: ["pull_request"] } }];
+  policy.evidence_bindings = [{ id: "owners-covered", kind: "workflow_path_coverage", source: structuredClone(referencedPathsRule.source), workflow: "project-ci", covers: ["tests/**"] }];
+  return policy;
+};
 const macroPolicy = () => ({
   ...structuredClone(BASE),
   cochange_rules: [],
@@ -181,6 +187,24 @@ describe("document relation strictness projection", () => {
     const comparison = compareConstraintPrograms(base, head);
     assert.equal(comparison.relation, "incomparable");
     assert.ok(comparison.incomparable.some((item) => item.pointer === "/document_relations/rules/owners-exist"));
+  });
+});
+
+describe("evidence binding strictness projection", () => {
+  it("treats adoption as stricter and removal as an explicit relaxation", () => {
+    const head = evidencePolicy(), base = structuredClone(head);
+    delete base.evidence_bindings;
+    assert.equal(compareConstraintPrograms(base, head).relation, "stricter");
+    const removal = computePolicyDelta(head, base);
+    assert.ok(removal.relaxations.some((item) => item.kind === "evidence_binding_removed" && item.evidence_binding_id === "owners-covered"));
+  });
+
+  it("treats binding source/workflow/coverage edits as incomparable", () => {
+    const base = evidencePolicy(), head = structuredClone(base);
+    head.evidence_bindings[0].covers = ["src/**"];
+    const comparison = compareConstraintPrograms(base, head);
+    assert.equal(comparison.relation, "incomparable");
+    assert.ok(comparison.incomparable.some((item) => item.pointer === "/evidence_bindings/owners-covered"));
   });
 });
 


### PR DESCRIPTION
Fixes #291

R4a implements the repository-path half of conformance evidence wiring without turning repo-guard into a test runner.

Implemented:
- new generic integration workflow role `ci_gate`, reusing the existing GitHub Actions extractor facts and normal integration evaluator;
- `ci_gate` validates configured lifecycle events, generic permissions/env/summary expectations, blocking semantics and truthy `continue-on-error` without requiring any repo-guard invocation;
- repo-guard-specific `action`, `mode`, `manual_clone`, and `direct_temp_cli_execution` expectations are semantic-rejected for `ci_gate` instead of becoming inert no-ops;
- new top-level `evidence_bindings` with one narrow kind, `workflow_path_coverage`;
- binding source is an existing R1 `repository_path_set` document selector; it references an integration workflow id plus explicit trusted `covers` patterns;
- semantic compiler requires the workflow to exist, declare `expect.enforcement: blocking`, and requires an exact equivalent R2 `referenced_paths_exist` selector;
- runtime coverage reads the normalized DocumentFacts path set and checks only workflow identity/blocking + `covers`; tracked-file existence remains a distinct R2 check;
- Constraint Program strictness treats binding adoption as stricter, removal as `evidence_binding_removed`, and source/workflow/covers edits as incomparable;
- schema is fail-closed (`additionalProperties:false`): no `command`, `shell`, callback, or arbitrary execution fields;
- end-to-end YAML regression proves a normal project CI workflow with `npm test` can be validated as `ci_gate` without repo-guard action wiring, while missing PR lifecycle / `continue-on-error:true` fails;
- runtime regression proves path existence and CI coverage are independent diagnostics;
- actual `anum_docs` topology (separate `.github/workflows/ci.yml` for Python/TS gates and `.github/workflows/repo-guard.yml` for repo-guard) is representable honestly without pretending to infer pytest/npm discovery.

Generated dist is compiler-produced and byte-for-byte pinned to CI #701 targets:
- constraint-program `26217b7…`
- integration-constraints `3d3408f…`
- constraints runtime `b959243…`
- policy-compiler `7b399eb…`
- runtime validation `fe7e865…`

Draft CI #706 is fully green: generated dist freshness, architecture metrics, schema validation, self-integration, doctor, discovered tests, advisory mode and packaged smoke all passed. PR policy is intentionally skipped only while draft.

Diff: 14 files, 509 additions / 382 deletions (net +127), no new files/docs; branch is `behind_by=0` and mergeable. No R4b semantic case-ID/anchor binding, job-command discovery, branch-protection API, MTS-specific fields, shell execution, or plugin callback DSL is included.