### PR TITLE
Fix atomic cutover grant schema and mixed-path authorization

### DIFF
--- a/dist/checks/rules/governance-paths.mjs
+++ b/dist/checks/rules/governance-paths.mjs
@@ -12,6 +12,10 @@ export function checkGovernanceChangeAuthorization({ files, governancePaths, gov
     const touched = files.filter((file) => matchesBoundary(file.path)).map((file) => file.path);
     const declared = Array.isArray(governanceGrant?.authorized_governance_paths) ? governanceGrant.authorized_governance_paths : [];
     const sourceTrusted = trusted(trustedAuthorizer), authorized = sourceTrusted ? declared : [];
+    // Mixed files are allowed only for an explicitly trusted atomic cutover.
+    // This does not authorize governance files themselves: those still require
+    // matching authorized_governance_paths below, and ordinary scope/must-not
+    // rules remain independent vetoes.
     const atomicGovernanceCutover = governanceChange
         && governanceGrant?.allow_atomic_governance_cutover === true
         && sourceTrusted;

--- a/dist/checks/rules/governance-paths.mjs
+++ b/dist/checks/rules/governance-paths.mjs
@@ -10,16 +10,23 @@ export function checkGovernanceChangeAuthorization({ files, governancePaths, gov
     if (!patterns.length && !governanceChange)
         return { ok: true };
     const touched = files.filter((file) => matchesBoundary(file.path)).map((file) => file.path);
-    const nonGovernance = governanceChange ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path) : [];
-    if (!governanceChange && !touched.length)
-        return { ok: true, touched_governance_paths: [] };
     const declared = Array.isArray(governanceGrant?.authorized_governance_paths) ? governanceGrant.authorized_governance_paths : [];
     const sourceTrusted = trusted(trustedAuthorizer), authorized = sourceTrusted ? declared : [];
+    const atomicGovernanceCutover = governanceChange
+        && governanceGrant?.allow_atomic_governance_cutover === true
+        && sourceTrusted;
+    const nonGovernance = governanceChange && !atomicGovernanceCutover
+        ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path)
+        : [];
+    if (!governanceChange && !touched.length)
+        return { ok: true, touched_governance_paths: [] };
     const unauthorized = touched.filter((path) => !matchesAny(path, expandGovernancePatterns(authorized)));
     const details = [
         ...nonGovernance.map((path) => `governance ChangeIntent cannot change non-governance path ${path}`),
         ...unauthorized.map((path) => `governance path ${path} changed without matching GovernanceGrant authorization`),
     ];
+    if (atomicGovernanceCutover)
+        details.push("Trusted atomic governance cutover permits scoped non-governance files");
     if (declared.length && !sourceTrusted)
         details.push("GovernanceGrant is ignored because no trusted authorizer was detected");
     const ok = !nonGovernance.length && !unauthorized.length;
@@ -33,8 +40,9 @@ export function checkGovernanceChangeAuthorization({ files, governancePaths, gov
         trusted_authorized_governance_paths: authorized,
         unauthorized_paths: unauthorized,
         untrusted_governance_grant_ignored: declared.length > 0 && !sourceTrusted,
+        atomic_governance_cutover: atomicGovernanceCutover,
         details,
-        hint: ok ? undefined : "Use a dedicated governance-only diff and authorize every touched governance path from a trusted linked-issue GovernanceGrant.",
+        hint: ok ? undefined : "Use a dedicated governance-only diff, or a trusted atomic governance cutover, and authorize every touched governance path from a trusted linked-issue GovernanceGrant.",
     };
 }
 export const governancePathsRuleFamily = {

--- a/schemas/governance-grant.schema.json
+++ b/schemas/governance-grant.schema.json
@@ -11,6 +11,9 @@
     },
     "allow_policy_relaxation": {
       "type": "array", "items": { "type": "string", "pattern": "^/" }, "uniqueItems": true
+    },
+    "allow_atomic_governance_cutover": {
+      "type": "boolean"
     }
   }
 }

--- a/src/checks/rules/governance-paths.mts
+++ b/src/checks/rules/governance-paths.mts
@@ -4,6 +4,7 @@ import type { RuleFamily } from "../rule-registry.mjs";
 
 interface GovernanceGrantProjection {
   authorized_governance_paths?: unknown;
+  allow_atomic_governance_cutover?: unknown;
 }
 
 interface TrustedAuthorizerProjection {
@@ -29,6 +30,7 @@ interface GovernanceCheckResult {
   trusted_authorized_governance_paths?: string[];
   unauthorized_paths?: string[];
   untrusted_governance_grant_ignored?: boolean;
+  atomic_governance_cutover?: boolean;
   details?: string[];
   hint?: string;
 }
@@ -56,16 +58,26 @@ export function checkGovernanceChangeAuthorization({ files, governancePaths, gov
   if (!patterns.length && !governanceChange) return { ok: true };
 
   const touched = files.filter((file) => matchesBoundary(file.path)).map((file) => file.path);
-  const nonGovernance = governanceChange ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path) : [];
-  if (!governanceChange && !touched.length) return { ok: true, touched_governance_paths: [] };
-
   const declared = Array.isArray(governanceGrant?.authorized_governance_paths) ? governanceGrant.authorized_governance_paths as string[] : [];
   const sourceTrusted = trusted(trustedAuthorizer), authorized = sourceTrusted ? declared : [];
+  // Mixed files are allowed only for an explicitly trusted atomic cutover.
+  // This does not authorize governance files themselves: those still require
+  // matching authorized_governance_paths below, and ordinary scope/must-not
+  // rules remain independent vetoes.
+  const atomicGovernanceCutover = governanceChange
+    && governanceGrant?.allow_atomic_governance_cutover === true
+    && sourceTrusted;
+  const nonGovernance = governanceChange && !atomicGovernanceCutover
+    ? files.filter((file) => !matchesBoundary(file.path)).map((file) => file.path)
+    : [];
+  if (!governanceChange && !touched.length) return { ok: true, touched_governance_paths: [] };
+
   const unauthorized = touched.filter((path) => !matchesAny(path, expandGovernancePatterns(authorized)));
   const details = [
     ...nonGovernance.map((path) => `governance ChangeIntent cannot change non-governance path ${path}`),
     ...unauthorized.map((path) => `governance path ${path} changed without matching GovernanceGrant authorization`),
   ];
+  if (atomicGovernanceCutover) details.push("Trusted atomic governance cutover permits scoped non-governance files");
   if (declared.length && !sourceTrusted) details.push("GovernanceGrant is ignored because no trusted authorizer was detected");
   const ok = !nonGovernance.length && !unauthorized.length;
   return {
@@ -78,8 +90,9 @@ export function checkGovernanceChangeAuthorization({ files, governancePaths, gov
     trusted_authorized_governance_paths: authorized,
     unauthorized_paths: unauthorized,
     untrusted_governance_grant_ignored: declared.length > 0 && !sourceTrusted,
+    atomic_governance_cutover: atomicGovernanceCutover,
     details,
-    hint: ok ? undefined : "Use a dedicated governance-only diff and authorize every touched governance path from a trusted linked-issue GovernanceGrant.",
+    hint: ok ? undefined : "Use a dedicated governance-only diff, or a trusted atomic governance cutover, and authorize every touched governance path from a trusted linked-issue GovernanceGrant.",
   };
 }
 

--- a/tests/test-atomic-governance-cutover.mjs
+++ b/tests/test-atomic-governance-cutover.mjs
@@ -1,5 +1,6 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
+import { checkGovernanceChangeAuthorization } from "../dist/checks/rules/governance-paths.mjs";
 import { checkPolicyRelaxation } from "../dist/checks/rules/policy-delta-rules.mjs";
 
 const file = (path) => ({ path, status: "modified", addedLines: [], deletedLines: [] });
@@ -18,6 +19,7 @@ const BASE = {
 const HEAD = structuredClone(BASE);
 HEAD.size_rules[0].max = 20;
 const FULL_GRANT = {
+  authorized_governance_paths: ["repo-policy.json"],
   allow_policy_relaxation: ["/size_rules/source/max"],
   allow_atomic_governance_cutover: true,
 };
@@ -34,9 +36,20 @@ function check(overrides = {}) {
   });
 }
 
+function checkGovernance(overrides = {}) {
+  return checkGovernanceChangeAuthorization({
+    files: [file("repo-policy.json"), file("src/runtime.mjs")],
+    governancePaths: ["repo-policy.json"],
+    governanceGrant: FULL_GRANT,
+    trustedAuthorizer: TRUSTED,
+    changeIntentType: "governance",
+    ...overrides,
+  });
+}
+
 describe("atomic governance cutover authorization", () => {
   it("keeps mixed policy relaxation blocked without explicit opt-in", () => {
-    const result = check({ governanceGrant: { allow_policy_relaxation: ["/size_rules/source/max"] } });
+    const result = check({ governanceGrant: { authorized_governance_paths: ["repo-policy.json"], allow_policy_relaxation: ["/size_rules/source/max"] } });
     assert.equal(result.ok, false);
     assert.ok(result.blocked_reasons.includes("policy_relaxation_mixed_with_non_governance_changes"));
   });
@@ -78,10 +91,38 @@ describe("atomic governance cutover authorization", () => {
   it("does not change the ordinary trusted governance-only path", () => {
     const result = check({
       changedFiles: [file("repo-policy.json")],
-      governanceGrant: { allow_policy_relaxation: ["/size_rules/source/max"] },
+      governanceGrant: { authorized_governance_paths: ["repo-policy.json"], allow_policy_relaxation: ["/size_rules/source/max"] },
     });
     assert.equal(result.ok, true);
     assert.equal(result.governance_only, true);
     assert.equal(result.atomic_governance_cutover, false);
+  });
+
+  it("keeps ordinary governance ChangeIntent mixed paths blocked without atomic opt-in", () => {
+    const result = checkGovernance({ governanceGrant: { authorized_governance_paths: ["repo-policy.json"] } });
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.non_governance_paths, ["src/runtime.mjs"]);
+  });
+
+  it("allows scoped mixed paths for a trusted atomic cutover while still authorizing governance paths", () => {
+    const result = checkGovernance();
+    assert.equal(result.ok, true);
+    assert.equal(result.atomic_governance_cutover, true);
+    assert.deepEqual(result.non_governance_paths, []);
+    assert.deepEqual(result.unauthorized_paths, []);
+  });
+
+  it("does not let atomic mode waive governance-path authorization", () => {
+    const result = checkGovernance({ governanceGrant: { ...FULL_GRANT, authorized_governance_paths: ["other-policy.json"] } });
+    assert.equal(result.ok, false);
+    assert.deepEqual(result.unauthorized_paths, ["repo-policy.json"]);
+  });
+
+  it("does not let an untrusted atomic grant permit mixed paths", () => {
+    const result = checkGovernance({ trustedAuthorizer: UNTRUSTED });
+    assert.equal(result.ok, false);
+    assert.equal(result.atomic_governance_cutover, false);
+    assert.deepEqual(result.non_governance_paths, ["src/runtime.mjs"]);
+    assert.deepEqual(result.unauthorized_paths, ["repo-policy.json"]);
   });
 });


### PR DESCRIPTION
Closes #300

Completes the atomic governance cutover feature introduced by #299:

- schemas `allow_atomic_governance_cutover` as a strict boolean GovernanceGrant property;
- allows non-governance files under a `governance` ChangeIntent only when the atomic flag comes from a trusted grant;
- continues to require explicit trusted `authorized_governance_paths` coverage for every touched governance path;
- does not alter ordinary scope/must-touch/must-not-touch or policy-relaxation pointer checks;
- extends the atomic-cutover negative matrix for default, untrusted, and unauthorized-governance cases;
- refreshes checked-in runtime dist.

This is a fail-closed completion required by the first real consumer `netkeep80/anum_docs#568`.