### PR TITLE
[Parallel P2] Add native merge-group state gate

### DIFF
--- a/dist/github-merge-group.mjs
+++ b/dist/github-merge-group.mjs
@@ -1,0 +1,161 @@
+import { readFileSync } from "node:fs";
+import { runGit, readBasePolicy } from "./git.mjs";
+import { resolveEnforcementMode } from "./enforcement.mjs";
+import { renderAnalysisReport } from "./reporting/renderers.mjs";
+import { loadPolicyRuntimeFromObject } from "./runtime/validation.mjs";
+import { runPolicyPipeline } from "./runtime/pipeline.mjs";
+const OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const value = (args, name) => {
+    const index = args.indexOf(name);
+    return index < 0 ? null : args[index + 1];
+};
+const stringValue = (input) => typeof input === "string" && input.length > 0 ? input : null;
+export function normalizeGitHubMergeGroupEvent(payload, environment = {}) {
+    if (!payload || typeof payload !== "object") {
+        return { ok: false, error: "not_merge_group_event", message: "GitHub event payload is not an object" };
+    }
+    const event = payload;
+    if (!event.merge_group || typeof event.merge_group !== "object") {
+        return { ok: false, error: "not_merge_group_event", message: "GitHub event does not contain merge_group data" };
+    }
+    if (event.action !== "checks_requested") {
+        return {
+            ok: false,
+            error: "unsupported_merge_group_action",
+            message: `Unsupported merge_group action: ${String(event.action || "<missing>")}`,
+        };
+    }
+    const payloadSha = stringValue(event.merge_group.head_sha);
+    const githubSha = stringValue(environment.githubSha);
+    if (payloadSha && !OBJECT_ID.test(payloadSha)) {
+        return { ok: false, error: "invalid_candidate_sha", message: "merge_group.head_sha is not an exact Git object id" };
+    }
+    if (githubSha && !OBJECT_ID.test(githubSha)) {
+        return { ok: false, error: "invalid_candidate_sha", message: "GITHUB_SHA is not an exact Git object id" };
+    }
+    if (payloadSha && githubSha && payloadSha.toLowerCase() !== githubSha.toLowerCase()) {
+        return {
+            ok: false,
+            error: "candidate_sha_mismatch",
+            message: `merge_group.head_sha ${payloadSha} disagrees with GITHUB_SHA ${githubSha}`,
+        };
+    }
+    const candidateSha = payloadSha || githubSha;
+    if (!candidateSha) {
+        return { ok: false, error: "missing_candidate_sha", message: "merge_group candidate SHA is missing" };
+    }
+    const rawBaseSha = stringValue(event.merge_group.base_sha);
+    if (rawBaseSha && !OBJECT_ID.test(rawBaseSha)) {
+        return { ok: false, error: "invalid_base_sha", message: "merge_group.base_sha is not an exact Git object id" };
+    }
+    return {
+        ok: true,
+        provider: "github_merge_queue",
+        candidateSha,
+        baseSha: rawBaseSha,
+        baseRef: stringValue(event.merge_group.base_ref),
+        headRef: stringValue(event.merge_group.head_ref),
+        repoFullName: stringValue(event.repository?.full_name),
+    };
+}
+export function loadGitHubMergeGroupEvent() {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath) {
+        return { ok: false, error: "no_event", message: "GITHUB_EVENT_PATH not set; not running in GitHub Actions" };
+    }
+    try {
+        const payload = JSON.parse(readFileSync(eventPath, "utf-8"));
+        return normalizeGitHubMergeGroupEvent(payload, { githubSha: process.env.GITHUB_SHA || null });
+    }
+    catch (error) {
+        return { ok: false, error: "event_read_error", message: `Cannot read event file: ${error.message}` };
+    }
+}
+function exactCandidateDiff(baseSha, candidateSha, cwd) {
+    return runGit(["-c", "core.quotepath=false", "diff", baseSha, candidateSha, "--"], { cwd });
+}
+export function runCheckMergeGroup(roots, args = []) {
+    const format = value(args, "--format") || "text";
+    if (!["text", "json", "summary"].includes(format)) {
+        console.error(`Unknown check-merge-group format: ${format}`);
+        return 1;
+    }
+    const event = loadGitHubMergeGroupEvent();
+    if (!event.ok) {
+        console.error(`ERROR: [${event.error}] ${event.message}`);
+        return 1;
+    }
+    if (!event.baseSha) {
+        console.error("ERROR: [missing_base_sha] merge_group.base_sha is required to establish the trusted policy boundary");
+        return 1;
+    }
+    let checkoutSha;
+    try {
+        checkoutSha = runGit(["rev-parse", "--verify", "HEAD^{commit}"], { cwd: roots.repoRoot }).trim();
+    }
+    catch (error) {
+        console.error(`ERROR: cannot resolve checked-out merge-group candidate: ${error.message}`);
+        return 1;
+    }
+    if (checkoutSha.toLowerCase() !== event.candidateSha.toLowerCase()) {
+        console.error(`ERROR: [candidate_checkout_mismatch] checked-out HEAD ${checkoutSha} != merge-group candidate ${event.candidateSha}`);
+        return 1;
+    }
+    const quiet = format !== "text";
+    const baseRead = readBasePolicy(event.baseSha, roots.repoRoot);
+    if (baseRead.error || baseRead.policy === null) {
+        console.error(`ERROR: cannot establish trusted merge-group base policy: ${baseRead.error || "empty_base_policy"}`);
+        return 1;
+    }
+    const runtime = loadPolicyRuntimeFromObject(roots, baseRead.policy, {
+        quiet,
+        label: "repo-policy.json (merge-group base)",
+    });
+    if (!runtime.ok) {
+        if (!quiet)
+            console.error("\nTrusted merge-group base policy compilation failed; aborting enforcement.");
+        return 1;
+    }
+    const enforcement = resolveEnforcementMode({
+        cliValue: roots.enforcementMode,
+        policy: runtime.policy,
+    });
+    if (!enforcement.ok) {
+        console.error(`ERROR: ${enforcement.message}`);
+        return 1;
+    }
+    let diffText;
+    try {
+        diffText = exactCandidateDiff(event.baseSha, event.candidateSha, roots.repoRoot);
+    }
+    catch (error) {
+        console.error(`ERROR: cannot inspect exact merge-group candidate diff: ${error.message}`);
+        return 1;
+    }
+    const baseReport = runPolicyPipeline({
+        mode: "check-merge-group",
+        repositoryRoot: roots.repoRoot,
+        policy: runtime.policy,
+        changeIntent: null,
+        changeIntentSource: "none",
+        enforcement,
+        diffText,
+        initialChecks: [],
+    }, {
+        quiet,
+        executionPhase: "state",
+    });
+    const report = {
+        ...baseReport,
+        provider: event.provider,
+        candidateSha: event.candidateSha,
+        baseSha: event.baseSha,
+        baseRef: event.baseRef,
+        headRef: event.headRef,
+        repository: event.repoFullName,
+    };
+    const output = renderAnalysisReport(report, { format });
+    if (output)
+        console.log(output);
+    return baseReport.exitCode;
+}

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -18,6 +18,10 @@ const COMMAND_SPECS = {
         options: {}, positionals: 0,
         run: async (roots, args) => (await import("./github-pr.mjs")).runCheckPR(roots, args),
     },
+    "check-merge-group": {
+        options: valueOptions("--format"), positionals: 0,
+        run: async (roots, args) => (await import("./github-merge-group.mjs")).runCheckMergeGroup(roots, args),
+    },
     init: {
         options: { ...valueOptions("--preset", "--mode", "--action-ref"), "--help": false }, positionals: 0,
         run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),

--- a/docs/self-hosting-coverage.json
+++ b/docs/self-hosting-coverage.json
@@ -5,6 +5,7 @@
     "rule:advisory-text-rules": "Репозиторий намеренно не хранит дублирующий Markdown ради проверки эвристики похожих документов.",
     "rule:anchor-extraction": "В repo-guard нет собственных requirement anchors; механизм покрывается специализированными тестами.",
     "profile:requirements-strict": "Data-driven policy pack требует канонические requirements/*.json; добавлять фиктивные требования ради dogfooding нельзя.",
-    "change-intent-format:repo-guard-json": "YAML является канонической собственной формой; второй JSON-блок в шаблоне был бы искусственным покрытием, формат проверяется тестами parser-а."
+    "change-intent-format:repo-guard-json": "YAML является канонической собственной формой; второй JSON-блок в шаблоне был бы искусственным покрытием, формат проверяется тестами parser-а.",
+    "command:check-merge-group": "Native GitHub Merge Queue недоступна для user-owned repo-guard; команда проверяется изолированными merge-group fixtures, а реальный parallel self-hosting выполняется через portable backend в #311."
   }
 }

--- a/examples/github-merge-queue-workflow.yml
+++ b/examples/github-merge-queue-workflow.yml
@@ -1,0 +1,39 @@
+name: repo-guard native merge queue
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  repo-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Replace the ref below with the immutable 40-hex SHA accepted for your rollout.
+      - name: Validate PR transaction
+        if: github.event_name == 'pull_request'
+        uses: netkeep80/repo-guard@REPLACE_WITH_EXACT_REPO_GUARD_SHA
+        with:
+          mode: check-pr
+          enforcement: blocking
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate exact merge-group state
+        if: github.event_name == 'merge_group'
+        uses: netkeep80/repo-guard@REPLACE_WITH_EXACT_REPO_GUARD_SHA
+        with:
+          mode: check-merge-group
+          enforcement: blocking
+
+# Project CI remains a separate required check and should also listen to merge_group.

--- a/src/github-merge-group.mts
+++ b/src/github-merge-group.mts
@@ -1,0 +1,205 @@
+import { readFileSync } from "node:fs";
+import { runGit, readBasePolicy } from "./git.mjs";
+import { resolveEnforcementMode } from "./enforcement.mjs";
+import { renderAnalysisReport } from "./reporting/renderers.mjs";
+import { loadPolicyRuntimeFromObject } from "./runtime/validation.mjs";
+import { runPolicyPipeline } from "./runtime/pipeline.mjs";
+
+type CheckMergeGroupRoots = Parameters<typeof loadPolicyRuntimeFromObject>[0] & {
+  enforcementMode?: Parameters<typeof resolveEnforcementMode>[0]["cliValue"];
+};
+
+interface MergeGroupProjection {
+  base_ref?: unknown;
+  base_sha?: unknown;
+  head_ref?: unknown;
+  head_sha?: unknown;
+}
+
+interface MergeGroupEventProjection {
+  action?: unknown;
+  merge_group?: MergeGroupProjection | null;
+  repository?: { full_name?: unknown } | null;
+}
+
+interface NormalizeEnvironment {
+  githubSha?: string | null;
+}
+
+type MergeGroupEventResult =
+  | {
+      ok: false;
+      error: string;
+      message: string;
+    }
+  | {
+      ok: true;
+      provider: "github_merge_queue";
+      candidateSha: string;
+      baseSha: string | null;
+      baseRef: string | null;
+      headRef: string | null;
+      repoFullName: string | null;
+    };
+
+const OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const value = (args: string[], name: string): string | null | undefined => {
+  const index = args.indexOf(name);
+  return index < 0 ? null : args[index + 1];
+};
+const stringValue = (input: unknown): string | null => typeof input === "string" && input.length > 0 ? input : null;
+
+export function normalizeGitHubMergeGroupEvent(payload: unknown, environment: NormalizeEnvironment = {}): MergeGroupEventResult {
+  if (!payload || typeof payload !== "object") {
+    return { ok: false, error: "not_merge_group_event", message: "GitHub event payload is not an object" };
+  }
+  const event = payload as MergeGroupEventProjection;
+  if (!event.merge_group || typeof event.merge_group !== "object") {
+    return { ok: false, error: "not_merge_group_event", message: "GitHub event does not contain merge_group data" };
+  }
+  if (event.action !== "checks_requested") {
+    return {
+      ok: false,
+      error: "unsupported_merge_group_action",
+      message: `Unsupported merge_group action: ${String(event.action || "<missing>")}`,
+    };
+  }
+
+  const payloadSha = stringValue(event.merge_group.head_sha);
+  const githubSha = stringValue(environment.githubSha);
+  if (payloadSha && !OBJECT_ID.test(payloadSha)) {
+    return { ok: false, error: "invalid_candidate_sha", message: "merge_group.head_sha is not an exact Git object id" };
+  }
+  if (githubSha && !OBJECT_ID.test(githubSha)) {
+    return { ok: false, error: "invalid_candidate_sha", message: "GITHUB_SHA is not an exact Git object id" };
+  }
+  if (payloadSha && githubSha && payloadSha.toLowerCase() !== githubSha.toLowerCase()) {
+    return {
+      ok: false,
+      error: "candidate_sha_mismatch",
+      message: `merge_group.head_sha ${payloadSha} disagrees with GITHUB_SHA ${githubSha}`,
+    };
+  }
+  const candidateSha = payloadSha || githubSha;
+  if (!candidateSha) {
+    return { ok: false, error: "missing_candidate_sha", message: "merge_group candidate SHA is missing" };
+  }
+
+  const rawBaseSha = stringValue(event.merge_group.base_sha);
+  if (rawBaseSha && !OBJECT_ID.test(rawBaseSha)) {
+    return { ok: false, error: "invalid_base_sha", message: "merge_group.base_sha is not an exact Git object id" };
+  }
+
+  return {
+    ok: true,
+    provider: "github_merge_queue",
+    candidateSha,
+    baseSha: rawBaseSha,
+    baseRef: stringValue(event.merge_group.base_ref),
+    headRef: stringValue(event.merge_group.head_ref),
+    repoFullName: stringValue(event.repository?.full_name),
+  };
+}
+
+export function loadGitHubMergeGroupEvent(): MergeGroupEventResult {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return { ok: false, error: "no_event", message: "GITHUB_EVENT_PATH not set; not running in GitHub Actions" };
+  }
+  try {
+    const payload: unknown = JSON.parse(readFileSync(eventPath, "utf-8"));
+    return normalizeGitHubMergeGroupEvent(payload, { githubSha: process.env.GITHUB_SHA || null });
+  } catch (error: unknown) {
+    return { ok: false, error: "event_read_error", message: `Cannot read event file: ${(error as Error).message}` };
+  }
+}
+
+function exactCandidateDiff(baseSha: string, candidateSha: string, cwd: string): string {
+  return runGit(["-c", "core.quotepath=false", "diff", baseSha, candidateSha, "--"], { cwd });
+}
+
+export function runCheckMergeGroup(roots: CheckMergeGroupRoots, args: string[] = []): number {
+  const format = value(args, "--format") || "text";
+  if (!["text", "json", "summary"].includes(format)) {
+    console.error(`Unknown check-merge-group format: ${format}`);
+    return 1;
+  }
+  const event = loadGitHubMergeGroupEvent();
+  if (!event.ok) {
+    console.error(`ERROR: [${event.error}] ${event.message}`);
+    return 1;
+  }
+  if (!event.baseSha) {
+    console.error("ERROR: [missing_base_sha] merge_group.base_sha is required to establish the trusted policy boundary");
+    return 1;
+  }
+
+  let checkoutSha: string;
+  try {
+    checkoutSha = runGit(["rev-parse", "--verify", "HEAD^{commit}"], { cwd: roots.repoRoot }).trim();
+  } catch (error: unknown) {
+    console.error(`ERROR: cannot resolve checked-out merge-group candidate: ${(error as Error).message}`);
+    return 1;
+  }
+  if (checkoutSha.toLowerCase() !== event.candidateSha.toLowerCase()) {
+    console.error(`ERROR: [candidate_checkout_mismatch] checked-out HEAD ${checkoutSha} != merge-group candidate ${event.candidateSha}`);
+    return 1;
+  }
+
+  const quiet = format !== "text";
+  const baseRead = readBasePolicy(event.baseSha, roots.repoRoot);
+  if (baseRead.error || baseRead.policy === null) {
+    console.error(`ERROR: cannot establish trusted merge-group base policy: ${baseRead.error || "empty_base_policy"}`);
+    return 1;
+  }
+  const runtime = loadPolicyRuntimeFromObject(roots, baseRead.policy, {
+    quiet,
+    label: "repo-policy.json (merge-group base)",
+  });
+  if (!runtime.ok) {
+    if (!quiet) console.error("\nTrusted merge-group base policy compilation failed; aborting enforcement.");
+    return 1;
+  }
+  const enforcement = resolveEnforcementMode({
+    cliValue: roots.enforcementMode,
+    policy: runtime.policy,
+  } as Parameters<typeof resolveEnforcementMode>[0]);
+  if (!enforcement.ok) {
+    console.error(`ERROR: ${enforcement.message}`);
+    return 1;
+  }
+
+  let diffText: string;
+  try {
+    diffText = exactCandidateDiff(event.baseSha, event.candidateSha, roots.repoRoot);
+  } catch (error: unknown) {
+    console.error(`ERROR: cannot inspect exact merge-group candidate diff: ${(error as Error).message}`);
+    return 1;
+  }
+
+  const baseReport = runPolicyPipeline({
+    mode: "check-merge-group",
+    repositoryRoot: roots.repoRoot,
+    policy: runtime.policy,
+    changeIntent: null,
+    changeIntentSource: "none",
+    enforcement,
+    diffText,
+    initialChecks: [],
+  } as Parameters<typeof runPolicyPipeline>[0], {
+    quiet,
+    executionPhase: "state",
+  });
+  const report = {
+    ...baseReport,
+    provider: event.provider,
+    candidateSha: event.candidateSha,
+    baseSha: event.baseSha,
+    baseRef: event.baseRef,
+    headRef: event.headRef,
+    repository: event.repoFullName,
+  };
+  const output = renderAnalysisReport(report, { format });
+  if (output) console.log(output);
+  return baseReport.exitCode;
+}

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -34,6 +34,10 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
     options: {}, positionals: 0,
     run: async (roots, args) => (await import("./github-pr.mjs")).runCheckPR(roots, args),
   },
+  "check-merge-group": {
+    options: valueOptions("--format"), positionals: 0,
+    run: async (roots, args) => (await import("./github-merge-group.mjs")).runCheckMergeGroup(roots, args),
+  },
   init: {
     options: { ...valueOptions("--preset", "--mode", "--action-ref"), "--help": false }, positionals: 0,
     run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),

--- a/tests/test-github-merge-group.mjs
+++ b/tests/test-github-merge-group.mjs
@@ -41,7 +41,7 @@ function basePolicy() {
     registry_rules: [
       {
         id: "merge-group-state",
-        kind: "equal",
+        kind: "set_equality",
         left: { type: "json_array", file: "left.json", json_pointer: "/items" },
         right: { type: "json_array", file: "right.json", json_pointer: "/items" },
       },

--- a/tests/test-github-merge-group.mjs
+++ b/tests/test-github-merge-group.mjs
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { execSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { normalizeGitHubMergeGroupEvent } from "../dist/github-merge-group.mjs";
+import { runCheckPR } from "../dist/github-pr.mjs";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+const projectRoot = resolve(__dirname, "..");
+const repoGuard = resolve(projectRoot, "dist/repo-guard.mjs");
+const SHA_A = "a".repeat(40);
+const SHA_B = "b".repeat(40);
+
+function expect(label, actual, expected) {
+  try {
+    assert.deepEqual(actual, expected);
+    console.log(`PASS: ${label}`);
+  } catch (error) {
+    console.error(`FAIL: ${label}`);
+    throw error;
+  }
+}
+
+function basePolicy() {
+  return {
+    policy_format_version: "0.3.0",
+    repository_kind: "tooling",
+    enforcement: { mode: "blocking" },
+    paths: {
+      forbidden: [],
+      canonical_docs: [],
+      governance_paths: ["repo-policy.json"],
+      operational_paths: [],
+    },
+    diff_rules: {
+      max_new_docs: 0,
+      max_new_files: 0,
+      max_net_added_lines: 0,
+    },
+    registry_rules: [
+      {
+        id: "merge-group-state",
+        kind: "equal",
+        left: { type: "json_array", file: "left.json", json_pointer: "/items" },
+        right: { type: "json_array", file: "right.json", json_pointer: "/items" },
+      },
+    ],
+    content_rules: [],
+    cochange_rules: [],
+  };
+}
+
+function writeTree(root, files) {
+  for (const [path, content] of Object.entries(files)) {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), content);
+  }
+}
+
+function commit(root, message) {
+  execSync("git add -A", { cwd: root, stdio: "pipe" });
+  execSync(`git commit -m ${JSON.stringify(message)}`, { cwd: root, stdio: "pipe" });
+  return execSync("git rev-parse HEAD", { cwd: root, encoding: "utf-8" }).trim();
+}
+
+function makeRepo({ brokenState = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "repo-guard-merge-group-"));
+  execSync("git init", { cwd: dir, stdio: "pipe" });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: "pipe" });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: "pipe" });
+  writeTree(dir, {
+    "repo-policy.json": JSON.stringify(basePolicy(), null, 2),
+    "left.json": JSON.stringify({ items: ["alpha"] }),
+    "right.json": JSON.stringify({ items: ["alpha"] }),
+  });
+  const base = commit(dir, "base");
+  writeTree(dir, {
+    "src/new.mjs": "export const combined = true;\n",
+    ...(brokenState ? { "right.json": JSON.stringify({ items: ["beta"] }) } : {}),
+  });
+  const head = commit(dir, "merge group candidate");
+  const eventPath = join(dir, "merge-group-event.json");
+  writeFileSync(eventPath, JSON.stringify({
+    action: "checks_requested",
+    merge_group: {
+      base_ref: "refs/heads/main",
+      base_sha: base,
+      head_ref: "refs/heads/gh-readonly-queue/main/pr-1-test",
+      head_sha: head,
+    },
+    repository: { full_name: "example/repo" },
+  }));
+  return { dir, base, head, eventPath };
+}
+
+function runMergeGroup(repo, extraEnv = {}) {
+  const result = spawnSync(process.execPath, [
+    repoGuard,
+    "--repo-root", repo.dir,
+    "check-merge-group",
+    "--format", "json",
+  ], {
+    cwd: projectRoot,
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GITHUB_EVENT_PATH: repo.eventPath,
+      GITHUB_SHA: repo.head,
+      ...extraEnv,
+    },
+  });
+  let parsed = null;
+  try {
+    parsed = JSON.parse(result.stdout || "");
+  } catch {}
+  return {
+    code: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    parsed,
+  };
+}
+
+console.log("\n--- merge_group event normalization ---");
+{
+  const payload = {
+    action: "checks_requested",
+    merge_group: {
+      base_ref: "refs/heads/main",
+      base_sha: SHA_B,
+      head_ref: "refs/heads/gh-readonly-queue/main/pr-1-test",
+      head_sha: SHA_A,
+    },
+    repository: { full_name: "example/repo" },
+  };
+  const normalized = normalizeGitHubMergeGroupEvent(payload, { githubSha: SHA_A });
+  expect("merge_group checks_requested is first-class", normalized.ok, true);
+  expect("provider is explicit", normalized.provider, "github_merge_queue");
+  expect("exact candidate SHA comes from merge-group evidence", normalized.candidateSha, SHA_A);
+  expect("base SHA is retained when present", normalized.baseSha, SHA_B);
+  expect("base ref is retained when present", normalized.baseRef, "refs/heads/main");
+  expect("repository identity is retained", normalized.repoFullName, "example/repo");
+}
+
+{
+  const mismatch = normalizeGitHubMergeGroupEvent({
+    action: "checks_requested",
+    merge_group: { head_sha: SHA_A },
+  }, { githubSha: SHA_B });
+  expect("payload/environment candidate disagreement fails closed", mismatch.ok, false);
+  expect("candidate mismatch is machine-readable", mismatch.error, "candidate_sha_mismatch");
+}
+
+{
+  const missing = normalizeGitHubMergeGroupEvent({
+    action: "checks_requested",
+    merge_group: {},
+  }, { githubSha: "" });
+  expect("missing exact candidate SHA fails closed", missing.ok, false);
+  expect("missing candidate reason is machine-readable", missing.error, "missing_candidate_sha");
+}
+
+{
+  const unsupported = normalizeGitHubMergeGroupEvent({
+    action: "destroyed",
+    merge_group: { head_sha: SHA_A },
+  }, { githubSha: SHA_A });
+  expect("unknown merge_group action fails closed", unsupported.ok, false);
+  expect("unsupported action reason is machine-readable", unsupported.error, "unsupported_merge_group_action");
+}
+
+console.log("\n--- state-only canonical pipeline over exact group candidate ---");
+{
+  const repo = makeRepo();
+  try {
+    const result = runMergeGroup(repo);
+    expect("transaction-only diff budget does not block merge-group state pass", result.code, 0);
+    expect("JSON output stays on stdout only", result.stderr, "");
+    expect("JSON output parses", Boolean(result.parsed), true);
+    expect("command is explicit", result.parsed?.command, "check-merge-group");
+    expect("provider is machine-visible", result.parsed?.provider, "github_merge_queue");
+    expect("execution phase is state", result.parsed?.executionPhase, "state");
+    expect("exact candidate SHA is machine-visible", result.parsed?.candidateSha, repo.head);
+    expect("exact base SHA is machine-visible", result.parsed?.baseSha, repo.base);
+    expect("base ref is machine-visible", result.parsed?.baseRef, "refs/heads/main");
+    expect("state relation executes", result.parsed?.ruleResults?.some((entry) => entry.rule === "registry-rules"), true);
+    expect("transaction diff budget is excluded", result.parsed?.ruleResults?.some((entry) => entry.rule === "max-new-files"), false);
+    expect("merge-group path invents no ChangeIntent check", result.parsed?.ruleResults?.some((entry) => entry.rule === "change-intent"), false);
+  } finally {
+    rmSync(repo.dir, { recursive: true, force: true });
+  }
+}
+
+console.log("\n--- combined candidate repository-state failure ---");
+{
+  const repo = makeRepo({ brokenState: true });
+  try {
+    const result = runMergeGroup(repo);
+    expect("broken combined repository state blocks exact candidate", result.code, 1);
+    expect("state failure remains structured", result.parsed?.violations?.some((entry) => entry.rule === "registry-rules"), true);
+    expect("failed group still reports exact candidate", result.parsed?.candidateSha, repo.head);
+  } finally {
+    rmSync(repo.dir, { recursive: true, force: true });
+  }
+}
+
+console.log("\n--- existing check-pr does not reinterpret merge_group as a PR ---");
+{
+  const repo = makeRepo();
+  const previousEvent = process.env.GITHUB_EVENT_PATH;
+  const previousSha = process.env.GITHUB_SHA;
+  const errors = [];
+  const originalError = console.error;
+  try {
+    process.env.GITHUB_EVENT_PATH = repo.eventPath;
+    process.env.GITHUB_SHA = repo.head;
+    console.error = (...args) => errors.push(args.join(" "));
+    const code = runCheckPR({ packageRoot: projectRoot, repoRoot: repo.dir });
+    expect("check-pr rejects merge_group event", code, 1);
+    expect("check-pr reports missing pull_request rather than fabricating metadata", errors.some((line) => line.includes("does not contain pull_request data")), true);
+  } finally {
+    console.error = originalError;
+    if (previousEvent === undefined) delete process.env.GITHUB_EVENT_PATH;
+    else process.env.GITHUB_EVENT_PATH = previousEvent;
+    if (previousSha === undefined) delete process.env.GITHUB_SHA;
+    else process.env.GITHUB_SHA = previousSha;
+    rmSync(repo.dir, { recursive: true, force: true });
+  }
+}
+
+console.log("\nAll GitHub merge-group tests passed");

--- a/tests/test-self-hosting.mjs
+++ b/tests/test-self-hosting.mjs
@@ -82,12 +82,17 @@ describe("derived test inventory", () => {
 });
 
 describe("derived capability inventory", () => {
-  it("derives commands from the CLI registry and finds real evidence", () => {
+  it("derives commands from the CLI registry and finds real evidence or an explicit exception", () => {
     const corpus = `${workflowText}\n${testFiles.join("\n")}\n${read(".github/PULL_REQUEST_TEMPLATE.md")}`;
     for (const command of COMMANDS) {
       if (command === "validate") assert.match(workflowText, /Validate repo-policy\.json/);
       else if (command === "init") assert.ok(testFiles.includes("test-init.mjs"));
-      else assert.ok(corpus.includes(command), `no self-hosting evidence for command ${command}`);
+      else if (!corpus.includes(command)) {
+        assert.ok(hasException(`command:${command}`), `no self-hosting evidence or exception for command ${command}`);
+      }
+    }
+    for (const id of Object.keys(exceptions).filter((id) => id.startsWith("command:"))) {
+      assert.ok(COMMANDS.includes(id.slice(8)), `stale command exception ${id}`);
     }
   });
 

--- a/tests/test-typescript-source-cutover.mjs
+++ b/tests/test-typescript-source-cutover.mjs
@@ -32,7 +32,7 @@ describe("strict TypeScript source cutover", () => {
     assert.deepEqual(tsconfig.include, ["src/**/*.mts"]);
   });
 
-  it("keeps the built CLI command inventory unchanged", () => {
-    assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "init", "doctor", "validate-integration"]);
+  it("keeps the built CLI command inventory explicit", () => {
+    assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "check-merge-group", "init", "doctor", "validate-integration"]);
   });
 });


### PR DESCRIPTION
## Краткое описание

Implements #307 as the native GitHub Merge Queue provider boundary. The implementation keeps `pull_request` as the transaction gate and adds a separate first-class `merge_group.checks_requested` state/integration gate over the exact merge-group candidate SHA.

The provider remains opt-in: this PR does not enable Merge Queue, change branch protection, or add `merge_group` to repo-guard's own workflow. Provider readiness and generated integration remain #309.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/github-merge-group.mts
  - dist/github-merge-group.mjs
  - src/repo-guard.mts
  - dist/repo-guard.mjs
  - tests/test-github-merge-group.mjs
  - tests/test-self-hosting.mjs
  - tests/test-typescript-source-cutover.mjs
  - examples/github-merge-queue-workflow.yml
  - docs/self-hosting-coverage.json
budgets:
  max_new_docs: 0
  max_new_files: 4
  max_net_added_lines: 1200
anchors:
  affects:
    - "#304"
    - "#307"
  implements:
    - "#307"
  verifies:
    - "native merge-group exact-candidate state validation"
must_touch:
  - tests/**
  - examples/**
must_not_touch:
  - .github/**
  - repo-policy.json
  - schemas/**
  - action.yml
  - src/checks/**
  - src/github-pr.mts
  - src/portable-integration/**
expected_effects:
  - merge_group.checks_requested is normalized as a first-class github_merge_queue provider event.
  - Payload head SHA and GITHUB_SHA must agree when both are present; missing or inconsistent candidate identity fails closed.
  - The exact merge-group candidate is evaluated through the existing canonical pipeline with executionPhase=state.
  - Transaction-only rules and ChangeIntent handling do not execute in merge-group context.
  - Existing check-pr continues to reject merge_group events rather than fabricating PR metadata.
  - Structured evidence exposes provider, exact candidate SHA and reliable base SHA/ref metadata.
  - A consumer workflow example demonstrates additive pull_request plus merge_group triggers without changing repo-guard self-host configuration.
  - Self-hosting coverage records an explicit command exception because this user-owned repository cannot honestly self-host the native Merge Queue provider; portable self-hosting remains #311.
  - Strict TypeScript cutover regression inventory accepts the intentional additive check-merge-group CLI command while continuing to pin the complete built command surface.
```

## TDD

RED contract is committed first at `2887326437266331bbdf5f5ef920e32908f790de`. It imports the intentionally absent generated merge-group adapter and exercises normalization, state-only canonical evaluation, broken combined-state rejection, and separation from `check-pr`.

Refs #304, #305, #307, #309, #311.