### PR TITLE
[Portable P1e] Add trusted coordinator recovery boundary

### DIFF
--- a/dist/portable-integration/trusted-command.mjs
+++ b/dist/portable-integration/trusted-command.mjs
@@ -1,0 +1,116 @@
+import { normalizeGitHubCandidate, normalizeGitHubReadyInventory, } from "./github-read.mjs";
+import { createGitHubWriteAdapter } from "./github-write.mjs";
+import { runPortableCoordinatorPass, } from "./coordinator.mjs";
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
+function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function isRepository(value) {
+    return typeof value === "string" && REPOSITORY.test(value);
+}
+function isNonEmptyString(value) {
+    return typeof value === "string" && value.length > 0;
+}
+function isMergeMethod(value) {
+    return typeof value === "string" && MERGE_METHODS.has(value);
+}
+function invalidEvidence(error, message) {
+    return {
+        provider: "portable",
+        kind: "invalid_input",
+        repository: null,
+        main_sha: null,
+        pr: null,
+        head_sha: null,
+        decision: null,
+        reason: null,
+        mutation: "none",
+        result: null,
+        error,
+        message,
+    };
+}
+function projectEvidence(pass) {
+    return {
+        provider: "portable",
+        kind: pass.kind,
+        repository: pass.repository,
+        main_sha: pass.mainSha,
+        pr: pass.prNumber,
+        head_sha: pass.headSha,
+        decision: pass.decision?.kind ?? null,
+        reason: pass.decision?.reason ?? null,
+        mutation: pass.mutation,
+        result: pass.result,
+        ...(pass.error === undefined ? {} : { error: pass.error }),
+        ...(pass.message === undefined ? {} : { message: pass.message }),
+    };
+}
+function overlayTrustedFields(raw, trusted) {
+    if (!isObject(raw))
+        return raw;
+    return { ...raw, ...trusted };
+}
+export async function runTrustedPortableCoordinator(input) {
+    if (!isObject(input)) {
+        return invalidEvidence("malformed_input", "trusted coordinator input must be an object");
+    }
+    if (!isRepository(input.repository)) {
+        return invalidEvidence("malformed_repository", "repository identity must be owner/name");
+    }
+    if (!isNonEmptyString(input.readyLabel)) {
+        return invalidEvidence("malformed_ready_label", "READY label must be non-empty");
+    }
+    if (!isMergeMethod(input.mergeMethod)) {
+        return invalidEvidence("invalid_merge_method", "merge method must be merge, squash, or rebase");
+    }
+    if (typeof input.readReadyInventory !== "function" || typeof input.readCandidate !== "function") {
+        return invalidEvidence("invalid_readers", "trusted coordinator readers must be callable");
+    }
+    const repository = input.repository;
+    const readyLabel = input.readyLabel;
+    const mergeMethod = input.mergeMethod;
+    const requiredChecks = input.requiredChecks;
+    const readReadyInventory = input.readReadyInventory;
+    const readCandidate = input.readCandidate;
+    const writer = createGitHubWriteAdapter(input.mutationTransport);
+    let inventory;
+    try {
+        const rawInventory = await readReadyInventory();
+        inventory = normalizeGitHubReadyInventory(overlayTrustedFields(rawInventory, {
+            repository,
+            readyLabel,
+        }));
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        inventory = {
+            ok: false,
+            error: "inventory_read_error",
+            message: `READY inventory read failed: ${message}`,
+        };
+    }
+    const pass = await runPortableCoordinatorPass({
+        inventory,
+        mergeMethod,
+        loadCandidate: async (prNumber) => {
+            const rawCandidate = await readCandidate(prNumber);
+            const normalized = normalizeGitHubCandidate(overlayTrustedFields(rawCandidate, {
+                repository,
+                readyLabel,
+                requiredChecks,
+            }));
+            if (!normalized.ok) {
+                throw new Error(`${normalized.error}: ${normalized.message}`);
+            }
+            if (normalized.repository !== repository) {
+                throw new Error("candidate repository identity changed during normalization");
+            }
+            return normalized.snapshot;
+        },
+        updateBranch: writer.updateBranch,
+        mergeExactHead: writer.mergeExactHead,
+    });
+    return projectEvidence(pass);
+}

--- a/src/portable-integration/trusted-command.mts
+++ b/src/portable-integration/trusted-command.mts
@@ -1,0 +1,156 @@
+import {
+  normalizeGitHubCandidate,
+  normalizeGitHubReadyInventory,
+} from "./github-read.mjs";
+import { createGitHubWriteAdapter } from "./github-write.mjs";
+import {
+  runPortableCoordinatorPass,
+  type PortableCoordinatorPassResult,
+} from "./coordinator.mjs";
+
+type MergeMethod = "merge" | "squash" | "rebase";
+type LooseObject = Record<string, unknown>;
+type ReadyInventoryReader = () => Promise<unknown>;
+type CandidateReader = (prNumber: number) => Promise<unknown>;
+
+export interface TrustedPortableCoordinatorEvidence {
+  provider: "portable";
+  kind: PortableCoordinatorPassResult["kind"];
+  repository: string | null;
+  main_sha: string | null;
+  pr: number | null;
+  head_sha: string | null;
+  decision: string | null;
+  reason: string | null;
+  mutation: PortableCoordinatorPassResult["mutation"];
+  result: unknown;
+  error?: string;
+  message?: string;
+}
+
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set<MergeMethod>(["merge", "squash", "rebase"]);
+
+function isObject(value: unknown): value is LooseObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRepository(value: unknown): value is string {
+  return typeof value === "string" && REPOSITORY.test(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isMergeMethod(value: unknown): value is MergeMethod {
+  return typeof value === "string" && MERGE_METHODS.has(value as MergeMethod);
+}
+
+function invalidEvidence(error: string, message: string): TrustedPortableCoordinatorEvidence {
+  return {
+    provider: "portable",
+    kind: "invalid_input",
+    repository: null,
+    main_sha: null,
+    pr: null,
+    head_sha: null,
+    decision: null,
+    reason: null,
+    mutation: "none",
+    result: null,
+    error,
+    message,
+  };
+}
+
+function projectEvidence(pass: PortableCoordinatorPassResult): TrustedPortableCoordinatorEvidence {
+  return {
+    provider: "portable",
+    kind: pass.kind,
+    repository: pass.repository,
+    main_sha: pass.mainSha,
+    pr: pass.prNumber,
+    head_sha: pass.headSha,
+    decision: pass.decision?.kind ?? null,
+    reason: pass.decision?.reason ?? null,
+    mutation: pass.mutation,
+    result: pass.result,
+    ...(pass.error === undefined ? {} : { error: pass.error }),
+    ...(pass.message === undefined ? {} : { message: pass.message }),
+  };
+}
+
+function overlayTrustedFields(
+  raw: unknown,
+  trusted: Record<string, unknown>,
+): unknown {
+  if (!isObject(raw)) return raw;
+  return { ...raw, ...trusted };
+}
+
+export async function runTrustedPortableCoordinator(input: unknown): Promise<TrustedPortableCoordinatorEvidence> {
+  if (!isObject(input)) {
+    return invalidEvidence("malformed_input", "trusted coordinator input must be an object");
+  }
+  if (!isRepository(input.repository)) {
+    return invalidEvidence("malformed_repository", "repository identity must be owner/name");
+  }
+  if (!isNonEmptyString(input.readyLabel)) {
+    return invalidEvidence("malformed_ready_label", "READY label must be non-empty");
+  }
+  if (!isMergeMethod(input.mergeMethod)) {
+    return invalidEvidence("invalid_merge_method", "merge method must be merge, squash, or rebase");
+  }
+  if (typeof input.readReadyInventory !== "function" || typeof input.readCandidate !== "function") {
+    return invalidEvidence("invalid_readers", "trusted coordinator readers must be callable");
+  }
+
+  const repository = input.repository;
+  const readyLabel = input.readyLabel;
+  const mergeMethod = input.mergeMethod;
+  const requiredChecks = input.requiredChecks;
+  const readReadyInventory = input.readReadyInventory as ReadyInventoryReader;
+  const readCandidate = input.readCandidate as CandidateReader;
+  const writer = createGitHubWriteAdapter(input.mutationTransport);
+
+  let inventory: unknown;
+  try {
+    const rawInventory = await readReadyInventory();
+    inventory = normalizeGitHubReadyInventory(overlayTrustedFields(rawInventory, {
+      repository,
+      readyLabel,
+    }));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    inventory = {
+      ok: false,
+      error: "inventory_read_error",
+      message: `READY inventory read failed: ${message}`,
+    };
+  }
+
+  const pass = await runPortableCoordinatorPass({
+    inventory,
+    mergeMethod,
+    loadCandidate: async (prNumber: number) => {
+      const rawCandidate = await readCandidate(prNumber);
+      const normalized = normalizeGitHubCandidate(overlayTrustedFields(rawCandidate, {
+        repository,
+        readyLabel,
+        requiredChecks,
+      }));
+      if (!normalized.ok) {
+        throw new Error(`${normalized.error}: ${normalized.message}`);
+      }
+      if (normalized.repository !== repository) {
+        throw new Error("candidate repository identity changed during normalization");
+      }
+      return normalized.snapshot;
+    },
+    updateBranch: writer.updateBranch,
+    mergeExactHead: writer.mergeExactHead,
+  });
+
+  return projectEvidence(pass);
+}

--- a/tests/test-portable-trusted-command-recovery.mjs
+++ b/tests/test-portable-trusted-command-recovery.mjs
@@ -1,0 +1,293 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { runTrustedPortableCoordinator } from "../dist/portable-integration/trusted-command.mjs";
+import { COMMANDS } from "../dist/repo-guard.mjs";
+
+let failures = 0;
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (error) {
+    failures++;
+    console.error(`FAIL: ${label}`);
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+const REPOSITORY = "netkeep80/example";
+const READY_LABEL = "repo-guard:ready";
+const TX = "repo-guard / transaction";
+const STATE = "repo-guard / state";
+const M0 = "1111111111111111111111111111111111111111";
+const M1 = "2222222222222222222222222222222222222222";
+const M2 = "3333333333333333333333333333333333333333";
+const MOLD = "0000000000000000000000000000000000000000";
+const A0 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const B0 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const B1 = "cccccccccccccccccccccccccccccccccccccccc";
+const C0 = "dddddddddddddddddddddddddddddddddddddddd";
+const C1 = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const C2 = "ffffffffffffffffffffffffffffffffffffffff";
+
+function checkRun(name, headSha, status) {
+  if (status === "pending") {
+    return { name, head_sha: headSha, status: "in_progress", conclusion: null, app: null };
+  }
+  return {
+    name,
+    head_sha: headSha,
+    status: "completed",
+    conclusion: status === "success" ? "success" : "failure",
+    app: null,
+  };
+}
+
+class FakeGitHubControlPlane {
+  constructor(mainSha = M0) {
+    this.mainSha = mainSha;
+    this.prs = new Map();
+    this.requests = [];
+    this.successfulMerges = 0;
+    this.beforeMutation = null;
+    this.throwNextMutation = false;
+    this.transport = { request: async (request) => this.mutate(request) };
+  }
+
+  addPr(number, headSha, options = {}) {
+    this.prs.set(number, {
+      number,
+      baseSha: options.baseSha ?? this.mainSha,
+      headSha,
+      open: true,
+      ready: options.ready ?? true,
+      draft: options.draft ?? false,
+      mergeability: options.mergeability ?? "mergeable",
+      transaction: options.transaction ?? "success",
+      state: options.state ?? "success",
+      nextHeadSha: options.nextHeadSha ?? null,
+      mergeSha: options.mergeSha ?? C2,
+    });
+  }
+
+  rawPr(pr) {
+    return {
+      number: pr.number,
+      draft: pr.draft,
+      mergeable: pr.mergeability === "mergeable" ? true : pr.mergeability === "conflicting" ? false : null,
+      base: { ref: "main", sha: pr.baseSha },
+      head: { ref: `pr-${pr.number}`, sha: pr.headSha, repo: { full_name: REPOSITORY } },
+      labels: pr.ready ? [{ name: READY_LABEL }] : [],
+    };
+  }
+
+  async readReadyInventory() {
+    const open = [...this.prs.values()].filter((pr) => pr.open).map((pr) => this.rawPr(pr));
+    return { complete: true, pages: [open] };
+  }
+
+  async readCandidate(prNumber) {
+    const pr = this.prs.get(prNumber);
+    if (!pr || !pr.open) throw new Error(`PR #${prNumber} is not open`);
+    return {
+      currentMainSha: this.mainSha,
+      pullRequest: this.rawPr(pr),
+      compare: {
+        mainSha: this.mainSha,
+        headSha: pr.headSha,
+        status: pr.baseSha === this.mainSha ? "ahead" : "behind",
+      },
+      checkRuns: {
+        complete: true,
+        headSha: pr.headSha,
+        runs: [
+          checkRun(TX, pr.headSha, pr.transaction),
+          checkRun(STATE, pr.headSha, pr.state),
+        ],
+      },
+    };
+  }
+
+  async mutate(request) {
+    if (this.throwNextMutation) {
+      this.throwNextMutation = false;
+      throw new Error("simulated coordinator crash before GitHub accepted mutation");
+    }
+    if (this.beforeMutation) {
+      const hook = this.beforeMutation;
+      this.beforeMutation = null;
+      await hook();
+    }
+
+    this.requests.push(request);
+    const update = request.path.match(/^\/repos\/[^/]+\/[^/]+\/pulls\/(\d+)\/update-branch$/);
+    const merge = request.path.match(/^\/repos\/[^/]+\/[^/]+\/pulls\/(\d+)\/merge$/);
+
+    if (update) {
+      const pr = this.prs.get(Number(update[1]));
+      if (!pr || !pr.open) return { status: 404, body: { message: "not found" } };
+      if (request.body.expected_head_sha !== pr.headSha) return { status: 422, body: { message: "head changed" } };
+      if (pr.mergeability !== "mergeable") return { status: 409, body: { message: "conflict" } };
+      if (!pr.nextHeadSha) return { status: 422, body: { message: "no refreshed head fixture" } };
+      pr.baseSha = this.mainSha;
+      pr.headSha = pr.nextHeadSha;
+      pr.nextHeadSha = null;
+      pr.transaction = "pending";
+      pr.state = "pending";
+      return { status: 202, body: { message: "scheduled" } };
+    }
+
+    if (merge) {
+      const pr = this.prs.get(Number(merge[1]));
+      if (!pr || !pr.open) return { status: 404, body: { message: "not found" } };
+      if (request.body.sha !== pr.headSha) return { status: 409, body: { message: "head changed" } };
+      if (pr.baseSha !== this.mainSha) return { status: 405, body: { message: "base branch was modified" } };
+      if (pr.mergeability !== "mergeable" || pr.transaction !== "success" || pr.state !== "success") {
+        return { status: 405, body: { message: "candidate is not mergeable" } };
+      }
+      pr.open = false;
+      this.mainSha = pr.mergeSha;
+      this.successfulMerges++;
+      return { status: 200, body: { merged: true, sha: pr.mergeSha } };
+    }
+
+    return { status: 404, body: { message: "unknown mutation" } };
+  }
+}
+
+function commandInput(control, overrides = {}) {
+  return {
+    repository: REPOSITORY,
+    readyLabel: READY_LABEL,
+    mergeMethod: "merge",
+    requiredChecks: {
+      transaction: [{ name: TX }],
+      state: [{ name: STATE }],
+    },
+    readReadyInventory: () => control.readReadyInventory(),
+    readCandidate: (prNumber) => control.readCandidate(prNumber),
+    mutationTransport: control.transport,
+    ...overrides,
+  };
+}
+
+async function run(control, overrides = {}) {
+  return runTrustedPortableCoordinator(commandInput(control, overrides));
+}
+
+console.log("\n--- trusted portable coordinator recovery/security contract ---");
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, A0, { mergeSha: M1 });
+  control.addPr(2, B0, { nextHeadSha: B1, mergeSha: M2 });
+
+  const a = await run(control);
+  expect("first READY candidate merges over exact M0", [a.pr, a.main_sha, a.head_sha, a.decision, a.mutation], [1, M0, A0, "merge_exact_head", "merge_exact_head"]);
+  expect("first merge advances fake main", control.mainSha, M1);
+
+  const refresh = await run(control);
+  expect("second PR becomes coordinator-owned freshness work", [refresh.pr, refresh.decision, refresh.mutation], [2, "refresh_branch", "refresh_branch"]);
+  expect("refresh sends exact old head", control.requests.at(-1)?.body.expected_head_sha, B0);
+
+  const wait = await run(control);
+  expect("refreshed head is reread and pending checks block merge", [wait.pr, wait.head_sha, wait.decision, wait.mutation], [2, B1, "wait_for_checks", "none"]);
+  const pr2 = control.prs.get(2);
+  pr2.transaction = "success";
+  pr2.state = "success";
+
+  const b = await run(control);
+  expect("new exact head merges only after new evidence", [b.pr, b.head_sha, b.decision, b.mutation], [2, B1, "merge_exact_head", "merge_exact_head"]);
+  expect("two concurrent READY PRs integrate without agent branch update", [control.mainSha, control.successfulMerges], [M2, 2]);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, C0, { baseSha: MOLD, nextHeadSha: C1, mergeSha: M1 });
+  control.throwNextMutation = true;
+
+  const crashed = await run(control);
+  expect("transport crash is evidence, not an unguarded retry", [crashed.mutation, crashed.result?.ok, crashed.result?.error], ["refresh_branch", false, "transport_error"]);
+  expect("crash before accepted mutation leaves head unchanged", control.prs.get(1).headSha, C0);
+
+  const restarted = await run(control);
+  expect("restart rebuilds queue and retries from fresh control-plane facts", [restarted.pr, restarted.head_sha, restarted.mutation], [1, C0, "refresh_branch"]);
+  expect("accepted refresh installs a new head", control.prs.get(1).headSha, C1);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, A0, { mergeSha: M1 });
+  const merged = await run(control);
+  const after = await run(control);
+  expect("merge response can be followed by restart without duplicate merge", [merged.mutation, after.kind, control.successfulMerges], ["merge_exact_head", "idle", 1]);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, A0, { mergeability: "conflicting" });
+  control.addPr(2, B0, { transaction: "failure" });
+  control.addPr(3, C0, { mergeSha: M1 });
+  const result = await run(control);
+  expect("conflict and failed checks do not head-of-line block later READY PR", [result.pr, result.decision, control.successfulMerges], [3, "merge_exact_head", 1]);
+  expect("blocked PRs remain unmerged and isolated", [control.prs.get(1).open, control.prs.get(2).open], [true, true]);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, A0, { mergeSha: M1 });
+  control.beforeMutation = async () => {
+    const pr = control.prs.get(1);
+    pr.headSha = B0;
+    pr.transaction = "pending";
+    pr.state = "pending";
+  };
+  const stale = await run(control);
+  expect("head change between read and merge is rejected by exact-head write", [stale.result?.ok, stale.result?.error, control.successfulMerges], [false, "stale_head", 0]);
+  const reread = await run(control);
+  expect("next pass rereads changed head instead of reusing old evidence", [reread.head_sha, reread.decision, reread.mutation], [B0, "wait_for_checks", "none"]);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, A0, { nextHeadSha: B1, mergeSha: M2 });
+  control.beforeMutation = async () => { control.mainSha = M1; };
+  const staleMain = await run(control);
+  expect("main advance before merge cannot stale-merge", [staleMain.result?.ok, staleMain.result?.error, control.successfulMerges], [false, "merge_not_allowed", 0]);
+  const refresh = await run(control);
+  expect("next pass sees new main and selects refresh", [refresh.main_sha, refresh.decision, refresh.mutation], [M1, "refresh_branch", "refresh_branch"]);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  control.addPr(1, C0, { baseSha: MOLD, nextHeadSha: C2, mergeSha: M1 });
+  control.beforeMutation = async () => {
+    const pr = control.prs.get(1);
+    pr.headSha = C1;
+    pr.nextHeadSha = C2;
+  };
+  const staleUpdate = await run(control);
+  expect("head change before update-branch rejects old expected head", [staleUpdate.result?.ok, staleUpdate.result?.error], [false, "stale_head"]);
+  const retry = await run(control);
+  expect("retry after rejected update uses reread head", [retry.head_sha, retry.mutation, control.requests.at(-1)?.body.expected_head_sha], [C1, "refresh_branch", C1]);
+}
+
+{
+  const control = new FakeGitHubControlPlane(M0);
+  const malformed = await run(control, { readReadyInventory: async () => ({ complete: false, pages: [] }) });
+  expect("incomplete control-plane inventory fails closed", [malformed.kind, malformed.mutation], ["invalid_inventory", "none"]);
+}
+
+{
+  const source = readFileSync(new URL("../src/portable-integration/trusted-command.mts", import.meta.url), "utf8");
+  for (const forbidden of ["node:child_process", "actions/checkout", "npm test", "npm run", "git merge", "git rebase", "bypass", "admin"]) {
+    expect(`trusted command source excludes privileged PR-code path: ${forbidden}`, source.includes(forbidden), false);
+  }
+  expect("trusted command delegates all mutations to guarded write adapter", source.includes("createGitHubWriteAdapter"), true);
+  expect("trusted command reuses canonical GitHub read normalizers", source.includes("normalizeGitHubReadyInventory") && source.includes("normalizeGitHubCandidate"), true);
+  expect("portable trusted command is not a public CLI command", COMMANDS.some((command) => command.includes("portable")), false);
+}
+
+console.log(`\n${failures === 0 ? "All trusted portable recovery/security tests passed" : `${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Краткое описание

Implements #317 as the final portable-backend implementation slice: an internal trusted coordinator command boundary plus end-to-end recovery/security fixtures.

The command boundary remains intentionally internal. It composes the already accepted portable layers and does not add a public CLI/Action mode or enable the provider by presence of code alone.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/portable-integration/trusted-command.mts
  - dist/portable-integration/trusted-command.mjs
  - tests/test-portable-trusted-command-recovery.mjs
budgets:
  max_new_docs: 0
  max_new_files: 3
  max_net_added_lines: 1200
anchors:
  affects:
    - "#304"
    - "#306"
    - "#317"
  implements:
    - "#317"
  verifies:
    - "portable coordinator recovery and privileged security boundary"
must_touch:
  - tests/**
must_not_touch:
  - src/checks/**
  - src/github-pr.mts
  - src/repo-guard.mts
  - schemas/**
  - .github/**
  - repo-policy.json
  - action.yml
expected_effects:
  - Internal trusted command composes #314 GitHub fact normalization, #316 coordinator orchestration and #315 exact-head guarded writes.
  - Raw/incomplete/stale GitHub control-plane facts fail closed before unsafe mutation.
  - Backend evidence exposes exact provider/main/head/PR/decision/mutation result without becoming public agent lifecycle #308.
  - Concurrent READY flow proves coordinator-owned freshness refresh and reread before merge.
  - Crash/restart and external head/main races never reuse stale evidence or perform unguarded retry.
  - Privileged path contains no checkout, project-code execution, local git merge/rebase, admin or protection-bypass path.
  - Existing public CLI, Action, check-pr, schemas, policy and Constraint Program remain unchanged and parallel provider stays inert until explicit #309 enablement.
```

## Implemented internal boundary

```text
trusted invocation
  -> raw READY inventory reader
  -> normalizeGitHubReadyInventory (#314)
  -> per-candidate raw fact reader
  -> normalizeGitHubCandidate (#314)
  -> runPortableCoordinatorPass (#316 / #313 planner)
  -> createGitHubWriteAdapter (#315)
  -> at most one exact-head guarded mutation
  -> structured backend evidence
```

The trusted overlay supplies repository identity, READY label and required-check declarations from trusted invocation inputs rather than accepting those control fields from raw GitHub payload fragments.

The command emits backend evidence with `provider=portable`, exact main/head/PR identity, decision kind/reason, mutation kind and guarded mutation result. It does not become the provider-neutral lifecycle protocol reserved for #308.

## TDD evidence

### RED

RED-only head: `cbe890da3616089bd00353856d3929b392d6b5b0`.

Run #772 / `32635344997` reached the new recovery/security test after generated-dist/self-policy/integration/doctor/package-smoke prerequisites were green and failed for the expected reason only: `ERR_MODULE_NOT_FOUND` for intentionally absent `dist/portable-integration/trusted-command.mjs`.

### Source-only freshness boundary

Source head: `093346e5198a9a4cd98410c9f8e3170325e9d4d5`.

Run #773 / `32635523127` completed package smoke successfully and failed at the expected `Verify generated dist freshness` boundary before generated output was committed; later validate steps were skipped.

### GREEN

Final implementation head: `e0eb8071924adc8a720a607d5ca1abaf1417e8b5`.

Draft run #774 / `32635720419` completed `success` on that exact head:
- repository TypeScript compiler confirms generated dist is current;
- self repo-policy GREEN;
- validate-integration GREEN (`7 passed, 0 failed`);
- doctor GREEN (`8 passed, 0 warnings, 0 failed`);
- package smoke GREEN;
- advisory exercise GREEN;
- all **48 discovered test files passed**;
- blocking `Run PR policy check` is intentionally skipped only because this checkpoint is still draft.

The dedicated trusted-command recovery/security fixture proves:
- first READY PR merges over exact M0 and advances the fake control plane to M1;
- a second READY PR becomes coordinator-owned freshness work instead of agent rebase work;
- refresh is guarded by the exact old head and stops the pass;
- refreshed head is reread and cannot merge while its exact-head checks are pending;
- the new exact head merges only after new transaction/state evidence, completing M0 -> M1 -> M2;
- transport crash is surfaced as evidence with no hidden retry, and restart reconstructs from fresh control-plane state;
- restart after a successful merge observes no duplicate merge opportunity;
- conflicting/failed-check candidates remain isolated while a later independent READY candidate progresses;
- external PR-head change between read and merge is rejected as stale-head and the next pass rereads the new head;
- external main advance before merge is rejected and the next pass replans as refresh work against the new main;
- external head change before update-branch rejects the old expected head and the next pass uses the reread head;
- incomplete READY inventory fails closed.

## Security / compatibility review

Exact final diff is limited to three new files:
- `src/portable-integration/trusted-command.mts` — 156 lines;
- generated `dist/portable-integration/trusted-command.mjs` — 116 lines;
- `tests/test-portable-trusted-command-recovery.mjs` — 293 lines.

Total additions: **565**, within the declared 1200-line budget.

Static/runtime evidence confirms the trusted command:
- reuses `normalizeGitHubReadyInventory` and `normalizeGitHubCandidate` rather than duplicating read validation;
- delegates every mutation through `createGitHubWriteAdapter`;
- contains no child-process path, Actions checkout invocation, project `npm` execution, local git merge/rebase, bypass/admin path or hidden retry;
- adds no public command containing `portable` to the existing CLI registry;
- changes no `.github`, schema, policy, Action, `check-pr`, Constraint Program or public CLI file.

Generated privileged workflow, GitHub Actions `concurrency`, permissions/readiness and external branch protection remain #309/#311 and are not falsely claimed by this implementation slice.

## Non-goals

- no generated workflow/concurrency YAML (#309);
- no branch protection/ruleset mutation (#309/#311);
- no public status/next_action protocol (#308);
- no native merge queue support (#307);
- no real self-host concurrent PR proof (#311);
- no ChangeIntent/schema/policy migration.

Refs #304, #306, #313, #314, #315, #316, #317.