### PR TITLE
[Node 24] Run repo-guard Action and self-CI on Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - run: npm ci
 
@@ -82,11 +82,11 @@ jobs:
   smoke-pack:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - run: npm ci
 

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -17,14 +17,14 @@ jobs:
   verify-release-ref:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Verify package version has a published Action ref
         env:

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
   node-version:
     description: "Node.js version to use when running repo-guard."
     required: false
-    default: "20"
+    default: "24"
 
 outputs:
   result:
@@ -72,7 +72,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "Unlicense",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "Unlicense",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=24.0.0"
   },
   "dependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
Closes #302

Переводит исполняемую инфраструктуру repo-guard на Node.js 24 без изменения семантики политики, схем, dist или package dependency surface.

Изменения:
- `action.yml`: Node 24 по умолчанию, `actions/setup-node@v6`;
- `.github/workflows/ci.yml`: `checkout@v6`, `setup-node@v6`, Node 24;
- `.github/workflows/release-integrity.yml`: тот же Node 24 baseline.

Exact pre-PR evidence:

```text
base main = e95fe766b0e13219d09a16d7f64761e2a8dab872
head = 014c7df9d6474de774f2f4780766f81ec5ebbeda
behind_by = 0
changed files = 3
package.json = unchanged
package-lock.json = unchanged
repo-policy.json = unchanged
src/dist/schemas/tests = unchanged
open PR before creation = none
```

Upstream Actions v6 используют `runs.using = node24`.