### PR TITLE
[Portable P1c] Add guarded GitHub write adapter

### DIFF
--- a/dist/portable-integration/github-write.mjs
+++ b/dist/portable-integration/github-write.mjs
@@ -1,0 +1,157 @@
+const SHA = /^[0-9a-f]{40}$/i;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
+function fail(error, message) {
+    return { ok: false, error, message };
+}
+function isRecord(value) {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function isSha(value) {
+    return typeof value === "string" && SHA.test(value);
+}
+function isRepository(value) {
+    return typeof value === "string" && REPOSITORY.test(value);
+}
+function isPositiveInteger(value) {
+    return Number.isInteger(value) && value > 0;
+}
+function isMergeMethod(value) {
+    return typeof value === "string" && MERGE_METHODS.has(value);
+}
+function normalizeTransport(input) {
+    if (!isRecord(input) || typeof input.request !== "function")
+        return null;
+    return input;
+}
+function normalizeResponse(input) {
+    if (!isRecord(input) || !Number.isInteger(input.status))
+        return null;
+    return { status: input.status, body: input.body };
+}
+function updateFailure(status, body) {
+    const suffix = responseMessage(body);
+    if (status === 403)
+        return fail("forbidden", `update-branch is forbidden${suffix}`);
+    if (status === 409)
+        return fail("conflict", `update-branch conflicts with current repository state${suffix}`);
+    if (status === 422)
+        return fail("stale_head", `update-branch expected head is stale or invalid${suffix}`);
+    return fail("unexpected_response", `update-branch returned unexpected HTTP ${status}${suffix}`);
+}
+function mergeFailure(status, body) {
+    const suffix = responseMessage(body);
+    if (status === 403)
+        return fail("forbidden", `merge is forbidden${suffix}`);
+    if (status === 404)
+        return fail("not_found", `pull request was not found${suffix}`);
+    if (status === 405)
+        return fail("merge_not_allowed", `pull request cannot be merged by this endpoint${suffix}`);
+    if (status === 409)
+        return fail("stale_head", `merge expected head is stale${suffix}`);
+    if (status === 422)
+        return fail("validation_failed", `merge request failed validation${suffix}`);
+    return fail("unexpected_response", `merge returned unexpected HTTP ${status}${suffix}`);
+}
+function responseMessage(body) {
+    if (!isRecord(body) || typeof body.message !== "string" || body.message.length === 0)
+        return "";
+    return `: ${body.message}`;
+}
+function validateCommonInput(input) {
+    if (!isRecord(input))
+        return fail("invalid_input", "mutation input must be an object");
+    if (!isRepository(input.repository))
+        return fail("invalid_input", "repository must be owner/name");
+    if (!isPositiveInteger(input.prNumber))
+        return fail("invalid_input", "PR number must be a positive integer");
+    if (!isSha(input.expectedHeadSha))
+        return fail("invalid_input", "expected head must be an exact 40-character SHA");
+    return {
+        ok: true,
+        value: {
+            repository: input.repository,
+            prNumber: input.prNumber,
+            expectedHeadSha: input.expectedHeadSha,
+        },
+    };
+}
+export function createGitHubWriteAdapter(transportInput) {
+    const transport = normalizeTransport(transportInput);
+    return {
+        async updateBranch(input) {
+            const common = validateCommonInput(input);
+            if (!common.ok)
+                return common;
+            const valid = common.value;
+            if (transport === null)
+                return fail("invalid_transport", "write transport must expose an async request function");
+            let rawResponse;
+            try {
+                rawResponse = await transport.request({
+                    method: "PUT",
+                    path: `/repos/${valid.repository}/pulls/${valid.prNumber}/update-branch`,
+                    body: { expected_head_sha: valid.expectedHeadSha },
+                });
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return fail("transport_error", `update-branch transport failed: ${message}`);
+            }
+            const response = normalizeResponse(rawResponse);
+            if (response === null)
+                return fail("malformed_response", "update-branch transport returned a malformed response");
+            if (response.status !== 202)
+                return updateFailure(response.status, response.body);
+            return {
+                ok: true,
+                kind: "update_accepted",
+                expectedHeadSha: valid.expectedHeadSha,
+                rereadRequired: true,
+            };
+        },
+        async mergeExactHead(input) {
+            const common = validateCommonInput(input);
+            if (!common.ok)
+                return common;
+            const valid = common.value;
+            if (!isRecord(input) || !isMergeMethod(input.mergeMethod))
+                return fail("invalid_input", "merge method must be merge, squash, or rebase");
+            if (transport === null)
+                return fail("invalid_transport", "write transport must expose an async request function");
+            let rawResponse;
+            try {
+                rawResponse = await transport.request({
+                    method: "PUT",
+                    path: `/repos/${valid.repository}/pulls/${valid.prNumber}/merge`,
+                    body: {
+                        sha: valid.expectedHeadSha,
+                        merge_method: input.mergeMethod,
+                    },
+                });
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return fail("transport_error", `merge transport failed: ${message}`);
+            }
+            const response = normalizeResponse(rawResponse);
+            if (response === null)
+                return fail("malformed_response", "merge transport returned a malformed response");
+            if (response.status !== 200)
+                return mergeFailure(response.status, response.body);
+            if (!isRecord(response.body))
+                return fail("malformed_response", "merge success response body must be an object");
+            if (response.body.merged === false)
+                return fail("merge_rejected", `GitHub did not merge the pull request${responseMessage(response.body)}`);
+            if (response.body.merged !== true || !isSha(response.body.sha))
+                return fail("malformed_response", "merge success response must contain merged=true and an exact merge SHA");
+            return {
+                ok: true,
+                kind: "merged",
+                expectedHeadSha: valid.expectedHeadSha,
+                mergeSha: response.body.sha,
+                mergeMethod: input.mergeMethod,
+            };
+        },
+    };
+}

--- a/src/portable-integration/github-write.mts
+++ b/src/portable-integration/github-write.mts
@@ -101,18 +101,24 @@ function responseMessage(body: unknown): string {
 }
 
 function validateCommonInput(input: unknown): Failure | {
-  repository: string;
-  prNumber: number;
-  expectedHeadSha: string;
+  ok: true;
+  value: {
+    repository: string;
+    prNumber: number;
+    expectedHeadSha: string;
+  };
 } {
   if (!isRecord(input)) return fail("invalid_input", "mutation input must be an object");
   if (!isRepository(input.repository)) return fail("invalid_input", "repository must be owner/name");
   if (!isPositiveInteger(input.prNumber)) return fail("invalid_input", "PR number must be a positive integer");
   if (!isSha(input.expectedHeadSha)) return fail("invalid_input", "expected head must be an exact 40-character SHA");
   return {
-    repository: input.repository,
-    prNumber: input.prNumber,
-    expectedHeadSha: input.expectedHeadSha,
+    ok: true,
+    value: {
+      repository: input.repository,
+      prNumber: input.prNumber,
+      expectedHeadSha: input.expectedHeadSha,
+    },
   };
 }
 
@@ -122,15 +128,16 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
   return {
     async updateBranch(input: unknown): Promise<GitHubUpdateBranchResult> {
       const common = validateCommonInput(input);
-      if ("ok" in common && common.ok === false) return common;
+      if (!common.ok) return common;
+      const valid = common.value;
       if (transport === null) return fail("invalid_transport", "write transport must expose an async request function");
 
       let rawResponse: unknown;
       try {
         rawResponse = await transport.request({
           method: "PUT",
-          path: `/repos/${common.repository}/pulls/${common.prNumber}/update-branch`,
-          body: { expected_head_sha: common.expectedHeadSha },
+          path: `/repos/${valid.repository}/pulls/${valid.prNumber}/update-branch`,
+          body: { expected_head_sha: valid.expectedHeadSha },
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -144,14 +151,15 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
       return {
         ok: true,
         kind: "update_accepted",
-        expectedHeadSha: common.expectedHeadSha,
+        expectedHeadSha: valid.expectedHeadSha,
         rereadRequired: true,
       };
     },
 
     async mergeExactHead(input: unknown): Promise<GitHubMergeExactHeadResult> {
       const common = validateCommonInput(input);
-      if ("ok" in common && common.ok === false) return common;
+      if (!common.ok) return common;
+      const valid = common.value;
       if (!isRecord(input) || !isMergeMethod(input.mergeMethod))
         return fail("invalid_input", "merge method must be merge, squash, or rebase");
       if (transport === null) return fail("invalid_transport", "write transport must expose an async request function");
@@ -160,9 +168,9 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
       try {
         rawResponse = await transport.request({
           method: "PUT",
-          path: `/repos/${common.repository}/pulls/${common.prNumber}/merge`,
+          path: `/repos/${valid.repository}/pulls/${valid.prNumber}/merge`,
           body: {
-            sha: common.expectedHeadSha,
+            sha: valid.expectedHeadSha,
             merge_method: input.mergeMethod,
           },
         });
@@ -182,7 +190,7 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
       return {
         ok: true,
         kind: "merged",
-        expectedHeadSha: common.expectedHeadSha,
+        expectedHeadSha: valid.expectedHeadSha,
         mergeSha: response.body.sha,
         mergeMethod: input.mergeMethod,
       };

--- a/src/portable-integration/github-write.mts
+++ b/src/portable-integration/github-write.mts
@@ -1,0 +1,191 @@
+type GitHubMutationRequest = {
+  method: "PUT";
+  path: string;
+  body: Record<string, string>;
+};
+
+type GitHubMutationResponse = {
+  status: number;
+  body: unknown;
+};
+
+type GitHubMutationTransport = {
+  request(request: GitHubMutationRequest): Promise<GitHubMutationResponse>;
+};
+
+type Failure = {
+  ok: false;
+  error: string;
+  message: string;
+};
+
+type UpdateSuccess = {
+  ok: true;
+  kind: "update_accepted";
+  expectedHeadSha: string;
+  rereadRequired: true;
+};
+
+type MergeMethod = "merge" | "squash" | "rebase";
+
+type MergeSuccess = {
+  ok: true;
+  kind: "merged";
+  expectedHeadSha: string;
+  mergeSha: string;
+  mergeMethod: MergeMethod;
+};
+
+export type GitHubUpdateBranchResult = Failure | UpdateSuccess;
+export type GitHubMergeExactHeadResult = Failure | MergeSuccess;
+
+const SHA = /^[0-9a-f]{40}$/i;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set<MergeMethod>(["merge", "squash", "rebase"]);
+
+function fail(error: string, message: string): Failure {
+  return { ok: false, error, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSha(value: unknown): value is string {
+  return typeof value === "string" && SHA.test(value);
+}
+
+function isRepository(value: unknown): value is string {
+  return typeof value === "string" && REPOSITORY.test(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function isMergeMethod(value: unknown): value is MergeMethod {
+  return typeof value === "string" && MERGE_METHODS.has(value as MergeMethod);
+}
+
+function normalizeTransport(input: unknown): GitHubMutationTransport | null {
+  if (!isRecord(input) || typeof input.request !== "function") return null;
+  return input as unknown as GitHubMutationTransport;
+}
+
+function normalizeResponse(input: unknown): GitHubMutationResponse | null {
+  if (!isRecord(input) || !Number.isInteger(input.status)) return null;
+  return { status: input.status as number, body: input.body };
+}
+
+function updateFailure(status: number, body: unknown): Failure {
+  const suffix = responseMessage(body);
+  if (status === 403) return fail("forbidden", `update-branch is forbidden${suffix}`);
+  if (status === 409) return fail("conflict", `update-branch conflicts with current repository state${suffix}`);
+  if (status === 422) return fail("stale_head", `update-branch expected head is stale or invalid${suffix}`);
+  return fail("unexpected_response", `update-branch returned unexpected HTTP ${status}${suffix}`);
+}
+
+function mergeFailure(status: number, body: unknown): Failure {
+  const suffix = responseMessage(body);
+  if (status === 403) return fail("forbidden", `merge is forbidden${suffix}`);
+  if (status === 404) return fail("not_found", `pull request was not found${suffix}`);
+  if (status === 405) return fail("merge_not_allowed", `pull request cannot be merged by this endpoint${suffix}`);
+  if (status === 409) return fail("stale_head", `merge expected head is stale${suffix}`);
+  if (status === 422) return fail("validation_failed", `merge request failed validation${suffix}`);
+  return fail("unexpected_response", `merge returned unexpected HTTP ${status}${suffix}`);
+}
+
+function responseMessage(body: unknown): string {
+  if (!isRecord(body) || typeof body.message !== "string" || body.message.length === 0) return "";
+  return `: ${body.message}`;
+}
+
+function validateCommonInput(input: unknown): Failure | {
+  repository: string;
+  prNumber: number;
+  expectedHeadSha: string;
+} {
+  if (!isRecord(input)) return fail("invalid_input", "mutation input must be an object");
+  if (!isRepository(input.repository)) return fail("invalid_input", "repository must be owner/name");
+  if (!isPositiveInteger(input.prNumber)) return fail("invalid_input", "PR number must be a positive integer");
+  if (!isSha(input.expectedHeadSha)) return fail("invalid_input", "expected head must be an exact 40-character SHA");
+  return {
+    repository: input.repository,
+    prNumber: input.prNumber,
+    expectedHeadSha: input.expectedHeadSha,
+  };
+}
+
+export function createGitHubWriteAdapter(transportInput: unknown) {
+  const transport = normalizeTransport(transportInput);
+
+  return {
+    async updateBranch(input: unknown): Promise<GitHubUpdateBranchResult> {
+      const common = validateCommonInput(input);
+      if ("ok" in common && common.ok === false) return common;
+      if (transport === null) return fail("invalid_transport", "write transport must expose an async request function");
+
+      let rawResponse: unknown;
+      try {
+        rawResponse = await transport.request({
+          method: "PUT",
+          path: `/repos/${common.repository}/pulls/${common.prNumber}/update-branch`,
+          body: { expected_head_sha: common.expectedHeadSha },
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return fail("transport_error", `update-branch transport failed: ${message}`);
+      }
+
+      const response = normalizeResponse(rawResponse);
+      if (response === null) return fail("malformed_response", "update-branch transport returned a malformed response");
+      if (response.status !== 202) return updateFailure(response.status, response.body);
+
+      return {
+        ok: true,
+        kind: "update_accepted",
+        expectedHeadSha: common.expectedHeadSha,
+        rereadRequired: true,
+      };
+    },
+
+    async mergeExactHead(input: unknown): Promise<GitHubMergeExactHeadResult> {
+      const common = validateCommonInput(input);
+      if ("ok" in common && common.ok === false) return common;
+      if (!isRecord(input) || !isMergeMethod(input.mergeMethod))
+        return fail("invalid_input", "merge method must be merge, squash, or rebase");
+      if (transport === null) return fail("invalid_transport", "write transport must expose an async request function");
+
+      let rawResponse: unknown;
+      try {
+        rawResponse = await transport.request({
+          method: "PUT",
+          path: `/repos/${common.repository}/pulls/${common.prNumber}/merge`,
+          body: {
+            sha: common.expectedHeadSha,
+            merge_method: input.mergeMethod,
+          },
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return fail("transport_error", `merge transport failed: ${message}`);
+      }
+
+      const response = normalizeResponse(rawResponse);
+      if (response === null) return fail("malformed_response", "merge transport returned a malformed response");
+      if (response.status !== 200) return mergeFailure(response.status, response.body);
+      if (!isRecord(response.body)) return fail("malformed_response", "merge success response body must be an object");
+      if (response.body.merged === false) return fail("merge_rejected", `GitHub did not merge the pull request${responseMessage(response.body)}`);
+      if (response.body.merged !== true || !isSha(response.body.sha))
+        return fail("malformed_response", "merge success response must contain merged=true and an exact merge SHA");
+
+      return {
+        ok: true,
+        kind: "merged",
+        expectedHeadSha: common.expectedHeadSha,
+        mergeSha: response.body.sha,
+        mergeMethod: input.mergeMethod,
+      };
+    },
+  };
+}

--- a/tests/test-portable-github-write-adapter.mjs
+++ b/tests/test-portable-github-write-adapter.mjs
@@ -1,0 +1,241 @@
+import { strict as assert } from "node:assert";
+import { createGitHubWriteAdapter } from "../dist/portable-integration/github-write.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+async function run() {
+  const REPO = "netkeep80/repo-guard";
+  const HEAD = "1111111111111111111111111111111111111111";
+  const MERGE = "2222222222222222222222222222222222222222";
+
+  console.log("\n--- portable GitHub write adapter contract ---");
+
+  {
+    const calls = [];
+    const adapter = createGitHubWriteAdapter({
+      request: async (request) => {
+        calls.push(request);
+        return { status: 202, body: { message: "Updating pull request branch." } };
+      },
+    });
+
+    const result = await adapter.updateBranch({
+      repository: REPO,
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+    });
+
+    expect("update-branch sends exactly one guarded mutation", calls.length, 1);
+    expect("update-branch request is exact and minimal", calls[0], {
+      method: "PUT",
+      path: "/repos/netkeep80/repo-guard/pulls/42/update-branch",
+      body: { expected_head_sha: HEAD },
+    });
+    expect("accepted update requires a fresh read", result, {
+      ok: true,
+      kind: "update_accepted",
+      expectedHeadSha: HEAD,
+      rereadRequired: true,
+    });
+    expect("accepted update never fabricates a new head", Object.hasOwn(result, "headSha"), false);
+  }
+
+  for (const [label, input] of [
+    ["missing update SHA", { repository: "netkeep80/repo-guard", prNumber: 42 }],
+    ["invalid update SHA", { repository: "netkeep80/repo-guard", prNumber: 42, expectedHeadSha: "main" }],
+    ["invalid update repository", { repository: "repo-guard", prNumber: 42, expectedHeadSha: HEAD }],
+    ["invalid update PR number", { repository: "netkeep80/repo-guard", prNumber: 0, expectedHeadSha: HEAD }],
+  ]) {
+    let called = false;
+    const adapter = createGitHubWriteAdapter({
+      request: async () => {
+        called = true;
+        return { status: 202, body: {} };
+      },
+    });
+    const result = await adapter.updateBranch(input);
+    expect(`${label} fails before transport`, called, false);
+    expect(`${label} is typed invalid input`, result.error, "invalid_input");
+  }
+
+  for (const [status, error] of [
+    [403, "forbidden"],
+    [409, "conflict"],
+    [422, "stale_head"],
+    [500, "unexpected_response"],
+  ]) {
+    const adapter = createGitHubWriteAdapter({
+      request: async () => ({ status, body: { message: `status ${status}` } }),
+    });
+    const result = await adapter.updateBranch({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD });
+    expect(`update status ${status} maps to ${error}`, result.error, error);
+    expect(`update status ${status} is never success`, result.ok, false);
+  }
+
+  {
+    let attempts = 0;
+    const adapter = createGitHubWriteAdapter({
+      request: async () => {
+        attempts++;
+        return { status: 422, body: { message: "head changed" } };
+      },
+    });
+    await adapter.updateBranch({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD });
+    expect("update adapter performs no hidden retry loop", attempts, 1);
+  }
+
+  {
+    const calls = [];
+    const adapter = createGitHubWriteAdapter({
+      request: async (request) => {
+        calls.push(request);
+        return {
+          status: 200,
+          body: { merged: true, sha: MERGE, message: "Pull Request successfully merged" },
+        };
+      },
+    });
+
+    const result = await adapter.mergeExactHead({
+      repository: REPO,
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+      mergeMethod: "squash",
+    });
+
+    expect("merge sends exactly one guarded mutation", calls.length, 1);
+    expect("merge request carries exact expected head and no bypass fields", calls[0], {
+      method: "PUT",
+      path: "/repos/netkeep80/repo-guard/pulls/42/merge",
+      body: { sha: HEAD, merge_method: "squash" },
+    });
+    expect("successful merge exposes exact GitHub merge SHA", result, {
+      ok: true,
+      kind: "merged",
+      expectedHeadSha: HEAD,
+      mergeSha: MERGE,
+      mergeMethod: "squash",
+    });
+  }
+
+  for (const mergeMethod of ["merge", "squash", "rebase"]) {
+    const calls = [];
+    const adapter = createGitHubWriteAdapter({
+      request: async (request) => {
+        calls.push(request);
+        return { status: 200, body: { merged: true, sha: MERGE } };
+      },
+    });
+    const result = await adapter.mergeExactHead({ repository: REPO, prNumber: 1, expectedHeadSha: HEAD, mergeMethod });
+    expect(`merge method ${mergeMethod} is allowed`, result.ok, true);
+    expect(`merge method ${mergeMethod} is passed explicitly`, calls[0].body.merge_method, mergeMethod);
+  }
+
+  for (const [label, input] of [
+    ["missing merge SHA", { repository: REPO, prNumber: 42, mergeMethod: "squash" }],
+    ["invalid merge SHA", { repository: REPO, prNumber: 42, expectedHeadSha: "HEAD", mergeMethod: "squash" }],
+    ["invalid merge repository", { repository: "repo", prNumber: 42, expectedHeadSha: HEAD, mergeMethod: "squash" }],
+    ["invalid merge PR number", { repository: REPO, prNumber: -1, expectedHeadSha: HEAD, mergeMethod: "squash" }],
+    ["invalid merge method", { repository: REPO, prNumber: 42, expectedHeadSha: HEAD, mergeMethod: "force" }],
+  ]) {
+    let called = false;
+    const adapter = createGitHubWriteAdapter({
+      request: async () => {
+        called = true;
+        return { status: 200, body: { merged: true, sha: MERGE } };
+      },
+    });
+    const result = await adapter.mergeExactHead(input);
+    expect(`${label} fails before transport`, called, false);
+    expect(`${label} is typed invalid input`, result.error, "invalid_input");
+  }
+
+  for (const [status, error] of [
+    [403, "forbidden"],
+    [404, "not_found"],
+    [405, "merge_not_allowed"],
+    [409, "stale_head"],
+    [422, "validation_failed"],
+    [500, "unexpected_response"],
+  ]) {
+    const adapter = createGitHubWriteAdapter({
+      request: async () => ({ status, body: { merged: false, message: `status ${status}` } }),
+    });
+    const result = await adapter.mergeExactHead({
+      repository: REPO,
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+      mergeMethod: "squash",
+    });
+    expect(`merge status ${status} maps to ${error}`, result.error, error);
+    expect(`merge status ${status} is never success`, result.ok, false);
+  }
+
+  {
+    const adapter = createGitHubWriteAdapter({
+      request: async () => ({ status: 200, body: { merged: false, sha: MERGE, message: "not merged" } }),
+    });
+    const result = await adapter.mergeExactHead({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD, mergeMethod: "merge" });
+    expect("HTTP 200 with merged=false is fail-closed", result.error, "merge_rejected");
+    expect("HTTP 200 with merged=false is not success", result.ok, false);
+  }
+
+  for (const body of [
+    { merged: true, sha: "bad" },
+    { merged: true },
+    { merged: "yes", sha: MERGE },
+    null,
+  ]) {
+    const adapter = createGitHubWriteAdapter({
+      request: async () => ({ status: 200, body }),
+    });
+    const result = await adapter.mergeExactHead({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD, mergeMethod: "rebase" });
+    expect(`malformed merge success payload ${JSON.stringify(body)} fails closed`, result.error, "malformed_response");
+  }
+
+  {
+    let attempts = 0;
+    const adapter = createGitHubWriteAdapter({
+      request: async () => {
+        attempts++;
+        return { status: 409, body: { message: "head mismatch" } };
+      },
+    });
+    await adapter.mergeExactHead({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD, mergeMethod: "squash" });
+    expect("merge adapter performs no hidden retry/fallback", attempts, 1);
+  }
+
+  {
+    const adapter = createGitHubWriteAdapter({
+      request: async () => {
+        throw new Error("network unavailable");
+      },
+    });
+    const update = await adapter.updateBranch({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD });
+    const merge = await adapter.mergeExactHead({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD, mergeMethod: "squash" });
+    expect("update transport exception is typed", update.error, "transport_error");
+    expect("merge transport exception is typed", merge.error, "transport_error");
+  }
+
+  {
+    const adapter = createGitHubWriteAdapter({ request: null });
+    const result = await adapter.updateBranch({ repository: REPO, prNumber: 42, expectedHeadSha: HEAD });
+    expect("misconfigured transport fails closed", result.error, "invalid_transport");
+  }
+
+  console.log(`\n${failures === 0 ? "All portable GitHub write-adapter tests passed" : `${failures} test(s) failed`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+await run();


### PR DESCRIPTION
## Краткое описание

Implements #315 as the minimal guarded mutation slice of portable provider #306.

This PR is deliberately narrower than a coordinator: it may execute exactly one caller-selected guarded mutation through an injected transport. It does not select PRs, inspect checks, retry, queue, label, checkout code, execute project scripts, change workflows, or bypass branch protection.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/portable-integration/github-write.mts
  - dist/portable-integration/github-write.mjs
  - tests/test-portable-github-write-adapter.mjs
budgets:
  max_new_docs: 0
  max_new_files: 3
  max_net_added_lines: 1000
anchors:
  affects:
    - "#304"
    - "#306"
    - "#315"
  implements:
    - "#315"
  verifies:
    - "conditional update-branch and exact-head merge mutation boundary"
must_touch:
  - tests/**
must_not_touch:
  - src/checks/**
  - src/github-pr.mts
  - schemas/**
  - .github/**
  - repo-policy.json
  - action.yml
expected_effects:
  - Update-branch always sends exact expected_head_sha and accepted update requires a fresh read.
  - Merge always sends exact expected head SHA and returns a merge SHA only from a confirmed GitHub merged=true response.
  - Invalid input, stale head, conflict, permission, validation, malformed and transport failures are typed fail-closed results.
  - No mutation has an unguarded fallback or hidden retry loop.
  - Existing planner/read adapter/check-pr/Constraint Program behavior remains untouched.
```

## Guarded contract

```text
createGitHubWriteAdapter({ request })
  .updateBranch({ repository, prNumber, expectedHeadSha })
  .mergeExactHead({ repository, prNumber, expectedHeadSha, mergeMethod })
```

Injected transport receives only the guarded GitHub REST-shaped operations:

```text
PUT /repos/{owner}/{repo}/pulls/{n}/update-branch
{ expected_head_sha: H }

PUT /repos/{owner}/{repo}/pulls/{n}/merge
{ sha: H, merge_method: merge|squash|rebase }
```

Accepted update returns `rereadRequired: true` and never fabricates a new head SHA. Merge success requires `merged=true` plus a valid exact returned merge SHA.

## TDD evidence

RED head: `bf0bef35a1b0be3667182570933a521f74898759`.

RED run #761 failed for the expected reason only: `ERR_MODULE_NOT_FOUND` for intentionally absent `dist/portable-integration/github-write.mjs`; prior test inventory and infrastructure gates were green.

Implementation head: `f2dab9cfa2bfec225e7e2f207d29e06da5785edb`.

GitHub Actions run #764 (`32633149703`) completed `success` on that exact head:
- generated dist current;
- self policy GREEN;
- validate-integration 7/7 GREEN;
- doctor 8/8 GREEN;
- package smoke GREEN;
- advisory exercise GREEN;
- all 46 discovered test files passed.

The write-adapter contract proves:
- update-branch sends exactly one mutation with exact `expected_head_sha`;
- merge sends exactly one mutation with exact `sha` and explicit merge method;
- accepted update requires reread and returns no synthetic head;
- malformed/missing input is rejected before transport;
- 403/404/405/409/422/unknown responses remain typed fail-closed failures;
- `merged=false` and malformed success payloads are never normalized as success;
- transport exceptions are typed;
- no hidden retry/fallback path exists;
- request bodies contain no bypass/admin fields.

## Review

Exact diff on final head is limited to the source adapter, generated dist, and its tests. No `.github`, schemas, policy, Action surface, `check-pr`, planner, read adapter, or Constraint Program changes.

Refs #304, #306, #313, #314, #315.