### PR TITLE
[Portable P1b] Add read-only GitHub control-plane adapter

### DIFF
--- a/dist/portable-integration/github-read.mjs
+++ b/dist/portable-integration/github-read.mjs
@@ -1,0 +1,261 @@
+const SHA = /^[0-9a-f]{40}$/i;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const PENDING_CHECK_STATUSES = new Set(["queued", "in_progress", "requested", "waiting", "pending"]);
+const FAILED_CHECK_CONCLUSIONS = new Set([
+    "failure",
+    "cancelled",
+    "timed_out",
+    "action_required",
+    "stale",
+    "startup_failure",
+    "neutral",
+    "skipped",
+]);
+function fail(error, message) {
+    return { ok: false, error, message };
+}
+function isRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function isNonEmptyString(value) {
+    return typeof value === "string" && value.length > 0;
+}
+function isSha(value) {
+    return typeof value === "string" && SHA.test(value);
+}
+function isRepository(value) {
+    return typeof value === "string" && REPOSITORY.test(value);
+}
+function normalizePullRequest(input, readyLabel) {
+    if (!isRecord(input))
+        return fail("malformed_pull_request", "pull request must be an object");
+    const base = input.base, head = input.head, labels = input.labels;
+    if (!Number.isInteger(input.number) || input.number <= 0)
+        return fail("malformed_pull_request", "pull request number must be a positive integer");
+    if (typeof input.draft !== "boolean")
+        return fail("malformed_pull_request", "pull request draft must be boolean");
+    if (input.mergeable !== true && input.mergeable !== false && input.mergeable !== null)
+        return fail("malformed_pull_request", "pull request mergeable must be true, false, or null");
+    if (!isRecord(base) || !isNonEmptyString(base.ref) || !isSha(base.sha))
+        return fail("malformed_pull_request", "pull request base ref/SHA is malformed");
+    if (!isRecord(head) || !isNonEmptyString(head.ref) || !isSha(head.sha) || !isRecord(head.repo) || !isRepository(head.repo.full_name))
+        return fail("malformed_pull_request", "pull request head ref/SHA/repository is malformed");
+    if (!Array.isArray(labels))
+        return fail("malformed_pull_request", "pull request labels must be an array");
+    const labelNames = [];
+    for (const label of labels) {
+        if (!isRecord(label) || !isNonEmptyString(label.name))
+            return fail("malformed_pull_request", "pull request label is malformed");
+        labelNames.push(label.name);
+    }
+    const mergeability = input.mergeable === true
+        ? "mergeable"
+        : input.mergeable === false
+            ? "conflicting"
+            : "unknown";
+    return {
+        ok: true,
+        value: {
+            prNumber: input.number,
+            baseRef: base.ref,
+            baseSha: base.sha,
+            headRef: head.ref,
+            headSha: head.sha,
+            headRepository: head.repo.full_name,
+            draft: input.draft,
+            ready: !input.draft && labelNames.includes(readyLabel),
+            mergeability,
+        },
+    };
+}
+function normalizeRequiredChecks(input) {
+    if (!isRecord(input))
+        return fail("malformed_required_checks", "required checks must be an object");
+    const result = { transaction: [], state: [] };
+    for (const phase of ["transaction", "state"]) {
+        const raw = input[phase];
+        if (!Array.isArray(raw) || raw.length === 0)
+            return fail("malformed_required_checks", `${phase} required checks must be a non-empty array`);
+        const seen = new Set();
+        for (const item of raw) {
+            if (!isRecord(item) || !isNonEmptyString(item.name) || (item.appSlug !== undefined && !isNonEmptyString(item.appSlug)))
+                return fail("malformed_required_checks", `${phase} required check is malformed`);
+            const required = item.appSlug === undefined
+                ? { name: item.name }
+                : { name: item.name, appSlug: item.appSlug };
+            const key = `${required.name}\u0000${required.appSlug ?? ""}`;
+            if (seen.has(key))
+                return fail("malformed_required_checks", `${phase} required check is duplicated`);
+            seen.add(key);
+            result[phase].push(required);
+        }
+    }
+    return { ok: true, ...result };
+}
+function normalizeFreshness(input, currentMainSha, headSha) {
+    if (!isRecord(input) || !isSha(input.mainSha) || !isSha(input.headSha))
+        return fail("malformed_freshness_evidence", "compare evidence must contain exact main/head SHA");
+    if (input.mainSha !== currentMainSha || input.headSha !== headSha)
+        return fail("stale_freshness_evidence", "compare evidence is not bound to the current main/head snapshot");
+    if (input.status === "ahead" || input.status === "identical")
+        return { ok: true, status: "current" };
+    if (input.status === "behind" || input.status === "diverged")
+        return { ok: true, status: "behind" };
+    if (input.status === "unknown" || input.status === null)
+        return { ok: true, status: "unknown" };
+    return fail("unknown_compare_state", "compare evidence contains an unknown status");
+}
+function checkRunAppSlug(input) {
+    if (input.app === null || input.app === undefined)
+        return null;
+    if (!isRecord(input.app) || !isNonEmptyString(input.app.slug))
+        return undefined;
+    return input.app.slug;
+}
+function normalizeObservedCheck(input, headSha) {
+    if (!isNonEmptyString(input.name) || !isSha(input.head_sha))
+        return fail("malformed_check_run", "required check run name/head SHA is malformed");
+    if (input.head_sha !== headSha)
+        return fail("stale_check_evidence", "required check run is bound to another head SHA");
+    const appSlug = checkRunAppSlug(input);
+    if (appSlug === undefined)
+        return fail("malformed_check_run", "required check run app identity is malformed");
+    if (PENDING_CHECK_STATUSES.has(input.status)) {
+        if (input.conclusion !== null && input.conclusion !== undefined)
+            return fail("unknown_check_state", "non-completed required check unexpectedly has a conclusion");
+        return {
+            ok: true,
+            evidence: { name: input.name, headSha, status: "pending", conclusion: null, appSlug },
+        };
+    }
+    if (input.status !== "completed")
+        return fail("unknown_check_state", "required check run has an unknown status");
+    if (input.conclusion === "success") {
+        return {
+            ok: true,
+            evidence: { name: input.name, headSha, status: "success", conclusion: "success", appSlug },
+        };
+    }
+    if (typeof input.conclusion === "string" && FAILED_CHECK_CONCLUSIONS.has(input.conclusion)) {
+        return {
+            ok: true,
+            evidence: { name: input.name, headSha, status: "failure", conclusion: input.conclusion, appSlug },
+        };
+    }
+    return fail("unknown_check_state", "completed required check has an unknown conclusion");
+}
+function normalizeGate(runs, required, headSha) {
+    const evidence = [];
+    let missing = false;
+    for (const spec of required) {
+        const matching = runs.filter((run) => {
+            if (!isRecord(run) || run.name !== spec.name)
+                return false;
+            if (spec.appSlug === undefined)
+                return true;
+            return checkRunAppSlug(run) === spec.appSlug;
+        });
+        if (matching.length > 1)
+            return fail("duplicate_required_check", `required check ${spec.name} matched more than one run`);
+        if (matching.length === 0) {
+            missing = true;
+            continue;
+        }
+        const normalized = normalizeObservedCheck(matching[0], headSha);
+        if (!normalized.ok)
+            return normalized;
+        evidence.push(normalized.evidence);
+    }
+    const status = evidence.some((item) => item.status === "failure")
+        ? "failure"
+        : evidence.some((item) => item.status === "pending")
+            ? "pending"
+            : missing
+                ? "missing"
+                : "success";
+    return { ok: true, status, evidence };
+}
+export function normalizeGitHubCandidate(input) {
+    if (!isRecord(input))
+        return fail("malformed_candidate", "candidate input must be an object");
+    if (!isRepository(input.repository))
+        return fail("malformed_repository", "repository identity is malformed");
+    if (!isSha(input.currentMainSha))
+        return fail("malformed_main", "current main must be an exact 40-character SHA");
+    if (!isNonEmptyString(input.readyLabel))
+        return fail("malformed_ready_label", "READY label must be non-empty");
+    const pr = normalizePullRequest(input.pullRequest, input.readyLabel);
+    if (!pr.ok)
+        return pr;
+    const freshness = normalizeFreshness(input.compare, input.currentMainSha, pr.value.headSha);
+    if (!freshness.ok)
+        return freshness;
+    if (!isRecord(input.checkRuns))
+        return fail("malformed_check_inventory", "check-run inventory must be an object");
+    if (input.checkRuns.complete !== true)
+        return fail("incomplete_check_inventory", "check-run pagination is incomplete");
+    if (!isSha(input.checkRuns.headSha))
+        return fail("malformed_check_inventory", "check-run inventory head SHA is malformed");
+    if (input.checkRuns.headSha !== pr.value.headSha)
+        return fail("stale_check_evidence", "check-run inventory is bound to another head SHA");
+    if (!Array.isArray(input.checkRuns.runs))
+        return fail("malformed_check_inventory", "check-run inventory runs must be an array");
+    const required = normalizeRequiredChecks(input.requiredChecks);
+    if (!required.ok)
+        return required;
+    const transaction = normalizeGate(input.checkRuns.runs, required.transaction, pr.value.headSha);
+    if (!transaction.ok)
+        return transaction;
+    const state = normalizeGate(input.checkRuns.runs, required.state, pr.value.headSha);
+    if (!state.ok)
+        return state;
+    const snapshot = {
+        currentMainSha: input.currentMainSha,
+        prNumber: pr.value.prNumber,
+        baseRef: pr.value.baseRef,
+        baseSha: pr.value.baseSha,
+        headSha: pr.value.headSha,
+        ready: pr.value.ready,
+        mergeability: pr.value.mergeability,
+        freshness: { mainSha: input.currentMainSha, status: freshness.status },
+        transaction: { headSha: pr.value.headSha, status: transaction.status },
+        state: { headSha: pr.value.headSha, status: state.status },
+    };
+    return {
+        ok: true,
+        repository: input.repository,
+        snapshot,
+        evidence: { transaction: transaction.evidence, state: state.evidence },
+    };
+}
+export function normalizeGitHubReadyInventory(input) {
+    if (!isRecord(input))
+        return fail("malformed_pr_inventory", "PR inventory must be an object");
+    if (!isRepository(input.repository))
+        return fail("malformed_repository", "repository identity is malformed");
+    if (!isNonEmptyString(input.readyLabel))
+        return fail("malformed_ready_label", "READY label must be non-empty");
+    if (input.complete !== true)
+        return fail("incomplete_pr_inventory", "PR inventory pagination is incomplete");
+    if (!Array.isArray(input.pages) || input.pages.some((page) => !Array.isArray(page)))
+        return fail("malformed_pr_inventory", "PR inventory pages must be arrays");
+    const items = [];
+    const seen = new Set();
+    for (const page of input.pages) {
+        for (const raw of page) {
+            const normalized = normalizePullRequest(raw, input.readyLabel);
+            if (!normalized.ok)
+                return normalized;
+            if (seen.has(normalized.value.prNumber))
+                return fail("malformed_pr_inventory", `PR #${normalized.value.prNumber} appears more than once`);
+            seen.add(normalized.value.prNumber);
+            items.push(normalized.value);
+        }
+    }
+    return {
+        ok: true,
+        repository: input.repository,
+        items,
+        readyPrNumbers: items.filter((item) => item.ready).map((item) => item.prNumber),
+    };
+}

--- a/src/portable-integration/github-read.mts
+++ b/src/portable-integration/github-read.mts
@@ -1,0 +1,308 @@
+import type {
+  PortableCandidateSnapshot,
+  PortableFreshnessStatus,
+  PortableGateStatus,
+  PortableMergeability,
+} from "./planner.mjs";
+
+type Failure = { ok: false; error: string; message: string };
+type Success<T> = { ok: true } & T;
+
+type RequiredCheck = { name: string; appSlug?: string };
+type GateEvidence = {
+  name: string;
+  headSha: string;
+  status: Exclude<PortableGateStatus, "missing">;
+  conclusion: string | null;
+  appSlug: string | null;
+};
+
+type NormalizedPullRequest = {
+  prNumber: number;
+  baseRef: string;
+  baseSha: string;
+  headRef: string;
+  headSha: string;
+  headRepository: string;
+  draft: boolean;
+  ready: boolean;
+  mergeability: PortableMergeability;
+};
+
+export type GitHubCandidateNormalizationResult =
+  | Failure
+  | Success<{
+      repository: string;
+      snapshot: PortableCandidateSnapshot;
+      evidence: { transaction: GateEvidence[]; state: GateEvidence[] };
+    }>;
+
+export type GitHubReadyInventoryResult =
+  | Failure
+  | Success<{
+      repository: string;
+      items: NormalizedPullRequest[];
+      readyPrNumbers: number[];
+    }>;
+
+const SHA = /^[0-9a-f]{40}$/i;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const PENDING_CHECK_STATUSES = new Set(["queued", "in_progress", "requested", "waiting", "pending"]);
+const FAILED_CHECK_CONCLUSIONS = new Set([
+  "failure",
+  "cancelled",
+  "timed_out",
+  "action_required",
+  "stale",
+  "startup_failure",
+  "neutral",
+  "skipped",
+]);
+
+function fail(error: string, message: string): Failure {
+  return { ok: false, error, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isSha(value: unknown): value is string {
+  return typeof value === "string" && SHA.test(value);
+}
+
+function isRepository(value: unknown): value is string {
+  return typeof value === "string" && REPOSITORY.test(value);
+}
+
+function normalizePullRequest(input: unknown, readyLabel: string): Failure | Success<{ value: NormalizedPullRequest }> {
+  if (!isRecord(input)) return fail("malformed_pull_request", "pull request must be an object");
+  const base = input.base, head = input.head, labels = input.labels;
+  if (!Number.isInteger(input.number) || (input.number as number) <= 0)
+    return fail("malformed_pull_request", "pull request number must be a positive integer");
+  if (typeof input.draft !== "boolean")
+    return fail("malformed_pull_request", "pull request draft must be boolean");
+  if (input.mergeable !== true && input.mergeable !== false && input.mergeable !== null)
+    return fail("malformed_pull_request", "pull request mergeable must be true, false, or null");
+  if (!isRecord(base) || !isNonEmptyString(base.ref) || !isSha(base.sha))
+    return fail("malformed_pull_request", "pull request base ref/SHA is malformed");
+  if (!isRecord(head) || !isNonEmptyString(head.ref) || !isSha(head.sha) || !isRecord(head.repo) || !isRepository(head.repo.full_name))
+    return fail("malformed_pull_request", "pull request head ref/SHA/repository is malformed");
+  if (!Array.isArray(labels)) return fail("malformed_pull_request", "pull request labels must be an array");
+
+  const labelNames: string[] = [];
+  for (const label of labels) {
+    if (!isRecord(label) || !isNonEmptyString(label.name))
+      return fail("malformed_pull_request", "pull request label is malformed");
+    labelNames.push(label.name);
+  }
+
+  const mergeability: PortableMergeability = input.mergeable === true
+    ? "mergeable"
+    : input.mergeable === false
+      ? "conflicting"
+      : "unknown";
+
+  return {
+    ok: true,
+    value: {
+      prNumber: input.number as number,
+      baseRef: base.ref,
+      baseSha: base.sha,
+      headRef: head.ref,
+      headSha: head.sha,
+      headRepository: head.repo.full_name,
+      draft: input.draft,
+      ready: !input.draft && labelNames.includes(readyLabel),
+      mergeability,
+    },
+  };
+}
+
+function normalizeRequiredChecks(input: unknown): Failure | Success<{ transaction: RequiredCheck[]; state: RequiredCheck[] }> {
+  if (!isRecord(input)) return fail("malformed_required_checks", "required checks must be an object");
+  const result: { transaction: RequiredCheck[]; state: RequiredCheck[] } = { transaction: [], state: [] };
+
+  for (const phase of ["transaction", "state"] as const) {
+    const raw = input[phase];
+    if (!Array.isArray(raw) || raw.length === 0)
+      return fail("malformed_required_checks", `${phase} required checks must be a non-empty array`);
+    const seen = new Set<string>();
+    for (const item of raw) {
+      if (!isRecord(item) || !isNonEmptyString(item.name) || (item.appSlug !== undefined && !isNonEmptyString(item.appSlug)))
+        return fail("malformed_required_checks", `${phase} required check is malformed`);
+      const required: RequiredCheck = item.appSlug === undefined
+        ? { name: item.name }
+        : { name: item.name, appSlug: item.appSlug };
+      const key = `${required.name}\u0000${required.appSlug ?? ""}`;
+      if (seen.has(key)) return fail("malformed_required_checks", `${phase} required check is duplicated`);
+      seen.add(key);
+      result[phase].push(required);
+    }
+  }
+  return { ok: true, ...result };
+}
+
+function normalizeFreshness(input: unknown, currentMainSha: string, headSha: string): Failure | Success<{ status: PortableFreshnessStatus }> {
+  if (!isRecord(input) || !isSha(input.mainSha) || !isSha(input.headSha))
+    return fail("malformed_freshness_evidence", "compare evidence must contain exact main/head SHA");
+  if (input.mainSha !== currentMainSha || input.headSha !== headSha)
+    return fail("stale_freshness_evidence", "compare evidence is not bound to the current main/head snapshot");
+
+  if (input.status === "ahead" || input.status === "identical") return { ok: true, status: "current" };
+  if (input.status === "behind" || input.status === "diverged") return { ok: true, status: "behind" };
+  if (input.status === "unknown" || input.status === null) return { ok: true, status: "unknown" };
+  return fail("unknown_compare_state", "compare evidence contains an unknown status");
+}
+
+function checkRunAppSlug(input: Record<string, unknown>): string | null | undefined {
+  if (input.app === null || input.app === undefined) return null;
+  if (!isRecord(input.app) || !isNonEmptyString(input.app.slug)) return undefined;
+  return input.app.slug;
+}
+
+function normalizeObservedCheck(input: Record<string, unknown>, headSha: string): Failure | Success<{ evidence: GateEvidence }> {
+  if (!isNonEmptyString(input.name) || !isSha(input.head_sha))
+    return fail("malformed_check_run", "required check run name/head SHA is malformed");
+  if (input.head_sha !== headSha)
+    return fail("stale_check_evidence", "required check run is bound to another head SHA");
+  const appSlug = checkRunAppSlug(input);
+  if (appSlug === undefined) return fail("malformed_check_run", "required check run app identity is malformed");
+
+  if (PENDING_CHECK_STATUSES.has(input.status as string)) {
+    if (input.conclusion !== null && input.conclusion !== undefined)
+      return fail("unknown_check_state", "non-completed required check unexpectedly has a conclusion");
+    return {
+      ok: true,
+      evidence: { name: input.name, headSha, status: "pending", conclusion: null, appSlug },
+    };
+  }
+  if (input.status !== "completed") return fail("unknown_check_state", "required check run has an unknown status");
+  if (input.conclusion === "success") {
+    return {
+      ok: true,
+      evidence: { name: input.name, headSha, status: "success", conclusion: "success", appSlug },
+    };
+  }
+  if (typeof input.conclusion === "string" && FAILED_CHECK_CONCLUSIONS.has(input.conclusion)) {
+    return {
+      ok: true,
+      evidence: { name: input.name, headSha, status: "failure", conclusion: input.conclusion, appSlug },
+    };
+  }
+  return fail("unknown_check_state", "completed required check has an unknown conclusion");
+}
+
+function normalizeGate(
+  runs: unknown[],
+  required: RequiredCheck[],
+  headSha: string,
+): Failure | Success<{ status: PortableGateStatus; evidence: GateEvidence[] }> {
+  const evidence: GateEvidence[] = [];
+  let missing = false;
+
+  for (const spec of required) {
+    const matching = runs.filter((run) => {
+      if (!isRecord(run) || run.name !== spec.name) return false;
+      if (spec.appSlug === undefined) return true;
+      return checkRunAppSlug(run) === spec.appSlug;
+    });
+    if (matching.length > 1)
+      return fail("duplicate_required_check", `required check ${spec.name} matched more than one run`);
+    if (matching.length === 0) {
+      missing = true;
+      continue;
+    }
+    const normalized = normalizeObservedCheck(matching[0] as Record<string, unknown>, headSha);
+    if (!normalized.ok) return normalized;
+    evidence.push(normalized.evidence);
+  }
+
+  const status: PortableGateStatus = evidence.some((item) => item.status === "failure")
+    ? "failure"
+    : evidence.some((item) => item.status === "pending")
+      ? "pending"
+      : missing
+        ? "missing"
+        : "success";
+  return { ok: true, status, evidence };
+}
+
+export function normalizeGitHubCandidate(input: unknown): GitHubCandidateNormalizationResult {
+  if (!isRecord(input)) return fail("malformed_candidate", "candidate input must be an object");
+  if (!isRepository(input.repository)) return fail("malformed_repository", "repository identity is malformed");
+  if (!isSha(input.currentMainSha)) return fail("malformed_main", "current main must be an exact 40-character SHA");
+  if (!isNonEmptyString(input.readyLabel)) return fail("malformed_ready_label", "READY label must be non-empty");
+
+  const pr = normalizePullRequest(input.pullRequest, input.readyLabel);
+  if (!pr.ok) return pr;
+  const freshness = normalizeFreshness(input.compare, input.currentMainSha, pr.value.headSha);
+  if (!freshness.ok) return freshness;
+
+  if (!isRecord(input.checkRuns)) return fail("malformed_check_inventory", "check-run inventory must be an object");
+  if (input.checkRuns.complete !== true) return fail("incomplete_check_inventory", "check-run pagination is incomplete");
+  if (!isSha(input.checkRuns.headSha)) return fail("malformed_check_inventory", "check-run inventory head SHA is malformed");
+  if (input.checkRuns.headSha !== pr.value.headSha)
+    return fail("stale_check_evidence", "check-run inventory is bound to another head SHA");
+  if (!Array.isArray(input.checkRuns.runs)) return fail("malformed_check_inventory", "check-run inventory runs must be an array");
+
+  const required = normalizeRequiredChecks(input.requiredChecks);
+  if (!required.ok) return required;
+  const transaction = normalizeGate(input.checkRuns.runs, required.transaction, pr.value.headSha);
+  if (!transaction.ok) return transaction;
+  const state = normalizeGate(input.checkRuns.runs, required.state, pr.value.headSha);
+  if (!state.ok) return state;
+
+  const snapshot: PortableCandidateSnapshot = {
+    currentMainSha: input.currentMainSha,
+    prNumber: pr.value.prNumber,
+    baseRef: pr.value.baseRef,
+    baseSha: pr.value.baseSha,
+    headSha: pr.value.headSha,
+    ready: pr.value.ready,
+    mergeability: pr.value.mergeability,
+    freshness: { mainSha: input.currentMainSha, status: freshness.status },
+    transaction: { headSha: pr.value.headSha, status: transaction.status },
+    state: { headSha: pr.value.headSha, status: state.status },
+  };
+
+  return {
+    ok: true,
+    repository: input.repository,
+    snapshot,
+    evidence: { transaction: transaction.evidence, state: state.evidence },
+  };
+}
+
+export function normalizeGitHubReadyInventory(input: unknown): GitHubReadyInventoryResult {
+  if (!isRecord(input)) return fail("malformed_pr_inventory", "PR inventory must be an object");
+  if (!isRepository(input.repository)) return fail("malformed_repository", "repository identity is malformed");
+  if (!isNonEmptyString(input.readyLabel)) return fail("malformed_ready_label", "READY label must be non-empty");
+  if (input.complete !== true) return fail("incomplete_pr_inventory", "PR inventory pagination is incomplete");
+  if (!Array.isArray(input.pages) || input.pages.some((page) => !Array.isArray(page)))
+    return fail("malformed_pr_inventory", "PR inventory pages must be arrays");
+
+  const items: NormalizedPullRequest[] = [];
+  const seen = new Set<number>();
+  for (const page of input.pages as unknown[][]) {
+    for (const raw of page) {
+      const normalized = normalizePullRequest(raw, input.readyLabel);
+      if (!normalized.ok) return normalized;
+      if (seen.has(normalized.value.prNumber))
+        return fail("malformed_pr_inventory", `PR #${normalized.value.prNumber} appears more than once`);
+      seen.add(normalized.value.prNumber);
+      items.push(normalized.value);
+    }
+  }
+
+  return {
+    ok: true,
+    repository: input.repository,
+    items,
+    readyPrNumbers: items.filter((item) => item.ready).map((item) => item.prNumber),
+  };
+}

--- a/tests/test-portable-github-read-adapter.mjs
+++ b/tests/test-portable-github-read-adapter.mjs
@@ -1,0 +1,288 @@
+import { strict as assert } from "node:assert";
+import {
+  normalizeGitHubCandidate,
+  normalizeGitHubReadyInventory,
+} from "../dist/portable-integration/github-read.mjs";
+import { planPortableIntegration } from "../dist/portable-integration/planner.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+const REPO = "netkeep80/repo-guard";
+const MAIN = "1111111111111111111111111111111111111111";
+const HEAD = "2222222222222222222222222222222222222222";
+const OTHER = "3333333333333333333333333333333333333333";
+const READY = "repo-guard:ready";
+
+function pr(overrides = {}) {
+  return {
+    number: 42,
+    draft: false,
+    mergeable: true,
+    base: { ref: "main", sha: MAIN },
+    head: {
+      ref: "feature/read-adapter",
+      sha: HEAD,
+      repo: { full_name: REPO },
+    },
+    labels: [{ name: READY }],
+    ...overrides,
+  };
+}
+
+function check(name, overrides = {}) {
+  return {
+    name,
+    head_sha: HEAD,
+    status: "completed",
+    conclusion: "success",
+    app: { slug: "github-actions" },
+    ...overrides,
+  };
+}
+
+function candidate(overrides = {}) {
+  return {
+    repository: REPO,
+    currentMainSha: MAIN,
+    readyLabel: READY,
+    pullRequest: pr(),
+    compare: {
+      mainSha: MAIN,
+      headSha: HEAD,
+      status: "ahead",
+    },
+    checkRuns: {
+      headSha: HEAD,
+      complete: true,
+      runs: [
+        check("transaction-gate"),
+        check("state-gate"),
+      ],
+    },
+    requiredChecks: {
+      transaction: [{ name: "transaction-gate", appSlug: "github-actions" }],
+      state: [{ name: "state-gate", appSlug: "github-actions" }],
+    },
+    ...overrides,
+  };
+}
+
+console.log("\n--- portable GitHub read adapter contract ---");
+
+const valid = normalizeGitHubCandidate(candidate());
+expect("valid GitHub state normalizes successfully", valid.ok, true);
+if (valid.ok) {
+  expect("candidate carries exact main SHA", valid.snapshot.currentMainSha, MAIN);
+  expect("candidate carries exact head SHA", valid.snapshot.headSha, HEAD);
+  expect("candidate carries exact base metadata", valid.snapshot.baseSha, MAIN);
+  expect("READY label makes non-draft PR ready", valid.snapshot.ready, true);
+  expect("mergeable=true maps to mergeable", valid.snapshot.mergeability, "mergeable");
+  expect("ahead exact compare maps to current freshness", valid.snapshot.freshness, { mainSha: MAIN, status: "current" });
+  expect("transaction gate is exact-head success", valid.snapshot.transaction, { headSha: HEAD, status: "success" });
+  expect("state gate is exact-head success", valid.snapshot.state, { headSha: HEAD, status: "success" });
+  expect("planner accepts normalized exact snapshot", planPortableIntegration(valid.snapshot).kind, "merge_exact_head");
+  expect("normalized evidence keeps source identity", valid.evidence.transaction[0], {
+    name: "transaction-gate",
+    headSha: HEAD,
+    status: "success",
+    conclusion: "success",
+    appSlug: "github-actions",
+  });
+}
+
+const behind = normalizeGitHubCandidate(candidate({
+  compare: { mainSha: MAIN, headSha: HEAD, status: "diverged" },
+}));
+expect("diverged compare is normalized as behind", behind.ok && behind.snapshot.freshness.status, "behind");
+if (behind.ok) expect("planner requests coordinator refresh for behind branch", planPortableIntegration(behind.snapshot).kind, "refresh_branch");
+
+const mergeabilityUnknown = normalizeGitHubCandidate(candidate({
+  pullRequest: pr({ mergeable: null }),
+}));
+expect("mergeable=null is preserved as unknown instead of optimistic true", mergeabilityUnknown.ok && mergeabilityUnknown.snapshot.mergeability, "unknown");
+if (mergeabilityUnknown.ok) expect("unknown mergeability cannot merge", planPortableIntegration(mergeabilityUnknown.snapshot).kind, "invalid_snapshot");
+
+const pending = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: true,
+    runs: [
+      check("transaction-gate", { status: "in_progress", conclusion: null }),
+      check("state-gate"),
+    ],
+  },
+}));
+expect("in-progress required check maps to pending gate", pending.ok && pending.snapshot.transaction.status, "pending");
+
+const failed = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: true,
+    runs: [
+      check("transaction-gate", { conclusion: "failure" }),
+      check("state-gate"),
+    ],
+  },
+}));
+expect("failed completed required check maps to failure gate", failed.ok && failed.snapshot.transaction.status, "failure");
+
+const missing = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: true,
+    runs: [check("transaction-gate")],
+  },
+}));
+expect("missing required check maps to missing gate", missing.ok && missing.snapshot.state.status, "missing");
+
+const wrongCheckSha = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: OTHER,
+    complete: true,
+    runs: [
+      check("transaction-gate", { head_sha: OTHER }),
+      check("state-gate", { head_sha: OTHER }),
+    ],
+  },
+}));
+expect("check evidence envelope bound to another SHA is rejected", wrongCheckSha.ok, false);
+expect("wrong-head check evidence is diagnosed", wrongCheckSha.error, "stale_check_evidence");
+
+const wrongCompareMain = normalizeGitHubCandidate(candidate({
+  compare: { mainSha: OTHER, headSha: HEAD, status: "ahead" },
+}));
+expect("compare evidence bound to another main is rejected", wrongCompareMain.ok, false);
+expect("stale compare main is diagnosed", wrongCompareMain.error, "stale_freshness_evidence");
+
+const wrongCompareHead = normalizeGitHubCandidate(candidate({
+  compare: { mainSha: MAIN, headSha: OTHER, status: "ahead" },
+}));
+expect("compare evidence bound to another head is rejected", wrongCompareHead.ok, false);
+expect("stale compare head is diagnosed", wrongCompareHead.error, "stale_freshness_evidence");
+
+const malformedPr = normalizeGitHubCandidate(candidate({
+  pullRequest: pr({ number: 0 }),
+}));
+expect("malformed PR number fails closed", malformedPr.ok, false);
+expect("malformed PR is diagnosed", malformedPr.error, "malformed_pull_request");
+
+const malformedRef = normalizeGitHubCandidate(candidate({
+  pullRequest: pr({ base: { ref: "", sha: MAIN } }),
+}));
+expect("empty base ref fails closed", malformedRef.ok, false);
+
+const malformedMain = normalizeGitHubCandidate(candidate({ currentMainSha: "main" }));
+expect("non-SHA current main fails closed", malformedMain.ok, false);
+expect("malformed main is diagnosed", malformedMain.error, "malformed_main");
+
+const unknownCheckState = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: true,
+    runs: [
+      check("transaction-gate", { status: "teleported" }),
+      check("state-gate"),
+    ],
+  },
+}));
+expect("unknown check status never becomes success", unknownCheckState.ok, false);
+expect("unknown check state is diagnosed", unknownCheckState.error, "unknown_check_state");
+
+const duplicate = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: true,
+    runs: [
+      check("transaction-gate"),
+      check("transaction-gate"),
+      check("state-gate"),
+    ],
+  },
+}));
+expect("duplicate required check identity is rejected deterministically", duplicate.ok, false);
+expect("duplicate required check is diagnosed", duplicate.error, "duplicate_required_check");
+
+const wrongApp = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: true,
+    runs: [
+      check("transaction-gate", { app: { slug: "other-app" } }),
+      check("state-gate"),
+    ],
+  },
+}));
+expect("same-name check from wrong app cannot satisfy required source", wrongApp.ok && wrongApp.snapshot.transaction.status, "missing");
+
+const incompleteChecks = normalizeGitHubCandidate(candidate({
+  checkRuns: {
+    headSha: HEAD,
+    complete: false,
+    runs: [
+      check("transaction-gate"),
+      check("state-gate"),
+    ],
+  },
+}));
+expect("incomplete check-run pagination fails closed", incompleteChecks.ok, false);
+expect("incomplete check pages are diagnosed", incompleteChecks.error, "incomplete_check_inventory");
+
+const inventory = normalizeGitHubReadyInventory({
+  repository: REPO,
+  readyLabel: READY,
+  complete: true,
+  pages: [
+    [pr()],
+    [pr({
+      number: 43,
+      labels: [],
+      head: { ref: "fork-work", sha: OTHER, repo: { full_name: "contributor/repo-guard" } },
+    })],
+  ],
+});
+expect("complete paginated inventory normalizes", inventory.ok, true);
+if (inventory.ok) {
+  expect("all PRs remain observable", inventory.items.map((item) => item.prNumber), [42, 43]);
+  expect("ready projection excludes not-ready PR", inventory.readyPrNumbers, [42]);
+  expect("fork repository remains inert metadata", inventory.items[1].headRepository, "contributor/repo-guard");
+}
+
+const draftReadyLabel = normalizeGitHubReadyInventory({
+  repository: REPO,
+  readyLabel: READY,
+  complete: true,
+  pages: [[pr({ draft: true })]],
+});
+expect("draft PR is not READY even with marker", draftReadyLabel.ok && draftReadyLabel.readyPrNumbers, []);
+
+const incompleteInventory = normalizeGitHubReadyInventory({
+  repository: REPO,
+  readyLabel: READY,
+  complete: false,
+  pages: [[pr()]],
+});
+expect("incomplete PR pagination fails closed", incompleteInventory.ok, false);
+expect("incomplete PR pages are diagnosed", incompleteInventory.error, "incomplete_pr_inventory");
+
+const malformedInventory = normalizeGitHubReadyInventory({
+  repository: REPO,
+  readyLabel: READY,
+  complete: true,
+  pages: [[pr({ head: { ref: "feature", sha: "bad", repo: { full_name: REPO } } })]],
+});
+expect("malformed inventory item fails whole inventory closed", malformedInventory.ok, false);
+expect("malformed inventory item is diagnosed", malformedInventory.error, "malformed_pull_request");
+
+console.log(`\n${failures === 0 ? "All portable GitHub read-adapter tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Краткое описание

Implements #314 as the read-only normalization slice of portable provider #306.

A strict TypeScript adapter now runtime-narrows untrusted GitHub control-plane facts into the exact provider-neutral snapshot consumed by the pure planner from #313. The module performs no GitHub writes, network calls, filesystem/process execution, CLI/Action dispatch, workflow mutation, policy/schema evaluation, `check-pr` logic or coordinator orchestration.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/portable-integration/github-read.mts
  - dist/portable-integration/github-read.mjs
  - tests/test-portable-github-read-adapter.mjs
budgets:
  max_new_docs: 0
  max_new_files: 3
  max_net_added_lines: 1000
anchors:
  affects:
    - "#304"
    - "#306"
    - "#314"
  implements:
    - "#314"
  verifies:
    - "read-only GitHub control-plane exact snapshot normalization"
must_touch:
  - tests/**
must_not_touch:
  - src/checks/**
  - src/github-pr.mts
  - schemas/**
  - .github/**
  - repo-policy.json
  - action.yml
expected_effects:
  - Untrusted GitHub PR, compare, check-run and inventory state is runtime-narrowed fail-closed.
  - Freshness evidence is explicitly bound to exact current-main and head SHA.
  - Required checks are observed only on exact head SHA and optionally exact app/source identity.
  - Incomplete pagination, malformed state, stale evidence and duplicate required checks never become optimistic success.
  - Normalized output is directly consumable by the pure planner from #313.
  - Existing check-pr and Constraint Program behavior remains untouched.
```

## Реализация

The adapter exposes two normalization functions only:

```text
normalizeGitHubCandidate(untrusted exact-bound API state)
  -> { ok: true, snapshot, evidence }
  -> { ok: false, error, message }

normalizeGitHubReadyInventory(untrusted paginated PR state)
  -> complete observable inventory + READY projection
  -> fail closed if pagination/state is incomplete
```

Key semantics implemented and locked by tests:

- exact 40-character SHA runtime narrowing for current main, PR base/head and evidence envelopes;
- `mergeable=true|false|null` -> `mergeable|conflicting|unknown`;
- exact compare `(mainSha, headSha)` `ahead|identical` -> freshness `current`;
- `behind|diverged` -> freshness `behind`;
- compare/check evidence bound to another main/head SHA is rejected;
- completed required check `success` -> success; in-progress -> pending; completed known non-success -> failure; absent -> missing;
- optional `appSlug` participates in required-check identity;
- duplicate matching required checks are rejected deterministically rather than guessed;
- incomplete check-run or PR pagination fails closed;
- draft PR is not READY even when the READY marker is present;
- all PRs remain observable in inventory while READY projection is separate;
- fork repository identity remains inert metadata only;
- normalized exact snapshot is accepted directly by `planPortableIntegration` from #313.

The source has only a type-only import from `planner.mjs`; the emitted runtime module has no imports and no side effects.

## TDD evidence

RED → GREEN was executed through the repository's real GitHub Actions CI.

### RED

- exact test-only head: `f994f3b30773439faa3a6c38745649a70c3f1aa5`;
- CI run `32632211266` / #756;
- expected failure: `ERR_MODULE_NOT_FOUND` for intentionally absent `dist/portable-integration/github-read.mjs`;
- before the expected test failure, `check:dist`, self policy, integration, doctor and package smoke were green.

### GREEN

- exact implementation head: `4278d73effe95d41e5d2af884bd6a6815b6fc514`;
- CI run `32632437808` / #758 completed `success`;
- repository `check:dist`: `Generated dist is current`;
- full suite: `All 45 test files passed`;
- all portable GitHub read-adapter vectors passed, including stale main/head evidence, mergeability unknown, pending/failure/missing checks, app identity, duplicate required checks, incomplete pagination, malformed inventory, READY/draft projection, fork metadata and planner handoff;
- self `repo-policy.json`, `validate-integration`, doctor, advisory exercise and package smoke passed.

The blocking `Run PR policy check` is currently skipped only because this PR remains draft. The next lifecycle transition is ready-for-review so the exact same head is evaluated by blocking `check-pr`.

## Diff / security review

Exactly three files are changed from current `main`:

- `src/portable-integration/github-read.mts` — 308 additions;
- generated `dist/portable-integration/github-read.mjs` — 261 additions;
- `tests/test-portable-github-read-adapter.mjs` — 288 additions.

Total net additions: 857, within the declared 1000-line budget. No `src/checks/**`, `src/github-pr.mts`, schema, workflow, `repo-policy.json` or `action.yml` files are touched. There is no update-branch, merge, label write, shell execution, local git operation or PR-code execution path in this slice.

Refs #304, #306, #313, #314.