### PR TITLE
[Parallel P0] Make execution phases explicit

### DIFF
--- a/dist/checks/default-rule-families.mjs
+++ b/dist/checks/default-rule-families.mjs
@@ -5,13 +5,16 @@ import { contentRuleFamily } from "./rules/content-rules.mjs";
 import { governancePathsRuleFamily } from "./rules/governance-paths.mjs";
 import { policyRelaxationRuleFamily } from "./rules/policy-delta-rules.mjs";
 import { createRuleRegistry } from "./rule-registry.mjs";
+function withPhase(family, phase) {
+    return { ...family, phase };
+}
 export const defaultRuleFamilies = [
-    constraintRuleFamily,
-    governancePathsRuleFamily,
-    policyRelaxationRuleFamily,
-    advisoryTextRuleFamily,
-    anchorExtractionRuleFamily,
-    contentRuleFamily,
+    withPhase(constraintRuleFamily, "both"),
+    withPhase(governancePathsRuleFamily, "transaction"),
+    withPhase(policyRelaxationRuleFamily, "transaction"),
+    withPhase(advisoryTextRuleFamily, "transaction"),
+    withPhase(anchorExtractionRuleFamily, "both"),
+    withPhase(contentRuleFamily, "transaction"),
 ];
 export function createDefaultRuleRegistry() {
     const registry = createRuleRegistry();

--- a/dist/checks/rule-registry.mjs
+++ b/dist/checks/rule-registry.mjs
@@ -1,3 +1,6 @@
+function isExecutionPhase(value) {
+    return value === "transaction" || value === "state" || value === "both";
+}
 function assertRuleFamily(family) {
     if (!family || typeof family !== "object") {
         throw new TypeError("rule family must be an object");
@@ -5,9 +8,26 @@ function assertRuleFamily(family) {
     if (!family.id || typeof family.id !== "string") {
         throw new TypeError("rule family requires a string id");
     }
+    if (!isExecutionPhase(family.phase)) {
+        throw new TypeError(`rule family "${family.id}" requires phase transaction, state, or both`);
+    }
     if (typeof family.evaluate !== "function") {
         throw new TypeError(`rule family "${family.id}" requires an evaluate function`);
     }
+}
+function requestedExecutionPhase(context) {
+    if (!context || typeof context !== "object" || !("executionPhase" in context))
+        return "both";
+    const phase = context.executionPhase;
+    if (phase === undefined)
+        return "both";
+    if (!isExecutionPhase(phase)) {
+        throw new TypeError("execution phase must be transaction, state, or both");
+    }
+    return phase;
+}
+function appliesToExecutionPhase(family, requested) {
+    return requested === "both" || family.phase === "both" || family.phase === requested;
 }
 function normalizeRuleEntries(family, entries) {
     const list = Array.isArray(entries) ? entries : [entries];
@@ -41,7 +61,10 @@ export function createRuleRegistry() {
             return families.map((family) => family.id);
         },
         evaluate(facts, context = {}) {
+            const executionPhase = requestedExecutionPhase(context);
             return families.flatMap((family) => {
+                if (!appliesToExecutionPhase(family, executionPhase))
+                    return [];
                 if (family.applies && !family.applies(facts, context))
                     return [];
                 return normalizeRuleEntries(family, family.evaluate(facts, context));

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -39,6 +39,23 @@ function constraintAppliesToPhase(constraint, requested) {
         throw new Error(`runtime constraint kind "${constraint.kind}" has no execution phase`);
     return requested === "both" || phase === "both" || phase === requested;
 }
+function projectSizeRules(rules, requested) {
+    if (requested === "both")
+        return rules;
+    return rules.flatMap((rule) => {
+        const transactionBound = rule.count === "changed_only" || rule.applies_to_change_types !== undefined;
+        if (requested === "state") {
+            if (transactionBound || rule.max === undefined)
+                return [];
+            return [{ ...rule, max_growth: undefined }];
+        }
+        if (transactionBound)
+            return [rule];
+        if (rule.max_growth === undefined)
+            return [];
+        return [{ ...rule, max: undefined }];
+    });
+}
 function budget(selected, max) {
     if (max === undefined)
         return { ok: true };
@@ -207,7 +224,10 @@ export function evaluateConstraintIR(facts, context = {}) {
             continue;
         }
         else if (constraint.kind === "size_rules") {
-            const result = checkSizeRules(files, constraint.rules, {
+            const rules = projectSizeRules(constraint.rules, executionPhase);
+            if (!rules.length)
+                continue;
+            const result = checkSizeRules(files, rules, {
                 repoRoot: facts.repositoryRoot, trackedFiles: facts.trackedFiles, readFile: facts.readFile,
                 ignorePatterns: facts.policy.paths.operational_paths, changeType: facts.changeIntent?.change_type,
             });

--- a/dist/checks/rules/constraints.mjs
+++ b/dist/checks/rules/constraints.mjs
@@ -8,6 +8,37 @@ import { checkTraceRuleResult } from "../trace-rules.mjs";
 import { checkChangeProfile } from "./change-profiles.mjs";
 import { checkRegistryRules } from "./registry-rules.mjs";
 import { checkSizeRules } from "./size-rules.mjs";
+const CONSTRAINT_PHASES = {
+    max_metric: "transaction",
+    surface_debt: "transaction",
+    scope_paths: "transaction",
+    require_paths: "transaction",
+    forbid_paths: "transaction",
+    implies_nonempty: "transaction",
+    size_rules: "both",
+    registry_rules: "state",
+    change_profile: "transaction",
+    trace_rules: "transaction",
+    integration: "state",
+    document_scalar_equal: "state",
+    document_scalar_equals_literal: "state",
+    document_referenced_paths_exist: "state",
+    evidence_workflow_path_coverage: "state",
+    evidence_anchor_value_coverage: "state",
+};
+function requestedExecutionPhase(context) {
+    const phase = context.executionPhase ?? "both";
+    if (phase !== "transaction" && phase !== "state" && phase !== "both") {
+        throw new TypeError("execution phase must be transaction, state, or both");
+    }
+    return phase;
+}
+function constraintAppliesToPhase(constraint, requested) {
+    const phase = CONSTRAINT_PHASES[constraint.kind];
+    if (!phase)
+        throw new Error(`runtime constraint kind "${constraint.kind}" has no execution phase`);
+    return requested === "both" || phase === "both" || phase === requested;
+}
 function budget(selected, max) {
     if (max === undefined)
         return { ok: true };
@@ -148,8 +179,11 @@ function checkEvidenceAnchorValueCoverage(facts, constraint) {
     };
 }
 export function evaluateConstraintIR(facts, context = {}) {
+    const executionPhase = requestedExecutionPhase(context);
     const { files, constraints } = compileConstraintIR(facts), results = [], cochange = [];
     for (const constraint of constraints) {
+        if (!constraintAppliesToPhase(constraint, executionPhase))
+            continue;
         let check;
         if (constraint.kind === "max_metric")
             check = evaluateMetric(files, constraint, facts.policy);
@@ -206,10 +240,12 @@ export function evaluateConstraintIR(facts, context = {}) {
         else if (constraint.kind === "evidence_anchor_value_coverage")
             check = checkEvidenceAnchorValueCoverage(facts, constraint);
         else
-            continue;
+            throw new Error(`runtime constraint kind "${constraint.kind}" is unsupported`);
         results.push({ name: constraint.name, check });
     }
-    results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed.join(",")} -> ${item.must_change_any.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));
+    if (executionPhase !== "state") {
+        results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed.join(",")} -> ${item.must_change_any.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));
+    }
     return results;
 }
 export const constraintRuleFamily = { id: "constraints", evaluate: (facts, context) => evaluateConstraintIR(facts, context) };

--- a/dist/runtime/pipeline.mjs
+++ b/dist/runtime/pipeline.mjs
@@ -27,7 +27,11 @@ export function runPolicyPipeline(input, options = {}) {
     const anchorDiagnostics = buildAnchorDiagnostics(facts);
     // Префикс меняет только diagnostic namespace; вычисление остаётся в одном canonical
     // pipeline и одном RuleRegistry, чтобы base/head не получили разные semantics engines.
-    runPolicyChecks(facts, { report }, { anchorDiagnostics, excludeFamilies: options.excludeRuleFamilies });
+    runPolicyChecks(facts, { report }, {
+        anchorDiagnostics,
+        excludeFamilies: options.excludeRuleFamilies,
+        executionPhase: options.executionPhase,
+    });
     return reporter.finish({
         command: input.mode,
         repositoryRoot: facts.repositoryRoot,
@@ -36,6 +40,7 @@ export function runPolicyPipeline(input, options = {}) {
             checkedFiles: facts.diff.files.checked.length,
             skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
         },
+        ...(options.executionPhase ? { executionPhase: options.executionPhase } : {}),
         ...anchorDiagnostics,
     });
 }

--- a/src/checks/default-rule-families.mts
+++ b/src/checks/default-rule-families.mts
@@ -4,16 +4,20 @@ import { constraintRuleFamily } from "./rules/constraints.mjs";
 import { contentRuleFamily } from "./rules/content-rules.mjs";
 import { governancePathsRuleFamily } from "./rules/governance-paths.mjs";
 import { policyRelaxationRuleFamily } from "./rules/policy-delta-rules.mjs";
-import type { RuleFamily, RuleRegistry } from "./rule-registry.mjs";
+import type { ExecutionPhase, RuleFamily, RuleRegistry } from "./rule-registry.mjs";
 import { createRuleRegistry } from "./rule-registry.mjs";
 
+function withPhase(family: RuleFamily, phase: ExecutionPhase): RuleFamily {
+  return { ...family, phase };
+}
+
 export const defaultRuleFamilies: RuleFamily[] = [
-  constraintRuleFamily,
-  governancePathsRuleFamily,
-  policyRelaxationRuleFamily,
-  advisoryTextRuleFamily,
-  anchorExtractionRuleFamily,
-  contentRuleFamily,
+  withPhase(constraintRuleFamily, "both"),
+  withPhase(governancePathsRuleFamily, "transaction"),
+  withPhase(policyRelaxationRuleFamily, "transaction"),
+  withPhase(advisoryTextRuleFamily, "transaction"),
+  withPhase(anchorExtractionRuleFamily, "both"),
+  withPhase(contentRuleFamily, "transaction"),
 ];
 
 export function createDefaultRuleRegistry(): RuleRegistry {

--- a/src/checks/orchestrator.mts
+++ b/src/checks/orchestrator.mts
@@ -1,5 +1,5 @@
 import { createDefaultRuleRegistry } from "./default-rule-families.mjs";
-import type { RuleRegistry } from "./rule-registry.mjs";
+import type { ExecutionPhase, RuleRegistry } from "./rule-registry.mjs";
 
 export interface PolicyCheckReporter {
   report(name: string, check: unknown): unknown;
@@ -8,6 +8,7 @@ export interface PolicyCheckReporter {
 export interface PolicyCheckOptions extends Record<string, unknown> {
   registry?: RuleRegistry;
   excludeFamilies?: readonly string[];
+  executionPhase?: ExecutionPhase;
 }
 
 export function runPolicyChecks(facts: unknown, reporter: PolicyCheckReporter, options: PolicyCheckOptions = {}): void {

--- a/src/checks/rule-registry.mts
+++ b/src/checks/rule-registry.mts
@@ -1,3 +1,5 @@
+export type ExecutionPhase = "transaction" | "state" | "both";
+
 export interface RuleEntry {
   name: string;
   check: unknown;
@@ -9,8 +11,13 @@ export interface NormalizedRuleEntry extends RuleEntry {
 
 export interface RuleFamily {
   id: string;
+  phase?: ExecutionPhase;
   applies?: (facts: unknown, context: unknown) => unknown;
   evaluate: (facts: unknown, context: unknown) => RuleEntry | readonly RuleEntry[] | null | undefined | false;
+}
+
+interface ClassifiedRuleFamily extends RuleFamily {
+  phase: ExecutionPhase;
 }
 
 export interface RuleRegistry<Facts = unknown, Context = Record<string, unknown>> {
@@ -19,19 +26,40 @@ export interface RuleRegistry<Facts = unknown, Context = Record<string, unknown>
   evaluate(facts: Facts, context?: Context): NormalizedRuleEntry[];
 }
 
-function assertRuleFamily(family: unknown): asserts family is RuleFamily {
+function isExecutionPhase(value: unknown): value is ExecutionPhase {
+  return value === "transaction" || value === "state" || value === "both";
+}
+
+function assertRuleFamily(family: unknown): asserts family is ClassifiedRuleFamily {
   if (!family || typeof family !== "object") {
     throw new TypeError("rule family must be an object");
   }
   if (!(family as Partial<RuleFamily>).id || typeof (family as Partial<RuleFamily>).id !== "string") {
     throw new TypeError("rule family requires a string id");
   }
+  if (!isExecutionPhase((family as Partial<RuleFamily>).phase)) {
+    throw new TypeError(`rule family "${(family as Partial<RuleFamily>).id}" requires phase transaction, state, or both`);
+  }
   if (typeof (family as Partial<RuleFamily>).evaluate !== "function") {
     throw new TypeError(`rule family "${(family as Partial<RuleFamily>).id}" requires an evaluate function`);
   }
 }
 
-function normalizeRuleEntries(family: RuleFamily, entries: ReturnType<RuleFamily["evaluate"]>): NormalizedRuleEntry[] {
+function requestedExecutionPhase(context: unknown): ExecutionPhase {
+  if (!context || typeof context !== "object" || !("executionPhase" in context)) return "both";
+  const phase = (context as { executionPhase?: unknown }).executionPhase;
+  if (phase === undefined) return "both";
+  if (!isExecutionPhase(phase)) {
+    throw new TypeError("execution phase must be transaction, state, or both");
+  }
+  return phase;
+}
+
+function appliesToExecutionPhase(family: ClassifiedRuleFamily, requested: ExecutionPhase): boolean {
+  return requested === "both" || family.phase === "both" || family.phase === requested;
+}
+
+function normalizeRuleEntries(family: ClassifiedRuleFamily, entries: ReturnType<RuleFamily["evaluate"]>): NormalizedRuleEntry[] {
   const list = Array.isArray(entries) ? entries : [entries];
   return list
     .filter(Boolean)
@@ -48,7 +76,7 @@ function normalizeRuleEntries(family: RuleFamily, entries: ReturnType<RuleFamily
 }
 
 export function createRuleRegistry<Facts = unknown, Context = Record<string, unknown>>(): RuleRegistry<Facts, Context> {
-  const families: RuleFamily[] = [];
+  const families: ClassifiedRuleFamily[] = [];
   const ids = new Set<string>();
 
   return {
@@ -67,7 +95,9 @@ export function createRuleRegistry<Facts = unknown, Context = Record<string, unk
     },
 
     evaluate(facts: Facts, context = {} as Context) {
+      const executionPhase = requestedExecutionPhase(context);
       return families.flatMap((family) => {
+        if (!appliesToExecutionPhase(family, executionPhase)) return [];
         if (family.applies && !family.applies(facts, context)) return [];
         return normalizeRuleEntries(family, family.evaluate(facts, context));
       });

--- a/src/checks/rules/constraints.mts
+++ b/src/checks/rules/constraints.mts
@@ -116,6 +116,20 @@ function constraintAppliesToPhase(constraint: RuntimeConstraint, requested: Exec
   return requested === "both" || phase === "both" || phase === requested;
 }
 
+function projectSizeRules(rules: SizeRule[], requested: ExecutionPhase): SizeRule[] {
+  if (requested === "both") return rules;
+  return rules.flatMap((rule) => {
+    const transactionBound = rule.count === "changed_only" || rule.applies_to_change_types !== undefined;
+    if (requested === "state") {
+      if (transactionBound || rule.max === undefined) return [];
+      return [{ ...rule, max_growth: undefined }];
+    }
+    if (transactionBound) return [rule];
+    if (rule.max_growth === undefined) return [];
+    return [{ ...rule, max: undefined }];
+  });
+}
+
 function budget(selected: ParsedDiffFile[], max: number | undefined): BudgetResult {
   if (max === undefined) return { ok: true };
   return { ok: selected.length <= max, actual: selected.length, limit: max, files: selected.map((file) => file.path) };
@@ -247,7 +261,9 @@ export function evaluateConstraintIR(facts: ConstraintFacts, context: Constraint
       if (selectPaths(files, constraint.if_changed!).length && !selectPaths(files, constraint.must_change_any!).length) cochange.push(constraint);
       continue;
     } else if (constraint.kind === "size_rules") {
-      const result = checkSizeRules(files, constraint.rules as SizeRule[], {
+      const rules = projectSizeRules(constraint.rules as SizeRule[], executionPhase);
+      if (!rules.length) continue;
+      const result = checkSizeRules(files, rules, {
         repoRoot: facts.repositoryRoot, trackedFiles: facts.trackedFiles, readFile: facts.readFile,
         ignorePatterns: facts.policy.paths.operational_paths, changeType: facts.changeIntent?.change_type,
       });

--- a/src/checks/rules/constraints.mts
+++ b/src/checks/rules/constraints.mts
@@ -5,7 +5,7 @@ import { readDocumentFact, type DocumentFactSelector, type DocumentReader } from
 import { matchesAny } from "../../utils/path-patterns.mjs";
 import { compileConstraintProgram, runtimeConstraints } from "../constraint-program.mjs";
 import { checkWorkflowPathCoverage, integrationConstraintEntries } from "../integration-constraints.mjs";
-import type { RuleFamily } from "../rule-registry.mjs";
+import type { ExecutionPhase, RuleFamily } from "../rule-registry.mjs";
 import { checkTraceRuleResult } from "../trace-rules.mjs";
 import { checkChangeProfile } from "./change-profiles.mjs";
 import { checkRegistryRules } from "./registry-rules.mjs";
@@ -76,9 +76,45 @@ interface ConstraintFacts {
   integration?: unknown;
   anchors?: { byType?: Record<string, AnchorEvidenceInstance[]> };
 }
-interface ConstraintContext { anchorDiagnostics?: { traceRuleResults?: Array<{ id: string; [key: string]: unknown }> }; }
+interface ConstraintContext {
+  executionPhase?: ExecutionPhase;
+  anchorDiagnostics?: { traceRuleResults?: Array<{ id: string; [key: string]: unknown }> };
+}
 interface ConstraintIR { files: ParsedDiffFile[]; constraints: RuntimeConstraint[]; }
 interface RuleResult { name: string; check: unknown; }
+
+const CONSTRAINT_PHASES: Record<RuntimeConstraintKind, ExecutionPhase> = {
+  max_metric: "transaction",
+  surface_debt: "transaction",
+  scope_paths: "transaction",
+  require_paths: "transaction",
+  forbid_paths: "transaction",
+  implies_nonempty: "transaction",
+  size_rules: "both",
+  registry_rules: "state",
+  change_profile: "transaction",
+  trace_rules: "transaction",
+  integration: "state",
+  document_scalar_equal: "state",
+  document_scalar_equals_literal: "state",
+  document_referenced_paths_exist: "state",
+  evidence_workflow_path_coverage: "state",
+  evidence_anchor_value_coverage: "state",
+};
+
+function requestedExecutionPhase(context: ConstraintContext): ExecutionPhase {
+  const phase = context.executionPhase ?? "both";
+  if (phase !== "transaction" && phase !== "state" && phase !== "both") {
+    throw new TypeError("execution phase must be transaction, state, or both");
+  }
+  return phase;
+}
+
+function constraintAppliesToPhase(constraint: RuntimeConstraint, requested: ExecutionPhase): boolean {
+  const phase = CONSTRAINT_PHASES[constraint.kind];
+  if (!phase) throw new Error(`runtime constraint kind "${constraint.kind}" has no execution phase`);
+  return requested === "both" || phase === "both" || phase === requested;
+}
 
 function budget(selected: ParsedDiffFile[], max: number | undefined): BudgetResult {
   if (max === undefined) return { ok: true };
@@ -195,8 +231,10 @@ function checkEvidenceAnchorValueCoverage(facts: ConstraintFacts, constraint: Ru
 }
 
 export function evaluateConstraintIR(facts: ConstraintFacts, context: ConstraintContext = {}): RuleResult[] {
+  const executionPhase = requestedExecutionPhase(context);
   const { files, constraints } = compileConstraintIR(facts), results: RuleResult[] = [], cochange: RuntimeConstraint[] = [];
   for (const constraint of constraints) {
+    if (!constraintAppliesToPhase(constraint, executionPhase)) continue;
     let check: unknown;
     if (constraint.kind === "max_metric") check = evaluateMetric(files, constraint, facts.policy);
     else if (constraint.kind === "surface_debt") check = checkSurfaceDebt(files, constraint.debt);
@@ -229,10 +267,12 @@ export function evaluateConstraintIR(facts: ConstraintFacts, context: Constraint
     else if (constraint.kind === "document_referenced_paths_exist") check = checkDocumentReferencedPathsExist(facts, constraint);
     else if (constraint.kind === "evidence_workflow_path_coverage") check = checkEvidenceWorkflowPathCoverage(facts, constraint);
     else if (constraint.kind === "evidence_anchor_value_coverage") check = checkEvidenceAnchorValueCoverage(facts, constraint);
-    else continue;
+    else throw new Error(`runtime constraint kind "${(constraint as { kind?: unknown }).kind}" is unsupported`);
     results.push({ name: constraint.name, check });
   }
-  results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed!.join(",")} -> ${item.must_change_any!.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));
+  if (executionPhase !== "state") {
+    results.push(...(cochange.length ? cochange.map((item) => ({ name: `cochange: ${item.if_changed!.join(",")} -> ${item.must_change_any!.join(",")}`, check: { ok: false, must_touch: item.must_change_any } })) : [{ name: "cochange-rules", check: { ok: true } }]));
+  }
   return results;
 }
 

--- a/src/runtime/pipeline.mts
+++ b/src/runtime/pipeline.mts
@@ -1,6 +1,7 @@
 import type { RepositoryFactsInput } from "../facts/input.mjs";
 import { buildPolicyFacts } from "../facts/input.mjs";
 import { runPolicyChecks } from "../checks/orchestrator.mjs";
+import type { ExecutionPhase } from "../checks/rule-registry.mjs";
 import { buildAnchorDiagnostics } from "../reporting/anchor-diagnostics.mjs";
 import { createAnalysisCollector } from "./analysis-report.mjs";
 import {
@@ -24,6 +25,7 @@ export interface PolicyPipelineOptions {
   printEnforcement?: boolean;
   ruleNamePrefix?: string;
   excludeRuleFamilies?: readonly string[];
+  executionPhase?: ExecutionPhase;
 }
 
 export function runPolicyPipeline(input: PolicyPipelineInput, options: PolicyPipelineOptions = {}) {
@@ -54,7 +56,11 @@ export function runPolicyPipeline(input: PolicyPipelineInput, options: PolicyPip
   const anchorDiagnostics = buildAnchorDiagnostics(facts);
   // Префикс меняет только diagnostic namespace; вычисление остаётся в одном canonical
   // pipeline и одном RuleRegistry, чтобы base/head не получили разные semantics engines.
-  runPolicyChecks(facts, { report }, { anchorDiagnostics, excludeFamilies: options.excludeRuleFamilies });
+  runPolicyChecks(facts, { report }, {
+    anchorDiagnostics,
+    excludeFamilies: options.excludeRuleFamilies,
+    executionPhase: options.executionPhase,
+  });
 
   return reporter.finish({
     command: input.mode,
@@ -64,6 +70,7 @@ export function runPolicyPipeline(input: PolicyPipelineInput, options: PolicyPip
       checkedFiles: facts.diff.files.checked.length,
       skippedOperationalFiles: facts.diagnostics.skippedOperationalFiles,
     },
+    ...(options.executionPhase ? { executionPhase: options.executionPhase } : {}),
     ...anchorDiagnostics,
   });
 }

--- a/tests/test-execution-phases.mjs
+++ b/tests/test-execution-phases.mjs
@@ -1,4 +1,5 @@
 import { createRuleRegistry } from "../dist/checks/rule-registry.mjs";
+import { defaultRuleFamilies } from "../dist/checks/default-rule-families.mjs";
 import { evaluateConstraintIR } from "../dist/checks/rules/constraints.mjs";
 import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
@@ -23,6 +24,10 @@ function hasName(entries, expected) {
 
 function namedCheck(entries, expected) {
   return entries.find((entry) => entry.name === expected)?.check;
+}
+
+function familyPhase(id) {
+  return defaultRuleFamilies.find((family) => family.id === id)?.phase;
 }
 
 const registry = createRuleRegistry();
@@ -93,10 +98,12 @@ expect(
   unknownPhaseError.includes("phase"),
   true
 );
+expect("governance authorization remains transaction-only", familyPhase("governance-paths"), "transaction");
+expect("policy relaxation authorization remains transaction-only", familyPhase("policy-delta"), "transaction");
 
 const documentContent = new Map([
   ["left.json", JSON.stringify({ items: ["src/a.mjs"] })],
-  ["right.json", JSON.stringify({ items: ["src/a.mjs"] })],
+  ["right.json", JSON.stringify({ items: ["src/b.mjs"] })],
 ]);
 const constraintFacts = {
   repositoryRoot: process.cwd(),
@@ -149,6 +156,7 @@ expect("transaction constraints keep diff budget", hasName(transactionConstraint
 expect("transaction constraints keep surface debt", hasName(transactionConstraints, "surface-debt"), true);
 expect("transaction constraints exclude registry state rule", hasName(transactionConstraints, "registry-rules"), false);
 expect("state constraints keep registry state rule", hasName(stateConstraints, "registry-rules"), true);
+expect("state constraints detect broken registry invariant", namedCheck(stateConstraints, "registry-rules").ok, false);
 expect("state constraints exclude diff budget", hasName(stateConstraints, "max-new-files"), false);
 expect("state constraints exclude surface debt", hasName(stateConstraints, "surface-debt"), false);
 expect("state constraints exclude cochange transaction summary", hasName(stateConstraints, "cochange-rules"), false);

--- a/tests/test-execution-phases.mjs
+++ b/tests/test-execution-phases.mjs
@@ -20,6 +20,10 @@ function hasName(entries, expected) {
   return entries.some((entry) => entry.name === expected);
 }
 
+function namedCheck(entries, expected) {
+  return entries.find((entry) => entry.name === expected)?.check;
+}
+
 const registry = createRuleRegistry();
 registry.register({
   id: "transaction-family",
@@ -147,6 +151,67 @@ expect("state constraints keep registry state rule", hasName(stateConstraints, "
 expect("state constraints exclude diff budget", hasName(stateConstraints, "max-new-files"), false);
 expect("state constraints exclude surface debt", hasName(stateConstraints, "surface-debt"), false);
 expect("state constraints exclude cochange transaction summary", hasName(stateConstraints, "cochange-rules"), false);
+
+const sizeFacts = {
+  repositoryRoot: process.cwd(),
+  trackedFiles: ["src/existing.mjs", "src/new.mjs"],
+  policy: {
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      operational_paths: [],
+    },
+    size_rules: [
+      {
+        id: "state-absolute",
+        scope: "directory",
+        metric: "files",
+        glob: "src/**",
+        max: 1,
+      },
+      {
+        id: "transaction-changed",
+        scope: "directory",
+        metric: "files",
+        glob: "src/**",
+        max: 0,
+        count: "changed_only",
+      },
+      {
+        id: "mixed-growth",
+        scope: "directory",
+        metric: "files",
+        glob: "src/**",
+        max: 2,
+        max_growth: 0,
+      },
+    ],
+  },
+  changeIntent: null,
+  diff: {
+    files: {
+      checked: [
+        {
+          path: "src/new.mjs",
+          status: "added",
+          addedLines: ["export const value = 1;"],
+          deletedLines: [],
+        },
+      ],
+    },
+  },
+};
+
+const stateSize = namedCheck(evaluateConstraintIR(sizeFacts, { executionPhase: "state" }), "size-rules");
+const transactionSize = namedCheck(evaluateConstraintIR(sizeFacts, { executionPhase: "transaction" }), "size-rules");
+
+expect("state size rules keep absolute repository invariant", stateSize.failed_rules.includes("state-absolute"), true);
+expect("state size rules exclude changed-only invariant", stateSize.failed_rules.includes("transaction-changed"), false);
+expect("state size rules strip growth facet from mixed invariant", stateSize.growth.length, 0);
+expect("transaction size rules exclude pure absolute repository invariant", transactionSize.failed_rules.includes("state-absolute"), false);
+expect("transaction size rules keep changed-only invariant", transactionSize.failed_rules.includes("transaction-changed"), true);
+expect("transaction size rules keep growth facet from mixed invariant", transactionSize.failed_rules.includes("mixed-growth"), true);
+expect("transaction size rules report mixed growth", transactionSize.growth.some((item) => item.ruleId === "mixed-growth"), true);
 
 console.log(`\n${failures === 0 ? "All execution phase tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-execution-phases.mjs
+++ b/tests/test-execution-phases.mjs
@@ -1,0 +1,88 @@
+import { createRuleRegistry } from "../dist/checks/rule-registry.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${expected}, got: ${actual}`);
+  }
+}
+
+function names(entries) {
+  return entries.map((entry) => entry.name).join(",");
+}
+
+const registry = createRuleRegistry();
+registry.register({
+  id: "transaction-family",
+  phase: "transaction",
+  evaluate: () => ({ name: "transaction-check", check: { ok: true } }),
+});
+registry.register({
+  id: "state-family",
+  phase: "state",
+  evaluate: () => ({ name: "state-check", check: { ok: true } }),
+});
+registry.register({
+  id: "both-family",
+  phase: "both",
+  evaluate: () => ({ name: "both-check", check: { ok: true } }),
+});
+
+expect(
+  "legacy/default evaluation still executes every classified family",
+  names(registry.evaluate({})),
+  "transaction-check,state-check,both-check"
+);
+expect(
+  "transaction phase executes transaction and both families only",
+  names(registry.evaluate({}, { executionPhase: "transaction" })),
+  "transaction-check,both-check"
+);
+expect(
+  "state phase executes state and both families only",
+  names(registry.evaluate({}, { executionPhase: "state" })),
+  "state-check,both-check"
+);
+expect(
+  "explicit both phase preserves legacy execution",
+  names(registry.evaluate({}, { executionPhase: "both" })),
+  "transaction-check,state-check,both-check"
+);
+
+let missingPhaseError = "";
+try {
+  createRuleRegistry().register({
+    id: "unclassified-family",
+    evaluate: () => ({ name: "unclassified-check", check: { ok: true } }),
+  });
+} catch (error) {
+  missingPhaseError = error.message;
+}
+expect(
+  "new rule family without phase classification fails closed",
+  missingPhaseError.includes("phase"),
+  true
+);
+
+let unknownPhaseError = "";
+try {
+  createRuleRegistry().register({
+    id: "unknown-phase-family",
+    phase: "future-phase",
+    evaluate: () => ({ name: "unknown-phase-check", check: { ok: true } }),
+  });
+} catch (error) {
+  unknownPhaseError = error.message;
+}
+expect(
+  "unknown rule family phase fails closed",
+  unknownPhaseError.includes("phase"),
+  true
+);
+
+console.log(`\n${failures === 0 ? "All execution phase tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-execution-phases.mjs
+++ b/tests/test-execution-phases.mjs
@@ -1,5 +1,6 @@
 import { createRuleRegistry } from "../dist/checks/rule-registry.mjs";
 import { evaluateConstraintIR } from "../dist/checks/rules/constraints.mjs";
+import { runPolicyPipeline } from "../dist/runtime/pipeline.mjs";
 
 let failures = 0;
 
@@ -212,6 +213,65 @@ expect("transaction size rules exclude pure absolute repository invariant", tran
 expect("transaction size rules keep changed-only invariant", transactionSize.failed_rules.includes("transaction-changed"), true);
 expect("transaction size rules keep growth facet from mixed invariant", transactionSize.failed_rules.includes("mixed-growth"), true);
 expect("transaction size rules report mixed growth", transactionSize.growth.some((item) => item.ruleId === "mixed-growth"), true);
+
+const pipelineFiles = new Map([
+  ["left.json", JSON.stringify({ items: ["src/a.mjs"] })],
+  ["right.json", JSON.stringify({ items: ["src/a.mjs"] })],
+]);
+const pipelineInput = {
+  mode: "check-diff",
+  repositoryRoot: "/tmp/repo-guard-phase-pipeline",
+  policy: {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      operational_paths: [],
+      governance_paths: [],
+    },
+    diff_rules: { max_new_files: 0 },
+    registry_rules: [
+      {
+        id: "pipeline-state-registry",
+        kind: "equal",
+        left: { type: "json_array", file: "left.json", json_pointer: "/items" },
+        right: { type: "json_array", file: "right.json", json_pointer: "/items" },
+      },
+    ],
+    content_rules: [],
+    cochange_rules: [],
+  },
+  changeIntent: null,
+  changeIntentSource: "none",
+  enforcement: { ok: true, mode: "blocking", source: "test", requested: "blocking" },
+  diffText: [
+    "diff --git a/src/new.mjs b/src/new.mjs",
+    "new file mode 100644",
+    "--- /dev/null",
+    "+++ b/src/new.mjs",
+    "+export const value = 1;",
+  ].join("\n"),
+  trackedFiles: ["left.json", "right.json", "src/new.mjs"],
+  readFile: (path) => pipelineFiles.get(path),
+};
+
+const legacyPipeline = runPolicyPipeline(pipelineInput, { quiet: true });
+const statePipeline = runPolicyPipeline(pipelineInput, { quiet: true, executionPhase: "state" });
+const transactionPipeline = runPolicyPipeline(pipelineInput, { quiet: true, executionPhase: "transaction" });
+const legacyPipelineRules = legacyPipeline.ruleResults.map((entry) => entry.rule);
+const statePipelineRules = statePipeline.ruleResults.map((entry) => entry.rule);
+const transactionPipelineRules = transactionPipeline.ruleResults.map((entry) => entry.rule);
+
+expect("legacy pipeline report keeps old machine shape", Object.prototype.hasOwnProperty.call(legacyPipeline, "executionPhase"), false);
+expect("state pipeline reports explicit execution phase", statePipeline.executionPhase, "state");
+expect("transaction pipeline reports explicit execution phase", transactionPipeline.executionPhase, "transaction");
+expect("legacy pipeline still executes transaction rule", legacyPipelineRules.includes("max-new-files"), true);
+expect("legacy pipeline still executes state rule", legacyPipelineRules.includes("registry-rules"), true);
+expect("state pipeline excludes transaction rule", statePipelineRules.includes("max-new-files"), false);
+expect("state pipeline executes state rule without ChangeIntent", statePipelineRules.includes("registry-rules"), true);
+expect("transaction pipeline executes transaction rule", transactionPipelineRules.includes("max-new-files"), true);
+expect("transaction pipeline excludes state rule", transactionPipelineRules.includes("registry-rules"), false);
 
 console.log(`\n${failures === 0 ? "All execution phase tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/tests/test-execution-phases.mjs
+++ b/tests/test-execution-phases.mjs
@@ -1,4 +1,5 @@
 import { createRuleRegistry } from "../dist/checks/rule-registry.mjs";
+import { evaluateConstraintIR } from "../dist/checks/rules/constraints.mjs";
 
 let failures = 0;
 
@@ -13,6 +14,10 @@ function expect(label, actual, expected) {
 
 function names(entries) {
   return entries.map((entry) => entry.name).join(",");
+}
+
+function hasName(entries, expected) {
+  return entries.some((entry) => entry.name === expected);
 }
 
 const registry = createRuleRegistry();
@@ -83,6 +88,65 @@ expect(
   unknownPhaseError.includes("phase"),
   true
 );
+
+const documentContent = new Map([
+  ["left.json", JSON.stringify({ items: ["src/a.mjs"] })],
+  ["right.json", JSON.stringify({ items: ["src/a.mjs"] })],
+]);
+const constraintFacts = {
+  repositoryRoot: process.cwd(),
+  trackedFiles: [...documentContent.keys(), "src/new.mjs"],
+  readFile: (path) => documentContent.get(path),
+  policy: {
+    paths: {
+      forbidden: ["secrets/**"],
+      canonical_docs: [],
+      operational_paths: [],
+    },
+    diff_rules: {
+      max_new_files: 0,
+    },
+    registry_rules: [
+      {
+        id: "state-registry",
+        kind: "equal",
+        left: { type: "json_array", file: "left.json", json_pointer: "/items" },
+        right: { type: "json_array", file: "right.json", json_pointer: "/items" },
+      },
+    ],
+  },
+  changeIntent: null,
+  diff: {
+    files: {
+      checked: [
+        {
+          path: "src/new.mjs",
+          status: "added",
+          addedLines: ["export const value = 1;"],
+          deletedLines: [],
+        },
+      ],
+    },
+  },
+};
+
+const legacyConstraints = evaluateConstraintIR(constraintFacts);
+const explicitBothConstraints = evaluateConstraintIR(constraintFacts, { executionPhase: "both" });
+const transactionConstraints = evaluateConstraintIR(constraintFacts, { executionPhase: "transaction" });
+const stateConstraints = evaluateConstraintIR(constraintFacts, { executionPhase: "state" });
+
+expect(
+  "explicit both keeps constraint evaluation byte-order compatible with legacy",
+  names(explicitBothConstraints),
+  names(legacyConstraints)
+);
+expect("transaction constraints keep diff budget", hasName(transactionConstraints, "max-new-files"), true);
+expect("transaction constraints keep surface debt", hasName(transactionConstraints, "surface-debt"), true);
+expect("transaction constraints exclude registry state rule", hasName(transactionConstraints, "registry-rules"), false);
+expect("state constraints keep registry state rule", hasName(stateConstraints, "registry-rules"), true);
+expect("state constraints exclude diff budget", hasName(stateConstraints, "max-new-files"), false);
+expect("state constraints exclude surface debt", hasName(stateConstraints, "surface-debt"), false);
+expect("state constraints exclude cochange transaction summary", hasName(stateConstraints, "cochange-rules"), false);
 
 console.log(`\n${failures === 0 ? "All execution phase tests passed" : `${failures} test(s) failed`}`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Краткое описание

Implements #305 as an internal execution-phase boundary for the existing canonical policy pipeline.

The same RuleRegistry / Constraint Program / evaluator is reused. Existing callers remain on legacy/default `both` semantics unless they explicitly request `transaction` or `state`.

No public policy schema, ChangeIntent schema, CLI command, Action input, workflow, or governance path is changed.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/checks/**
  - src/runtime/pipeline.mts
  - dist/checks/**
  - dist/runtime/pipeline.mjs
  - tests/test-execution-phases.mjs
budgets:
  max_new_docs: 0
  max_new_files: 1
  max_net_added_lines: 550
anchors:
  affects:
    - "#304"
    - "#305"
  implements:
    - "#305"
  verifies:
    - "transaction/state phase selection"
must_touch:
  - tests/**
must_not_touch:
  - schemas/**
  - .github/**
  - repo-policy.json
  - action.yml
expected_effects:
  - Legacy/default policy execution remains behavior-compatible with v2.
  - State-only execution can omit transaction-only rules without a fake ChangeIntent.
  - Every registered rule family must declare transaction/state/both applicability.
  - Mixed size rules project absolute and growth/change-context facets onto the correct execution phase.
  - Explicit execution phase is machine-visible while legacy report shape stays unchanged.
```

## Реализация

- RuleRegistry requires explicit family applicability: `transaction | state | both` and fails closed on missing/unknown values.
- Built-in families are classified centrally; no second rule engine is introduced.
- Runtime Constraint Program kinds have explicit phase applicability and unknown runtime kinds fail closed.
- `size_rules` is projected by facet: state keeps unconditional absolute repository bounds; transaction keeps changed/change-type/growth semantics; default `both` passes the original rules unchanged.
- `runPolicyPipeline(..., { executionPhase })` propagates the phase through the existing orchestrator and reports it only when explicitly selected.
- Normal existing pipeline calls do not add an `executionPhase` field and retain `both` behavior.

## TDD evidence

Four RED → GREEN cycles were executed through the repository's real GitHub Actions CI:

1. Rule-family classification/filtering
   - RED: run `32629192319`
   - GREEN: run `32629286039`
2. Runtime constraint filtering inside the single `constraints` family
   - RED: run `32629400006`
   - GREEN: run `32629550140`
3. Mixed `size_rules` absolute/growth/change-context semantics
   - RED: run `32629626822`
   - GREEN: run `32629730769`
4. Canonical pipeline option/report boundary
   - RED: run `32629884066`
   - GREEN: run `32629954465`

Final draft-head CI on `e7903a860b439e3f0657f8defbf6b34cab862ae5` is green for build/dist freshness, self-policy validation, integration validation, doctor, full tests, advisory exercise and package smoke. The blocking PR policy step remains intentionally skipped only because this PR is still draft; the next lifecycle transition is ready-for-review so that exact gate executes.

Refs #304, #305.