### PR TITLE
[Portable P1d] Add durable READY coordinator loop

### DIFF
--- a/dist/portable-integration/coordinator.mjs
+++ b/dist/portable-integration/coordinator.mjs
@@ -1,0 +1,193 @@
+import { planPortableIntegration, } from "./planner.mjs";
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
+function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function isPositiveInteger(value) {
+    return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+function isRepository(value) {
+    return typeof value === "string" && REPOSITORY.test(value);
+}
+function isMergeMethod(value) {
+    return typeof value === "string" && MERGE_METHODS.has(value);
+}
+function invalid(kind, error, message) {
+    return {
+        kind,
+        repository: null,
+        prNumber: null,
+        mainSha: null,
+        headSha: null,
+        decision: null,
+        mutation: "none",
+        result: null,
+        error,
+        message,
+    };
+}
+function normalizeInventory(input) {
+    if (!isObject(input)) {
+        return {
+            ok: false,
+            result: invalid("invalid_inventory", "malformed_inventory", "READY inventory must be an object"),
+        };
+    }
+    if (input.ok === false) {
+        const error = typeof input.error === "string" ? input.error : "inventory_unavailable";
+        const message = typeof input.message === "string" ? input.message : "READY inventory is unavailable or incomplete";
+        return { ok: false, result: invalid("invalid_inventory", error, message) };
+    }
+    if (input.ok !== true || !isRepository(input.repository) || !Array.isArray(input.readyPrNumbers)) {
+        return {
+            ok: false,
+            result: invalid("invalid_inventory", "malformed_inventory", "READY inventory is malformed"),
+        };
+    }
+    const seen = new Set();
+    const readyPrNumbers = [];
+    for (const value of input.readyPrNumbers) {
+        if (!isPositiveInteger(value) || seen.has(value)) {
+            return {
+                ok: false,
+                result: invalid("invalid_inventory", "invalid_ready_membership", "READY inventory must contain unique positive PR numbers"),
+            };
+        }
+        seen.add(value);
+        readyPrNumbers.push(value);
+    }
+    readyPrNumbers.sort((left, right) => left - right);
+    return {
+        ok: true,
+        value: {
+            repository: input.repository,
+            readyPrNumbers,
+        },
+    };
+}
+function observed(repository, decision, error, message) {
+    return {
+        kind: "observed",
+        repository,
+        prNumber: decision?.prNumber ?? null,
+        mainSha: decision?.mainSha ?? null,
+        headSha: decision?.headSha ?? null,
+        decision,
+        mutation: "none",
+        result: null,
+        ...(error === undefined ? {} : { error }),
+        ...(message === undefined ? {} : { message }),
+    };
+}
+function mutationAttempt(repository, decision, mutation, result) {
+    return {
+        kind: "mutation_attempted",
+        repository,
+        prNumber: decision.prNumber,
+        mainSha: decision.mainSha,
+        headSha: decision.headSha,
+        decision,
+        mutation,
+        result,
+    };
+}
+export async function runPortableCoordinatorPass(input) {
+    if (!isObject(input)) {
+        return invalid("invalid_input", "malformed_input", "coordinator input must be an object");
+    }
+    if (!isMergeMethod(input.mergeMethod)) {
+        return invalid("invalid_input", "invalid_merge_method", "merge method must be merge, squash, or rebase");
+    }
+    if (typeof input.loadCandidate !== "function"
+        || typeof input.updateBranch !== "function"
+        || typeof input.mergeExactHead !== "function") {
+        return invalid("invalid_input", "invalid_dependencies", "coordinator dependencies must be callable");
+    }
+    const normalizedInventory = normalizeInventory(input.inventory);
+    if (!normalizedInventory.ok)
+        return normalizedInventory.result;
+    const { repository, readyPrNumbers } = normalizedInventory.value;
+    if (readyPrNumbers.length === 0) {
+        return {
+            kind: "idle",
+            repository,
+            prNumber: null,
+            mainSha: null,
+            headSha: null,
+            decision: null,
+            mutation: "none",
+            result: null,
+        };
+    }
+    const loadCandidate = input.loadCandidate;
+    const updateBranch = input.updateBranch;
+    const mergeExactHead = input.mergeExactHead;
+    let lastObservation = null;
+    for (const readyPrNumber of readyPrNumbers) {
+        let snapshot;
+        try {
+            snapshot = await loadCandidate(readyPrNumber);
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            lastObservation = observed(repository, null, "candidate_load_error", message);
+            continue;
+        }
+        const decision = planPortableIntegration(snapshot);
+        if (decision.prNumber !== null && decision.prNumber !== readyPrNumber) {
+            lastObservation = observed(repository, decision, "candidate_identity_mismatch", `READY PR ${readyPrNumber} loaded snapshot for PR ${decision.prNumber}`);
+            continue;
+        }
+        if (decision.kind === "refresh_branch") {
+            if (decision.prNumber === null || decision.headSha === null) {
+                lastObservation = observed(repository, decision, "missing_mutation_identity", "refresh decision lacks exact PR/head identity");
+                continue;
+            }
+            let result;
+            try {
+                result = await updateBranch({
+                    repository,
+                    prNumber: decision.prNumber,
+                    expectedHeadSha: decision.headSha,
+                });
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                result = { ok: false, error: "mutation_transport_error", message };
+            }
+            return mutationAttempt(repository, decision, "refresh_branch", result);
+        }
+        if (decision.kind === "merge_exact_head") {
+            if (decision.prNumber === null || decision.headSha === null) {
+                lastObservation = observed(repository, decision, "missing_mutation_identity", "merge decision lacks exact PR/head identity");
+                continue;
+            }
+            let result;
+            try {
+                result = await mergeExactHead({
+                    repository,
+                    prNumber: decision.prNumber,
+                    expectedHeadSha: decision.headSha,
+                    mergeMethod: input.mergeMethod,
+                });
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                result = { ok: false, error: "mutation_transport_error", message };
+            }
+            return mutationAttempt(repository, decision, "merge_exact_head", result);
+        }
+        lastObservation = observed(repository, decision);
+    }
+    return lastObservation ?? {
+        kind: "idle",
+        repository,
+        prNumber: null,
+        mainSha: null,
+        headSha: null,
+        decision: null,
+        mutation: "none",
+        result: null,
+    };
+}

--- a/src/portable-integration/coordinator.mts
+++ b/src/portable-integration/coordinator.mts
@@ -1,0 +1,289 @@
+import {
+  planPortableIntegration,
+  type PortableIntegrationDecision,
+} from "./planner.mjs";
+
+type MergeMethod = "merge" | "squash" | "rebase";
+type MutationKind = "none" | "refresh_branch" | "merge_exact_head";
+type PassKind =
+  | "invalid_input"
+  | "invalid_inventory"
+  | "idle"
+  | "observed"
+  | "mutation_attempted";
+
+type ReadyInventory = {
+  repository: string;
+  readyPrNumbers: number[];
+};
+
+type UpdateBranch = (input: {
+  repository: string;
+  prNumber: number;
+  expectedHeadSha: string;
+}) => Promise<unknown>;
+
+type MergeExactHead = (input: {
+  repository: string;
+  prNumber: number;
+  expectedHeadSha: string;
+  mergeMethod: MergeMethod;
+}) => Promise<unknown>;
+
+type CandidateLoader = (prNumber: number) => Promise<unknown>;
+
+export interface PortableCoordinatorPassResult {
+  kind: PassKind;
+  repository: string | null;
+  prNumber: number | null;
+  mainSha: string | null;
+  headSha: string | null;
+  decision: PortableIntegrationDecision | null;
+  mutation: MutationKind;
+  result: unknown;
+  error?: string;
+  message?: string;
+}
+
+type LooseObject = Record<string, unknown>;
+
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set<MergeMethod>(["merge", "squash", "rebase"]);
+
+function isObject(value: unknown): value is LooseObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isRepository(value: unknown): value is string {
+  return typeof value === "string" && REPOSITORY.test(value);
+}
+
+function isMergeMethod(value: unknown): value is MergeMethod {
+  return typeof value === "string" && MERGE_METHODS.has(value as MergeMethod);
+}
+
+function invalid(
+  kind: "invalid_input" | "invalid_inventory",
+  error: string,
+  message: string,
+): PortableCoordinatorPassResult {
+  return {
+    kind,
+    repository: null,
+    prNumber: null,
+    mainSha: null,
+    headSha: null,
+    decision: null,
+    mutation: "none",
+    result: null,
+    error,
+    message,
+  };
+}
+
+function normalizeInventory(input: unknown):
+  | { ok: true; value: ReadyInventory }
+  | { ok: false; result: PortableCoordinatorPassResult } {
+  if (!isObject(input)) {
+    return {
+      ok: false,
+      result: invalid("invalid_inventory", "malformed_inventory", "READY inventory must be an object"),
+    };
+  }
+
+  if (input.ok === false) {
+    const error = typeof input.error === "string" ? input.error : "inventory_unavailable";
+    const message = typeof input.message === "string" ? input.message : "READY inventory is unavailable or incomplete";
+    return { ok: false, result: invalid("invalid_inventory", error, message) };
+  }
+
+  if (input.ok !== true || !isRepository(input.repository) || !Array.isArray(input.readyPrNumbers)) {
+    return {
+      ok: false,
+      result: invalid("invalid_inventory", "malformed_inventory", "READY inventory is malformed"),
+    };
+  }
+
+  const seen = new Set<number>();
+  const readyPrNumbers: number[] = [];
+  for (const value of input.readyPrNumbers) {
+    if (!isPositiveInteger(value) || seen.has(value)) {
+      return {
+        ok: false,
+        result: invalid(
+          "invalid_inventory",
+          "invalid_ready_membership",
+          "READY inventory must contain unique positive PR numbers",
+        ),
+      };
+    }
+    seen.add(value);
+    readyPrNumbers.push(value);
+  }
+
+  readyPrNumbers.sort((left, right) => left - right);
+  return {
+    ok: true,
+    value: {
+      repository: input.repository,
+      readyPrNumbers,
+    },
+  };
+}
+
+function observed(
+  repository: string,
+  decision: PortableIntegrationDecision | null,
+  error?: string,
+  message?: string,
+): PortableCoordinatorPassResult {
+  return {
+    kind: "observed",
+    repository,
+    prNumber: decision?.prNumber ?? null,
+    mainSha: decision?.mainSha ?? null,
+    headSha: decision?.headSha ?? null,
+    decision,
+    mutation: "none",
+    result: null,
+    ...(error === undefined ? {} : { error }),
+    ...(message === undefined ? {} : { message }),
+  };
+}
+
+function mutationAttempt(
+  repository: string,
+  decision: PortableIntegrationDecision,
+  mutation: Exclude<MutationKind, "none">,
+  result: unknown,
+): PortableCoordinatorPassResult {
+  return {
+    kind: "mutation_attempted",
+    repository,
+    prNumber: decision.prNumber,
+    mainSha: decision.mainSha,
+    headSha: decision.headSha,
+    decision,
+    mutation,
+    result,
+  };
+}
+
+export async function runPortableCoordinatorPass(input: unknown): Promise<PortableCoordinatorPassResult> {
+  if (!isObject(input)) {
+    return invalid("invalid_input", "malformed_input", "coordinator input must be an object");
+  }
+
+  if (!isMergeMethod(input.mergeMethod)) {
+    return invalid("invalid_input", "invalid_merge_method", "merge method must be merge, squash, or rebase");
+  }
+
+  if (typeof input.loadCandidate !== "function"
+    || typeof input.updateBranch !== "function"
+    || typeof input.mergeExactHead !== "function") {
+    return invalid("invalid_input", "invalid_dependencies", "coordinator dependencies must be callable");
+  }
+
+  const normalizedInventory = normalizeInventory(input.inventory);
+  if (!normalizedInventory.ok) return normalizedInventory.result;
+
+  const { repository, readyPrNumbers } = normalizedInventory.value;
+  if (readyPrNumbers.length === 0) {
+    return {
+      kind: "idle",
+      repository,
+      prNumber: null,
+      mainSha: null,
+      headSha: null,
+      decision: null,
+      mutation: "none",
+      result: null,
+    };
+  }
+
+  const loadCandidate = input.loadCandidate as CandidateLoader;
+  const updateBranch = input.updateBranch as UpdateBranch;
+  const mergeExactHead = input.mergeExactHead as MergeExactHead;
+  let lastObservation: PortableCoordinatorPassResult | null = null;
+
+  for (const readyPrNumber of readyPrNumbers) {
+    let snapshot: unknown;
+    try {
+      snapshot = await loadCandidate(readyPrNumber);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      lastObservation = observed(repository, null, "candidate_load_error", message);
+      continue;
+    }
+
+    const decision = planPortableIntegration(snapshot);
+
+    if (decision.prNumber !== null && decision.prNumber !== readyPrNumber) {
+      lastObservation = observed(
+        repository,
+        decision,
+        "candidate_identity_mismatch",
+        `READY PR ${readyPrNumber} loaded snapshot for PR ${decision.prNumber}`,
+      );
+      continue;
+    }
+
+    if (decision.kind === "refresh_branch") {
+      if (decision.prNumber === null || decision.headSha === null) {
+        lastObservation = observed(repository, decision, "missing_mutation_identity", "refresh decision lacks exact PR/head identity");
+        continue;
+      }
+
+      let result: unknown;
+      try {
+        result = await updateBranch({
+          repository,
+          prNumber: decision.prNumber,
+          expectedHeadSha: decision.headSha,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        result = { ok: false, error: "mutation_transport_error", message };
+      }
+      return mutationAttempt(repository, decision, "refresh_branch", result);
+    }
+
+    if (decision.kind === "merge_exact_head") {
+      if (decision.prNumber === null || decision.headSha === null) {
+        lastObservation = observed(repository, decision, "missing_mutation_identity", "merge decision lacks exact PR/head identity");
+        continue;
+      }
+
+      let result: unknown;
+      try {
+        result = await mergeExactHead({
+          repository,
+          prNumber: decision.prNumber,
+          expectedHeadSha: decision.headSha,
+          mergeMethod: input.mergeMethod,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        result = { ok: false, error: "mutation_transport_error", message };
+      }
+      return mutationAttempt(repository, decision, "merge_exact_head", result);
+    }
+
+    lastObservation = observed(repository, decision);
+  }
+
+  return lastObservation ?? {
+    kind: "idle",
+    repository,
+    prNumber: null,
+    mainSha: null,
+    headSha: null,
+    decision: null,
+    mutation: "none",
+    result: null,
+  };
+}

--- a/tests/test-portable-coordinator-loop.mjs
+++ b/tests/test-portable-coordinator-loop.mjs
@@ -1,0 +1,217 @@
+import { strict as assert } from "node:assert";
+import { runPortableCoordinatorPass } from "../dist/portable-integration/coordinator.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+const REPOSITORY = "netkeep80/example";
+const MAIN = "1111111111111111111111111111111111111111";
+const H1 = "2222222222222222222222222222222222222222";
+const H2 = "3333333333333333333333333333333333333333";
+const H3 = "4444444444444444444444444444444444444444";
+
+function candidate(prNumber, headSha, overrides = {}) {
+  return {
+    currentMainSha: MAIN,
+    prNumber,
+    baseRef: "main",
+    baseSha: MAIN,
+    headSha,
+    ready: true,
+    mergeability: "mergeable",
+    freshness: { mainSha: MAIN, status: "current" },
+    transaction: { headSha, status: "success" },
+    state: { headSha, status: "success" },
+    ...overrides,
+  };
+}
+
+function inventory(prNumbers = [3, 1, 2]) {
+  return {
+    ok: true,
+    repository: REPOSITORY,
+    readyPrNumbers: prNumbers,
+  };
+}
+
+function harness(snapshots, mutationResults = {}) {
+  const calls = { candidate: [], update: [], merge: [] };
+  return {
+    calls,
+    deps: {
+      async loadCandidate(prNumber) {
+        calls.candidate.push(prNumber);
+        return snapshots.get(prNumber);
+      },
+      async updateBranch(input) {
+        calls.update.push(input);
+        return mutationResults.update ?? {
+          ok: true,
+          kind: "update_accepted",
+          expectedHeadSha: input.expectedHeadSha,
+          rereadRequired: true,
+        };
+      },
+      async mergeExactHead(input) {
+        calls.merge.push(input);
+        return mutationResults.merge ?? {
+          ok: true,
+          kind: "merged",
+          expectedHeadSha: input.expectedHeadSha,
+          mergeSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          mergeMethod: input.mergeMethod,
+        };
+      },
+    },
+  };
+}
+
+console.log("\n--- portable durable READY coordinator contract ---");
+
+{
+  const h = harness(new Map([
+    [1, candidate(1, H1)],
+    [2, candidate(2, H2)],
+    [3, candidate(3, H3)],
+  ]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory(),
+    mergeMethod: "merge",
+    ...h.deps,
+  });
+  expect("READY inventory is processed in deterministic PR-number order", h.calls.candidate, [1]);
+  expect("first actionable candidate is selected deterministically", result.prNumber, 1);
+  expect("fresh candidate produces exactly one merge mutation", h.calls.merge.length, 1);
+  expect("merge carries exact candidate head", h.calls.merge[0]?.expectedHeadSha, H1);
+  expect("merge result stops the pass", result.mutation, "merge_exact_head");
+}
+
+{
+  const h = harness(new Map([
+    [1, candidate(1, H1, { freshness: { mainSha: MAIN, status: "behind" } })],
+    [2, candidate(2, H2)],
+  ]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([2, 1]),
+    mergeMethod: "squash",
+    ...h.deps,
+  });
+  expect("behind first candidate performs one guarded refresh", h.calls.update.length, 1);
+  expect("refresh uses exact old head", h.calls.update[0]?.expectedHeadSha, H1);
+  expect("refresh never falls through to optimistic same-pass merge", h.calls.merge.length, 0);
+  expect("refresh pass requires a future reread", result.result?.rereadRequired, true);
+}
+
+{
+  const h = harness(new Map([
+    [1, candidate(1, H1, { transaction: { headSha: H1, status: "pending" } })],
+    [2, candidate(2, H2)],
+  ]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([1, 2]),
+    mergeMethod: "merge",
+    ...h.deps,
+  });
+  expect("waiting candidate does not permanently head-of-line block later READY PR", h.calls.candidate, [1, 2]);
+  expect("later actionable candidate can merge", result.prNumber, 2);
+  expect("only one mutation is executed in the pass", h.calls.merge.length + h.calls.update.length, 1);
+}
+
+{
+  const h = harness(new Map([
+    [1, candidate(1, H1, { mergeability: "conflicting" })],
+    [2, candidate(2, H2, { transaction: { headSha: H2, status: "failure" } })],
+    [3, candidate(3, H3)],
+  ]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([3, 2, 1]),
+    mergeMethod: "rebase",
+    ...h.deps,
+  });
+  expect("blocked candidates are observed in deterministic order before later progress", h.calls.candidate, [1, 2, 3]);
+  expect("conflict/check failures do not corrupt the durable queue", result.prNumber, 3);
+  expect("later independent READY candidate progresses", h.calls.merge.length, 1);
+}
+
+{
+  const h = harness(new Map([
+    [1, candidate(1, H1, { transaction: { headSha: H3, status: "success" } })],
+    [2, candidate(2, H2)],
+  ]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([1, 2]),
+    mergeMethod: "merge",
+    ...h.deps,
+  });
+  expect("stale candidate evidence cannot refresh", h.calls.update.length, 0);
+  expect("stale candidate evidence cannot itself merge", h.calls.merge.length, 1);
+  expect("later exact candidate may still progress", result.prNumber, 2);
+}
+
+{
+  const first = harness(new Map([[1, candidate(1, H1)]]));
+  const second = harness(new Map([[1, candidate(1, H1)]]));
+  const input = { inventory: inventory([1]), mergeMethod: "merge" };
+  const a = await runPortableCoordinatorPass({ ...input, ...first.deps });
+  const b = await runPortableCoordinatorPass({ ...input, ...second.deps });
+  expect("restart rebuilds the same durable READY membership from supplied control-plane inventory", a.prNumber, b.prNumber);
+  expect("same pass snapshot is deterministic", JSON.stringify(a), JSON.stringify(b));
+}
+
+{
+  const h = harness(new Map());
+  const result = await runPortableCoordinatorPass({
+    inventory: { ok: false, error: "incomplete_pr_inventory", message: "pagination incomplete" },
+    mergeMethod: "merge",
+    ...h.deps,
+  });
+  expect("incomplete inventory fails closed", result.kind, "invalid_inventory");
+  expect("incomplete inventory performs no candidate reads", h.calls.candidate.length, 0);
+  expect("incomplete inventory performs no writes", h.calls.merge.length + h.calls.update.length, 0);
+}
+
+{
+  const h = harness(new Map([[1, candidate(1, H1)]]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([1, 1]),
+    mergeMethod: "merge",
+    ...h.deps,
+  });
+  expect("duplicate READY membership fails closed", result.kind, "invalid_inventory");
+  expect("duplicate membership performs no writes", h.calls.merge.length + h.calls.update.length, 0);
+}
+
+{
+  const h = harness(new Map([[1, candidate(1, H1)]]));
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([1]),
+    mergeMethod: "octopus",
+    ...h.deps,
+  });
+  expect("invalid merge method fails closed before candidate reads", result.kind, "invalid_input");
+  expect("invalid merge method performs no writes", h.calls.merge.length + h.calls.update.length, 0);
+}
+
+{
+  const h = harness(new Map());
+  const result = await runPortableCoordinatorPass({
+    inventory: inventory([]),
+    mergeMethod: "merge",
+    ...h.deps,
+  });
+  expect("empty durable READY inventory is a stable no-op", result.kind, "idle");
+  expect("empty inventory performs no writes", h.calls.merge.length + h.calls.update.length, 0);
+}
+
+console.log(`\n${failures === 0 ? "All portable coordinator tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Краткое описание

Implements #316 as the minimal deterministic coordinator-loop slice of portable provider #306.

The coordinator remains deliberately narrow. Queue membership is supplied from the complete durable READY inventory normalized by #314; this slice does not persist queue state in repository files or process memory, generate workflows, expose public agent lifecycle, or execute PR-controlled code.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/portable-integration/coordinator.mts
  - dist/portable-integration/coordinator.mjs
  - tests/test-portable-coordinator-loop.mjs
budgets:
  max_new_docs: 0
  max_new_files: 3
  max_net_added_lines: 900
anchors:
  affects:
    - "#304"
    - "#306"
    - "#316"
  implements:
    - "#316"
  verifies:
    - "durable READY inventory and single-mutation coordinator pass"
must_touch:
  - tests/**
must_not_touch:
  - src/checks/**
  - src/github-pr.mts
  - schemas/**
  - .github/**
  - repo-policy.json
  - action.yml
expected_effects:
  - Coordinator rebuilds candidate order from supplied durable READY control-plane inventory on every pass.
  - READY candidates are scanned deterministically and blocked or waiting candidates do not permanently head-of-line block later independent candidates.
  - Behind candidate performs exactly one guarded update-branch and stops for a future reread.
  - Fresh exact candidate performs exactly one guarded exact-head merge and stops.
  - Invalid or incomplete inventory fails closed before writes.
  - Existing planner, read adapter, write adapter, check-pr and Constraint Program semantics remain unchanged.
```

## Implemented boundary

```text
complete READY inventory (#314)
  -> deterministic PR-number order
  -> load exact candidate snapshot
  -> planPortableIntegration (#313)
  -> at most one guarded mutation (#315)
  -> stop
```

The pass never owns persistent queue state. A restart receives a newly read control-plane inventory and reconstructs the deterministic candidate order. Non-actionable waiting/blocked candidates are observed and skipped so an independent later READY PR can progress.

Both actionable branches stop immediately after the first mutation attempt:
- `refresh_branch` -> exact-head `updateBranch` -> return;
- `merge_exact_head` -> exact-head `mergeExactHead` -> return.

This PR does **not** claim cross-run/process mutex enforcement. GitHub Actions `concurrency` and generated privileged workflow/readiness configuration remain the deployment layer in #309, as defined by #316.

## TDD evidence

RED-only head: `3f065193978a74328746af22cfa70b2bb36885c7`.

Run #767 / `32634186786` reached the new coordinator test and failed for the expected reason only: `ERR_MODULE_NOT_FOUND` for intentionally absent `dist/portable-integration/coordinator.mjs`; generated-dist/self-policy/integration/doctor/package-smoke prerequisites were otherwise green.

Source head: `17a7f58aa2234a65dc226d98e7181d265b467d6f`.

Run #768 / `32634332466` failed at the expected generated-dist freshness boundary before the generated artifact was committed; package smoke remained green.

Final implementation head: `37afc855bdd23e41dfe838d808a930a9f14a158e`.

Draft GitHub Actions run #769 / `32634428759` completed `success` on that exact head:
- generated dist current;
- self policy GREEN;
- validate-integration GREEN;
- doctor GREEN;
- package smoke GREEN;
- advisory exercise GREEN;
- all **47 discovered test files passed**;
- blocking `Run PR policy check` is intentionally skipped only because the PR is still draft at this checkpoint.

The new executable contract proves:
- three READY PRs are processed in deterministic PR-number order;
- one coordinator pass performs at most one mutation attempt;
- behind candidate performs guarded refresh and never optimistic same-pass merge;
- refresh requires a future reread/new exact-head evidence;
- pending, conflicting, failed or stale candidates do not permanently head-of-line block an independent later READY candidate;
- stale candidate evidence cannot itself mutate;
- restart with the same supplied durable inventory reconstructs the same deterministic selection;
- incomplete or duplicate READY inventory fails closed without writes;
- invalid merge method fails before reads/writes;
- empty READY inventory is a stable idle no-op.

## Security / compatibility review

Exact final diff is limited to three new files:
- `src/portable-integration/coordinator.mts` — 289 lines;
- generated `dist/portable-integration/coordinator.mjs` — 193 lines;
- `tests/test-portable-coordinator-loop.mjs` — 217 lines.

Total additions: 699, within the declared 900-line budget.

The coordinator imports only the canonical planner. It has no filesystem/process/network/child-process/local-git/checkout/bypass/admin/persistent-queue path. It delegates mutations only to injected guarded boundaries and contains no hidden retry loop.

No `.github`, schema, policy, Action, `check-pr`, planner, read-adapter, write-adapter or Constraint Program behavior changed.

## Non-goals

- no workflow/concurrency YAML (#309);
- no branch-protection configuration (#309);
- no public status/next_action protocol (#308);
- no trusted command/runtime entrypoint (#317);
- no native merge queue support (#307);
- no repository-file queue persistence;
- no checkout, shell, local git merge/rebase or PR-controlled execution.

Refs #304, #306, #313, #314, #315, #316.