### PR TITLE
[Portable P1a] Add exact-snapshot integration planner

### DIFF
--- a/dist/portable-integration/planner.mjs
+++ b/dist/portable-integration/planner.mjs
@@ -1,0 +1,99 @@
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function isSha(value) {
+    return typeof value === "string" && SHA_PATTERN.test(value);
+}
+function isPositiveInteger(value) {
+    return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+function isNonEmptyString(value) {
+    return typeof value === "string" && value.trim().length > 0;
+}
+function isMergeability(value) {
+    return value === "mergeable" || value === "conflicting" || value === "unknown";
+}
+function isFreshnessStatus(value) {
+    return value === "current" || value === "behind" || value === "unknown";
+}
+function isGateStatus(value) {
+    return value === "success" || value === "pending" || value === "failure" || value === "missing";
+}
+function decision(kind, reason, identity) {
+    return {
+        kind,
+        prNumber: identity.prNumber,
+        mainSha: identity.mainSha,
+        headSha: identity.headSha,
+        reason,
+    };
+}
+function looseIdentity(input) {
+    if (!isObject(input))
+        return { prNumber: null, mainSha: null, headSha: null };
+    return {
+        prNumber: isPositiveInteger(input.prNumber) ? input.prNumber : null,
+        mainSha: isSha(input.currentMainSha) ? input.currentMainSha : null,
+        headSha: isSha(input.headSha) ? input.headSha : null,
+    };
+}
+function hasValidIdentity(input) {
+    return isSha(input.currentMainSha)
+        && isPositiveInteger(input.prNumber)
+        && isNonEmptyString(input.baseRef)
+        && isSha(input.baseSha)
+        && isSha(input.headSha)
+        && typeof input.ready === "boolean";
+}
+function hasValidFreshness(value) {
+    return isObject(value) && isSha(value.mainSha) && isFreshnessStatus(value.status);
+}
+function hasValidGate(value) {
+    return isObject(value) && isSha(value.headSha) && isGateStatus(value.status);
+}
+export function planPortableIntegration(input) {
+    const identity = looseIdentity(input);
+    if (!isObject(input) || !hasValidIdentity(input)) {
+        return decision("invalid_snapshot", "malformed_snapshot", identity);
+    }
+    const exactIdentity = {
+        prNumber: input.prNumber,
+        mainSha: input.currentMainSha,
+        headSha: input.headSha,
+    };
+    if (!input.ready) {
+        return decision("ignore_not_ready", "not_ready", exactIdentity);
+    }
+    if (!isMergeability(input.mergeability)
+        || !hasValidFreshness(input.freshness)
+        || !hasValidGate(input.transaction)
+        || !hasValidGate(input.state)) {
+        return decision("invalid_snapshot", "malformed_snapshot", exactIdentity);
+    }
+    if (input.freshness.mainSha !== input.currentMainSha) {
+        return decision("invalid_snapshot", "freshness_stale", exactIdentity);
+    }
+    if (input.mergeability === "unknown") {
+        return decision("invalid_snapshot", "mergeability_unknown", exactIdentity);
+    }
+    if (input.mergeability === "conflicting") {
+        return decision("block_conflict", "merge_conflict", exactIdentity);
+    }
+    if (input.freshness.status === "unknown") {
+        return decision("invalid_snapshot", "freshness_unknown", exactIdentity);
+    }
+    if (input.freshness.status === "behind") {
+        return decision("refresh_branch", "branch_behind", exactIdentity);
+    }
+    if (input.transaction.headSha !== input.headSha || input.state.headSha !== input.headSha) {
+        return decision("invalid_snapshot", "evidence_stale", exactIdentity);
+    }
+    if (input.transaction.status === "failure" || input.state.status === "failure") {
+        return decision("block_failed_checks", "checks_failed", exactIdentity);
+    }
+    if (input.transaction.status !== "success" || input.state.status !== "success") {
+        return decision("wait_for_checks", "checks_pending", exactIdentity);
+    }
+    return decision("merge_exact_head", "ready_to_merge", exactIdentity);
+}

--- a/src/portable-integration/planner.mts
+++ b/src/portable-integration/planner.mts
@@ -1,0 +1,193 @@
+export type PortableDecisionKind =
+  | "ignore_not_ready"
+  | "refresh_branch"
+  | "wait_for_checks"
+  | "merge_exact_head"
+  | "block_conflict"
+  | "block_failed_checks"
+  | "invalid_snapshot";
+
+export type PortableDecisionReason =
+  | "not_ready"
+  | "branch_behind"
+  | "merge_conflict"
+  | "checks_failed"
+  | "checks_pending"
+  | "malformed_snapshot"
+  | "freshness_stale"
+  | "freshness_unknown"
+  | "mergeability_unknown"
+  | "evidence_stale"
+  | "ready_to_merge";
+
+export type PortableMergeability = "mergeable" | "conflicting" | "unknown";
+export type PortableFreshnessStatus = "current" | "behind" | "unknown";
+export type PortableGateStatus = "success" | "pending" | "failure" | "missing";
+
+export interface PortableFreshnessEvidence {
+  mainSha: string;
+  status: PortableFreshnessStatus;
+}
+
+export interface PortableGateEvidence {
+  headSha: string;
+  status: PortableGateStatus;
+}
+
+export interface PortableCandidateSnapshot {
+  currentMainSha: string;
+  prNumber: number;
+  baseRef: string;
+  baseSha: string;
+  headSha: string;
+  ready: boolean;
+  mergeability: PortableMergeability;
+  freshness: PortableFreshnessEvidence;
+  transaction: PortableGateEvidence;
+  state: PortableGateEvidence;
+}
+
+export interface PortableIntegrationDecision {
+  kind: PortableDecisionKind;
+  prNumber: number | null;
+  mainSha: string | null;
+  headSha: string | null;
+  reason: PortableDecisionReason;
+}
+
+type LooseObject = Record<string, unknown>;
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function isObject(value: unknown): value is LooseObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSha(value: unknown): value is string {
+  return typeof value === "string" && SHA_PATTERN.test(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isMergeability(value: unknown): value is PortableMergeability {
+  return value === "mergeable" || value === "conflicting" || value === "unknown";
+}
+
+function isFreshnessStatus(value: unknown): value is PortableFreshnessStatus {
+  return value === "current" || value === "behind" || value === "unknown";
+}
+
+function isGateStatus(value: unknown): value is PortableGateStatus {
+  return value === "success" || value === "pending" || value === "failure" || value === "missing";
+}
+
+function decision(
+  kind: PortableDecisionKind,
+  reason: PortableDecisionReason,
+  identity: { prNumber: number | null; mainSha: string | null; headSha: string | null },
+): PortableIntegrationDecision {
+  return {
+    kind,
+    prNumber: identity.prNumber,
+    mainSha: identity.mainSha,
+    headSha: identity.headSha,
+    reason,
+  };
+}
+
+function looseIdentity(input: unknown) {
+  if (!isObject(input)) return { prNumber: null, mainSha: null, headSha: null };
+  return {
+    prNumber: isPositiveInteger(input.prNumber) ? input.prNumber : null,
+    mainSha: isSha(input.currentMainSha) ? input.currentMainSha : null,
+    headSha: isSha(input.headSha) ? input.headSha : null,
+  };
+}
+
+function hasValidIdentity(input: LooseObject): input is LooseObject & {
+  currentMainSha: string;
+  prNumber: number;
+  baseRef: string;
+  baseSha: string;
+  headSha: string;
+  ready: boolean;
+} {
+  return isSha(input.currentMainSha)
+    && isPositiveInteger(input.prNumber)
+    && isNonEmptyString(input.baseRef)
+    && isSha(input.baseSha)
+    && isSha(input.headSha)
+    && typeof input.ready === "boolean";
+}
+
+function hasValidFreshness(value: unknown): value is PortableFreshnessEvidence {
+  return isObject(value) && isSha(value.mainSha) && isFreshnessStatus(value.status);
+}
+
+function hasValidGate(value: unknown): value is PortableGateEvidence {
+  return isObject(value) && isSha(value.headSha) && isGateStatus(value.status);
+}
+
+export function planPortableIntegration(input: unknown): PortableIntegrationDecision {
+  const identity = looseIdentity(input);
+  if (!isObject(input) || !hasValidIdentity(input)) {
+    return decision("invalid_snapshot", "malformed_snapshot", identity);
+  }
+
+  const exactIdentity = {
+    prNumber: input.prNumber,
+    mainSha: input.currentMainSha,
+    headSha: input.headSha,
+  };
+
+  if (!input.ready) {
+    return decision("ignore_not_ready", "not_ready", exactIdentity);
+  }
+
+  if (!isMergeability(input.mergeability)
+    || !hasValidFreshness(input.freshness)
+    || !hasValidGate(input.transaction)
+    || !hasValidGate(input.state)) {
+    return decision("invalid_snapshot", "malformed_snapshot", exactIdentity);
+  }
+
+  if (input.freshness.mainSha !== input.currentMainSha) {
+    return decision("invalid_snapshot", "freshness_stale", exactIdentity);
+  }
+
+  if (input.mergeability === "unknown") {
+    return decision("invalid_snapshot", "mergeability_unknown", exactIdentity);
+  }
+
+  if (input.mergeability === "conflicting") {
+    return decision("block_conflict", "merge_conflict", exactIdentity);
+  }
+
+  if (input.freshness.status === "unknown") {
+    return decision("invalid_snapshot", "freshness_unknown", exactIdentity);
+  }
+
+  if (input.freshness.status === "behind") {
+    return decision("refresh_branch", "branch_behind", exactIdentity);
+  }
+
+  if (input.transaction.headSha !== input.headSha || input.state.headSha !== input.headSha) {
+    return decision("invalid_snapshot", "evidence_stale", exactIdentity);
+  }
+
+  if (input.transaction.status === "failure" || input.state.status === "failure") {
+    return decision("block_failed_checks", "checks_failed", exactIdentity);
+  }
+
+  if (input.transaction.status !== "success" || input.state.status !== "success") {
+    return decision("wait_for_checks", "checks_pending", exactIdentity);
+  }
+
+  return decision("merge_exact_head", "ready_to_merge", exactIdentity);
+}

--- a/tests/test-portable-integration-planner.mjs
+++ b/tests/test-portable-integration-planner.mjs
@@ -1,0 +1,142 @@
+import { strict as assert } from "node:assert";
+import { planPortableIntegration } from "../dist/portable-integration/planner.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+const MAIN = "1111111111111111111111111111111111111111";
+const HEAD = "2222222222222222222222222222222222222222";
+const OLD_MAIN = "3333333333333333333333333333333333333333";
+const OLD_HEAD = "4444444444444444444444444444444444444444";
+
+function snapshot(overrides = {}) {
+  return {
+    currentMainSha: MAIN,
+    prNumber: 42,
+    baseRef: "main",
+    baseSha: MAIN,
+    headSha: HEAD,
+    ready: true,
+    mergeability: "mergeable",
+    freshness: { mainSha: MAIN, status: "current" },
+    transaction: { headSha: HEAD, status: "success" },
+    state: { headSha: HEAD, status: "success" },
+    ...overrides,
+  };
+}
+
+console.log("\n--- portable integration planner exact snapshot contract ---");
+
+const merge = planPortableIntegration(snapshot());
+expect("fresh exact candidate is mergeable", merge.kind, "merge_exact_head");
+expect("merge decision carries exact main SHA", merge.mainSha, MAIN);
+expect("merge decision carries exact head SHA", merge.headSha, HEAD);
+expect("merge decision carries PR number", merge.prNumber, 42);
+expect("merge decision explains readiness", merge.reason, "ready_to_merge");
+
+const behind = planPortableIntegration(snapshot({ freshness: { mainSha: MAIN, status: "behind" } }));
+expect("behind candidate requests coordinator refresh", behind.kind, "refresh_branch");
+expect("behind candidate reason is explicit", behind.reason, "branch_behind");
+
+const behindWithOldGreenEvidence = planPortableIntegration(snapshot({
+  freshness: { mainSha: MAIN, status: "behind" },
+  transaction: { headSha: OLD_HEAD, status: "success" },
+  state: { headSha: OLD_HEAD, status: "success" },
+}));
+expect("behind candidate with old green evidence still refreshes instead of merging", behindWithOldGreenEvidence.kind, "refresh_branch");
+
+const staleHeadEvidence = planPortableIntegration(snapshot({
+  transaction: { headSha: OLD_HEAD, status: "success" },
+}));
+expect("stale transaction evidence cannot merge", staleHeadEvidence.kind, "invalid_snapshot");
+expect("stale transaction evidence is diagnosed", staleHeadEvidence.reason, "evidence_stale");
+
+const staleStateEvidence = planPortableIntegration(snapshot({
+  state: { headSha: OLD_HEAD, status: "success" },
+}));
+expect("stale state evidence cannot merge", staleStateEvidence.kind, "invalid_snapshot");
+expect("stale state evidence is diagnosed", staleStateEvidence.reason, "evidence_stale");
+
+const staleFreshness = planPortableIntegration(snapshot({
+  freshness: { mainSha: OLD_MAIN, status: "current" },
+}));
+expect("freshness evidence bound to an old main fails closed", staleFreshness.kind, "invalid_snapshot");
+expect("old-main freshness evidence is diagnosed", staleFreshness.reason, "freshness_stale");
+
+const baseMetadataCounterexample = planPortableIntegration(snapshot({
+  baseSha: MAIN,
+  freshness: { mainSha: MAIN, status: "behind" },
+}));
+expect("base SHA equality does not override explicit behind evidence", baseMetadataCounterexample.kind, "refresh_branch");
+
+const conflict = planPortableIntegration(snapshot({ mergeability: "conflicting" }));
+expect("conflicting candidate is blocked", conflict.kind, "block_conflict");
+expect("conflict reason is explicit", conflict.reason, "merge_conflict");
+
+const mergeabilityUnknown = planPortableIntegration(snapshot({ mergeability: "unknown" }));
+expect("unknown mergeability fails closed", mergeabilityUnknown.kind, "invalid_snapshot");
+expect("unknown mergeability is diagnosed", mergeabilityUnknown.reason, "mergeability_unknown");
+
+const freshnessUnknown = planPortableIntegration(snapshot({
+  freshness: { mainSha: MAIN, status: "unknown" },
+}));
+expect("unknown freshness fails closed", freshnessUnknown.kind, "invalid_snapshot");
+expect("unknown freshness is diagnosed", freshnessUnknown.reason, "freshness_unknown");
+
+const failedTransaction = planPortableIntegration(snapshot({
+  transaction: { headSha: HEAD, status: "failure" },
+}));
+expect("failed transaction gate blocks candidate", failedTransaction.kind, "block_failed_checks");
+expect("failed transaction gate reason is explicit", failedTransaction.reason, "checks_failed");
+
+const failedState = planPortableIntegration(snapshot({
+  state: { headSha: HEAD, status: "failure" },
+}));
+expect("failed state gate blocks candidate", failedState.kind, "block_failed_checks");
+
+const pending = planPortableIntegration(snapshot({
+  transaction: { headSha: HEAD, status: "pending" },
+}));
+expect("pending exact-head check waits", pending.kind, "wait_for_checks");
+expect("pending check reason is explicit", pending.reason, "checks_pending");
+
+const missing = planPortableIntegration(snapshot({
+  state: { headSha: HEAD, status: "missing" },
+}));
+expect("missing exact-head check waits", missing.kind, "wait_for_checks");
+
+const notReady = planPortableIntegration(snapshot({ ready: false }));
+expect("PR without READY marker is ignored", notReady.kind, "ignore_not_ready");
+expect("not-ready reason is explicit", notReady.reason, "not_ready");
+
+const malformedSha = planPortableIntegration(snapshot({ headSha: "not-a-sha" }));
+expect("malformed candidate SHA fails closed", malformedSha.kind, "invalid_snapshot");
+expect("malformed candidate is diagnosed", malformedSha.reason, "malformed_snapshot");
+
+const missingFreshness = planPortableIntegration({
+  ...snapshot(),
+  freshness: undefined,
+});
+expect("missing freshness evidence fails closed", missingFreshness.kind, "invalid_snapshot");
+expect("missing freshness is diagnosed", missingFreshness.reason, "malformed_snapshot");
+
+const malformedPr = planPortableIntegration(snapshot({ prNumber: 0 }));
+expect("invalid PR number fails closed", malformedPr.kind, "invalid_snapshot");
+
+const deterministicInput = snapshot();
+const first = JSON.stringify(planPortableIntegration(deterministicInput));
+const second = JSON.stringify(planPortableIntegration(deterministicInput));
+expect("same snapshot produces byte-stable decision", first, second);
+
+console.log(`\n${failures === 0 ? "All portable integration planner tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Краткое описание

Implements #313 as the first pure slice of portable provider #306.

A deterministic exact-snapshot planner now decides portable integration intent without GitHub/network/process/filesystem side effects. It does not call adapters, mutate repository state, execute PR code, change CLI/Action inputs, or touch the canonical Constraint Program / `check-pr` path.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/portable-integration/**
  - dist/portable-integration/**
  - tests/test-portable-integration-planner.mjs
budgets:
  max_new_docs: 0
  max_new_files: 3
  max_net_added_lines: 500
anchors:
  affects:
    - "#304"
    - "#306"
    - "#313"
  implements:
    - "#313"
  verifies:
    - "portable integration planner exact snapshot semantics"
must_touch:
  - tests/**
must_not_touch:
  - src/checks/**
  - src/github-pr.mts
  - schemas/**
  - .github/**
  - repo-policy.json
  - action.yml
expected_effects:
  - Pure deterministic planner makes no network, process or filesystem calls.
  - Freshness is explicit evidence bound to exact current main and is never inferred from PR base SHA.
  - Stale, incomplete or unknown evidence cannot produce merge_exact_head.
  - Existing check-pr and Constraint Program behavior remains untouched.
```

## Реализация

Provider-internal decisions are a finite exhaustive set:

```text
ignore_not_ready
refresh_branch
wait_for_checks
merge_exact_head
block_conflict
block_failed_checks
invalid_snapshot
```

The planner runtime-narrows an untrusted snapshot and carries exact `currentMainSha`, `prNumber` and `headSha` into every valid decision. Merge is possible only when:

- READY is explicit;
- mergeability is known and non-conflicting;
- freshness is `current` and bound to the exact current-main SHA;
- transaction and state evidence are both bound to the exact current head SHA;
- both exact-head gates are successful.

`baseSha` is intentionally informational only. A locked negative vector proves that `baseSha == currentMainSha` does not imply freshness: explicit `freshness=behind` still yields coordinator `refresh_branch`.

Malformed, stale, unknown, conflicting, failed and pending states are deterministic and fail closed / non-mergeable.

## TDD evidence

RED → GREEN was executed through the repository's real GitHub Actions CI.

### RED

- test-only head: `602eaa814893803b1da843602e4c300a41d2e1d0`;
- CI run `32631550163`;
- expected failure: `ERR_MODULE_NOT_FOUND` for intentionally absent `dist/portable-integration/planner.mjs`;
- `check:dist`, self policy/integration/doctor and package smoke were otherwise green.

### GREEN

- exact implementation head: `6c821f7f01df945df2c015cad03603d8b4c164d0`;
- CI run `32631747765` completed `success`;
- TypeScript 7.0.2 `check:dist` reports `Generated dist is current`;
- full suite: `All 44 test files passed`;
- every portable planner contract vector passed, including stale-main/head evidence, conflict, pending/failure, explicit-behind counterexample and byte-stable deterministic output;
- self policy validation, integration validation, doctor, advisory exercise and package smoke passed.

The blocking `Run PR policy check` is still intentionally skipped only because this PR remains draft. Next lifecycle transition is ready-for-review so the exact same head is checked by the blocking PR transaction gate.

## Diff review

Exactly three files are changed:

- `src/portable-integration/planner.mts`;
- generated `dist/portable-integration/planner.mjs`;
- `tests/test-portable-integration-planner.mjs`.

No prohibited governance/schema/workflow/check-pr/Constraint Program files are touched. The source planner has no imports and no side effects.

Refs #304, #306, #313.