### PR TITLE
[Parallel P4a] Add pure provider readiness evaluator

### DIFF
--- a/dist/parallel-readiness.mjs
+++ b/dist/parallel-readiness.mjs
@@ -1,0 +1,196 @@
+const SHA = /^[0-9a-f]{40}$/i;
+const REPO_GUARD = /(?:^|\/)repo-guard(?:@|$)/i;
+const PROJECT_EXECUTION = /(?:^|\s)(?:npm|pnpm|yarn|bun)\s+(?:ci|install|test|run\s+build|build)|(?:^|\s)(?:make|mvn|gradle|cargo)\s+(?:test|build|check)(?:\s|$)/im;
+function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function array(value) {
+    return Array.isArray(value) ? value : [];
+}
+function stringArray(value) {
+    if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string" || item.length === 0))
+        return null;
+    return [...new Set(value)].sort();
+}
+function truthy(value) {
+    return ![undefined, null, false, 0, "", "false", "0", "null"].includes(value);
+}
+function workflows(input) {
+    if (!isObject(input))
+        return [];
+    const integration = input;
+    return array(integration.workflows).filter(isObject);
+}
+function workflowPath(workflow) {
+    return typeof workflow?.path === "string" && workflow.path.length > 0 ? workflow.path : null;
+}
+function hasEvent(workflow, event) {
+    return array(workflow.triggerEvents).includes(event);
+}
+function hasEventType(workflow, event, type) {
+    return array(workflow.triggerEventTypes).some((fact) => {
+        if (!isObject(fact))
+            return false;
+        const typed = fact;
+        return typed.event === event && array(typed.types).includes(type);
+    });
+}
+function repoGuardActions(workflow) {
+    return array(workflow.actionUses)
+        .filter(isObject)
+        .map((fact) => fact.uses)
+        .filter((uses) => typeof uses === "string" && (uses === "./" || uses.startsWith("./") || REPO_GUARD.test(uses)));
+}
+function externalActionIsImmutable(uses) {
+    if (uses === "./" || uses.startsWith("./"))
+        return true;
+    const at = uses.lastIndexOf("@");
+    return at > 0 && SHA.test(uses.slice(at + 1));
+}
+function hasBlockingMode(workflow, mode) {
+    const expected = workflow.expect;
+    if (expected?.mode !== mode || expected?.enforcement !== "blocking")
+        return false;
+    return array(workflow.stepInputs).filter(isObject).some((fact) => {
+        const inputs = fact.inputs;
+        return inputs?.mode === mode && inputs?.enforcement === "blocking";
+    });
+}
+function hasContinueOnError(workflow) {
+    return array(workflow.continueOnError).filter(isObject).some((fact) => truthy(fact.value));
+}
+function hasCheckout(workflow) {
+    return array(workflow.actionUses).filter(isObject).some((fact) => {
+        const uses = fact.uses;
+        return typeof uses === "string" && uses.toLowerCase().startsWith("actions/checkout@");
+    });
+}
+function hasProjectExecution(workflow) {
+    return array(workflow.runCommands).filter(isObject).some((fact) => PROJECT_EXECUTION.test(String(fact.run ?? "")));
+}
+function add(blockers, id, source, message, hint) {
+    if (blockers.some((item) => item.id === id))
+        return;
+    blockers.push({ id, source, message, ...(hint === undefined ? {} : { hint }) });
+}
+function checkActionPin(workflow, blockers) {
+    const actions = repoGuardActions(workflow);
+    if (actions.length === 0) {
+        add(blockers, "missing_repo_guard_action", "repository", "workflow has no repo-guard Action invocation");
+        return;
+    }
+    if (actions.some((uses) => !externalActionIsImmutable(uses))) {
+        add(blockers, "mutable_action_ref", "repository", "external repo-guard Action ref must be an exact commit SHA");
+    }
+}
+function checkTransaction(workflow, blockers) {
+    if (!workflow) {
+        add(blockers, "missing_transaction_gate", "repository", "blocking pull-request transaction gate is missing");
+        return;
+    }
+    if (!hasEvent(workflow, "pull_request"))
+        add(blockers, "missing_pull_request_event", "repository", "transaction gate must listen to pull_request");
+    if (!hasBlockingMode(workflow, "check-pr"))
+        add(blockers, "transaction_gate_not_blocking", "repository", "transaction gate must run blocking check-pr");
+    if (hasContinueOnError(workflow))
+        add(blockers, "transaction_gate_continue_on_error", "repository", "transaction gate must not continue on error");
+    checkActionPin(workflow, blockers);
+}
+function checkControlPlane(provider, input, blockers) {
+    const facts = isObject(input) ? input : {};
+    const targetBranch = typeof facts.targetBranch === "string" && facts.targetBranch.length > 0 ? facts.targetBranch : null;
+    const requiredChecks = stringArray(facts.requiredChecks);
+    if (!targetBranch)
+        add(blockers, "unknown_target_branch", "control_plane", "target branch must be known exactly");
+    if (!requiredChecks)
+        add(blockers, "unknown_required_checks", "control_plane", "required check names must be known and non-empty");
+    if (facts.pullRequestRequired === null || facts.pullRequestRequired === undefined)
+        add(blockers, "unknown_pull_request_requirement", "control_plane", "pull-request requirement is unknown");
+    else if (facts.pullRequestRequired !== true)
+        add(blockers, "pull_request_not_required", "control_plane", "target branch must require pull requests");
+    if (facts.requiredChecksEnforced === null || facts.requiredChecksEnforced === undefined)
+        add(blockers, "unknown_required_checks_enforcement", "control_plane", "required-check enforcement is unknown");
+    else if (facts.requiredChecksEnforced !== true)
+        add(blockers, "required_checks_not_enforced", "control_plane", "required checks must be enforced");
+    if (facts.noBypass === null || facts.noBypass === undefined)
+        add(blockers, "unknown_bypass_state", "control_plane", "effective bypass state is unknown");
+    else if (facts.noBypass !== true)
+        add(blockers, "bypass_enabled", "control_plane", "integration path must not rely on a protection bypass");
+    if (provider === "portable") {
+        if (facts.upToDateRequired === null || facts.upToDateRequired === undefined)
+            add(blockers, "unknown_up_to_date_requirement", "control_plane", "up-to-date branch requirement is unknown");
+        else if (facts.upToDateRequired !== true)
+            add(blockers, "branch_not_required_up_to_date", "control_plane", "portable integration requires up-to-date protection");
+    }
+    else {
+        if (facts.mergeQueueEnabled === null || facts.mergeQueueEnabled === undefined)
+            add(blockers, "unknown_merge_queue_capability", "control_plane", "merge queue capability is unknown");
+        else if (facts.mergeQueueEnabled !== true)
+            add(blockers, "merge_queue_unavailable", "control_plane", "GitHub Merge Queue must be enabled for the selected provider");
+    }
+    return { targetBranch, requiredChecks };
+}
+function checkNative(workflow, blockers) {
+    if (!workflow) {
+        add(blockers, "missing_native_state_gate", "repository", "native merge-group state gate is missing");
+        return;
+    }
+    if (!hasEvent(workflow, "merge_group"))
+        add(blockers, "missing_merge_group_event", "repository", "native state gate must listen to merge_group");
+    if (!hasEventType(workflow, "merge_group", "checks_requested"))
+        add(blockers, "missing_checks_requested", "repository", "merge_group gate must handle checks_requested");
+    if (!hasBlockingMode(workflow, "check-merge-group"))
+        add(blockers, "native_state_not_blocking", "repository", "native state gate must run blocking check-merge-group");
+    if (hasContinueOnError(workflow))
+        add(blockers, "native_state_continue_on_error", "repository", "native state gate must not continue on error");
+    checkActionPin(workflow, blockers);
+}
+function checkPortable(transaction, workflow, blockers) {
+    if (!workflow) {
+        add(blockers, "missing_portable_coordinator", "repository", "portable coordinator workflow is missing");
+        return;
+    }
+    if (workflowPath(transaction) !== null && workflowPath(transaction) === workflowPath(workflow)) {
+        add(blockers, "coordinator_shares_transaction_workflow", "repository", "privileged coordinator must be separated from the PR transaction workflow");
+    }
+    if (!hasBlockingMode(workflow, "portable-coordinator"))
+        add(blockers, "coordinator_not_blocking", "repository", "portable coordinator must use its blocking trusted mode");
+    if (hasContinueOnError(workflow))
+        add(blockers, "coordinator_continue_on_error", "repository", "portable coordinator must not continue on error");
+    if (hasCheckout(workflow))
+        add(blockers, "coordinator_checkout_forbidden", "repository", "privileged coordinator must not checkout repository content");
+    if (hasProjectExecution(workflow))
+        add(blockers, "coordinator_project_execution_forbidden", "repository", "privileged coordinator must not execute project build or test commands");
+    checkActionPin(workflow, blockers);
+}
+export function evaluateParallelReadiness(input) {
+    const blockers = [];
+    const all = workflows(input.integrationFacts);
+    const transaction = all.find((workflow) => workflow.role === "repo_guard_pr_gate");
+    const providerWorkflow = input.provider === "portable"
+        ? all.find((workflow) => workflow.role === "repo_guard_portable_coordinator")
+        : all.find((workflow) => workflow.role === "repo_guard_merge_group_gate");
+    if (!isObject(input.integrationFacts))
+        add(blockers, "invalid_integration_facts", "repository", "integration facts must be an object");
+    else if (array(input.integrationFacts.errors).length > 0)
+        add(blockers, "integration_extraction_failed", "repository", "integration extraction contains errors");
+    checkTransaction(transaction, blockers);
+    if (input.provider === "portable")
+        checkPortable(transaction, providerWorkflow, blockers);
+    else
+        checkNative(providerWorkflow, blockers);
+    const control = checkControlPlane(input.provider, input.controlPlaneFacts, blockers);
+    blockers.sort((left, right) => left.id.localeCompare(right.id));
+    return {
+        provider: input.provider,
+        ready: blockers.length === 0,
+        blockers,
+        evidence: {
+            repository: {
+                transactionWorkflow: workflowPath(transaction),
+                providerWorkflow: workflowPath(providerWorkflow),
+            },
+            control_plane: control,
+        },
+    };
+}

--- a/src/parallel-readiness.mts
+++ b/src/parallel-readiness.mts
@@ -1,0 +1,291 @@
+export type ParallelReadinessProvider = "portable" | "github_merge_queue";
+export type ParallelReadinessSource = "repository" | "control_plane";
+
+interface ActionFact {
+  uses?: unknown;
+}
+
+interface StepInputFact extends ActionFact {
+  inputs?: Record<string, string>;
+}
+
+interface RunCommandFact {
+  run?: unknown;
+}
+
+interface ContinueOnErrorFact {
+  value?: unknown;
+}
+
+interface EventTypeFact {
+  event?: unknown;
+  types?: unknown;
+}
+
+interface WorkflowExpectation {
+  mode?: unknown;
+  enforcement?: unknown;
+}
+
+interface WorkflowFact {
+  path?: unknown;
+  role?: unknown;
+  expect?: WorkflowExpectation;
+  triggerEvents?: unknown;
+  triggerEventTypes?: unknown;
+  actionUses?: unknown;
+  stepInputs?: unknown;
+  runCommands?: unknown;
+  continueOnError?: unknown;
+}
+
+interface IntegrationFactsInput {
+  workflows?: unknown;
+  errors?: unknown;
+}
+
+export interface ParallelControlPlaneFacts {
+  targetBranch?: unknown;
+  requiredChecks?: unknown;
+  pullRequestRequired?: unknown;
+  requiredChecksEnforced?: unknown;
+  upToDateRequired?: unknown;
+  noBypass?: unknown;
+  mergeQueueEnabled?: unknown;
+}
+
+export interface ParallelReadinessInput {
+  provider: ParallelReadinessProvider;
+  integrationFacts: unknown;
+  controlPlaneFacts: unknown;
+}
+
+export interface ParallelReadinessBlocker {
+  id: string;
+  source: ParallelReadinessSource;
+  message: string;
+  hint?: string;
+}
+
+export interface ParallelReadinessReport {
+  provider: ParallelReadinessProvider;
+  ready: boolean;
+  blockers: ParallelReadinessBlocker[];
+  evidence: {
+    repository: {
+      transactionWorkflow: string | null;
+      providerWorkflow: string | null;
+    };
+    control_plane: {
+      targetBranch: string | null;
+      requiredChecks: string[] | null;
+    };
+  };
+}
+
+const SHA = /^[0-9a-f]{40}$/i;
+const REPO_GUARD = /(?:^|\/)repo-guard(?:@|$)/i;
+const PROJECT_EXECUTION = /(?:^|\s)(?:npm|pnpm|yarn|bun)\s+(?:ci|install|test|run\s+build|build)|(?:^|\s)(?:make|mvn|gradle|cargo)\s+(?:test|build|check)(?:\s|$)/im;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.some((item) => typeof item !== "string" || item.length === 0)) return null;
+  return [...new Set(value as string[])].sort();
+}
+
+function truthy(value: unknown): boolean {
+  return ![undefined, null, false, 0, "", "false", "0", "null"].includes(value as never);
+}
+
+function workflows(input: unknown): WorkflowFact[] {
+  if (!isObject(input)) return [];
+  const integration = input as IntegrationFactsInput;
+  return array(integration.workflows).filter(isObject) as WorkflowFact[];
+}
+
+function workflowPath(workflow: WorkflowFact | undefined): string | null {
+  return typeof workflow?.path === "string" && workflow.path.length > 0 ? workflow.path : null;
+}
+
+function hasEvent(workflow: WorkflowFact, event: string): boolean {
+  return array(workflow.triggerEvents).includes(event);
+}
+
+function hasEventType(workflow: WorkflowFact, event: string, type: string): boolean {
+  return array(workflow.triggerEventTypes).some((fact) => {
+    if (!isObject(fact)) return false;
+    const typed = fact as EventTypeFact;
+    return typed.event === event && array(typed.types).includes(type);
+  });
+}
+
+function repoGuardActions(workflow: WorkflowFact): string[] {
+  return array(workflow.actionUses)
+    .filter(isObject)
+    .map((fact) => (fact as ActionFact).uses)
+    .filter((uses): uses is string => typeof uses === "string" && (uses === "./" || uses.startsWith("./") || REPO_GUARD.test(uses)));
+}
+
+function externalActionIsImmutable(uses: string): boolean {
+  if (uses === "./" || uses.startsWith("./")) return true;
+  const at = uses.lastIndexOf("@");
+  return at > 0 && SHA.test(uses.slice(at + 1));
+}
+
+function hasBlockingMode(workflow: WorkflowFact, mode: string): boolean {
+  const expected = workflow.expect;
+  if (expected?.mode !== mode || expected?.enforcement !== "blocking") return false;
+  return array(workflow.stepInputs).filter(isObject).some((fact) => {
+    const inputs = (fact as StepInputFact).inputs;
+    return inputs?.mode === mode && inputs?.enforcement === "blocking";
+  });
+}
+
+function hasContinueOnError(workflow: WorkflowFact): boolean {
+  return array(workflow.continueOnError).filter(isObject).some((fact) => truthy((fact as ContinueOnErrorFact).value));
+}
+
+function hasCheckout(workflow: WorkflowFact): boolean {
+  return array(workflow.actionUses).filter(isObject).some((fact) => {
+    const uses = (fact as ActionFact).uses;
+    return typeof uses === "string" && uses.toLowerCase().startsWith("actions/checkout@");
+  });
+}
+
+function hasProjectExecution(workflow: WorkflowFact): boolean {
+  return array(workflow.runCommands).filter(isObject).some((fact) => PROJECT_EXECUTION.test(String((fact as RunCommandFact).run ?? "")));
+}
+
+function add(
+  blockers: ParallelReadinessBlocker[],
+  id: string,
+  source: ParallelReadinessSource,
+  message: string,
+  hint?: string,
+): void {
+  if (blockers.some((item) => item.id === id)) return;
+  blockers.push({ id, source, message, ...(hint === undefined ? {} : { hint }) });
+}
+
+function checkActionPin(workflow: WorkflowFact, blockers: ParallelReadinessBlocker[]): void {
+  const actions = repoGuardActions(workflow);
+  if (actions.length === 0) {
+    add(blockers, "missing_repo_guard_action", "repository", "workflow has no repo-guard Action invocation");
+    return;
+  }
+  if (actions.some((uses) => !externalActionIsImmutable(uses))) {
+    add(blockers, "mutable_action_ref", "repository", "external repo-guard Action ref must be an exact commit SHA");
+  }
+}
+
+function checkTransaction(workflow: WorkflowFact | undefined, blockers: ParallelReadinessBlocker[]): void {
+  if (!workflow) {
+    add(blockers, "missing_transaction_gate", "repository", "blocking pull-request transaction gate is missing");
+    return;
+  }
+  if (!hasEvent(workflow, "pull_request")) add(blockers, "missing_pull_request_event", "repository", "transaction gate must listen to pull_request");
+  if (!hasBlockingMode(workflow, "check-pr")) add(blockers, "transaction_gate_not_blocking", "repository", "transaction gate must run blocking check-pr");
+  if (hasContinueOnError(workflow)) add(blockers, "transaction_gate_continue_on_error", "repository", "transaction gate must not continue on error");
+  checkActionPin(workflow, blockers);
+}
+
+function checkControlPlane(
+  provider: ParallelReadinessProvider,
+  input: unknown,
+  blockers: ParallelReadinessBlocker[],
+): { targetBranch: string | null; requiredChecks: string[] | null } {
+  const facts = isObject(input) ? input as ParallelControlPlaneFacts : {};
+  const targetBranch = typeof facts.targetBranch === "string" && facts.targetBranch.length > 0 ? facts.targetBranch : null;
+  const requiredChecks = stringArray(facts.requiredChecks);
+
+  if (!targetBranch) add(blockers, "unknown_target_branch", "control_plane", "target branch must be known exactly");
+  if (!requiredChecks) add(blockers, "unknown_required_checks", "control_plane", "required check names must be known and non-empty");
+
+  if (facts.pullRequestRequired === null || facts.pullRequestRequired === undefined) add(blockers, "unknown_pull_request_requirement", "control_plane", "pull-request requirement is unknown");
+  else if (facts.pullRequestRequired !== true) add(blockers, "pull_request_not_required", "control_plane", "target branch must require pull requests");
+
+  if (facts.requiredChecksEnforced === null || facts.requiredChecksEnforced === undefined) add(blockers, "unknown_required_checks_enforcement", "control_plane", "required-check enforcement is unknown");
+  else if (facts.requiredChecksEnforced !== true) add(blockers, "required_checks_not_enforced", "control_plane", "required checks must be enforced");
+
+  if (facts.noBypass === null || facts.noBypass === undefined) add(blockers, "unknown_bypass_state", "control_plane", "effective bypass state is unknown");
+  else if (facts.noBypass !== true) add(blockers, "bypass_enabled", "control_plane", "integration path must not rely on a protection bypass");
+
+  if (provider === "portable") {
+    if (facts.upToDateRequired === null || facts.upToDateRequired === undefined) add(blockers, "unknown_up_to_date_requirement", "control_plane", "up-to-date branch requirement is unknown");
+    else if (facts.upToDateRequired !== true) add(blockers, "branch_not_required_up_to_date", "control_plane", "portable integration requires up-to-date protection");
+  } else {
+    if (facts.mergeQueueEnabled === null || facts.mergeQueueEnabled === undefined) add(blockers, "unknown_merge_queue_capability", "control_plane", "merge queue capability is unknown");
+    else if (facts.mergeQueueEnabled !== true) add(blockers, "merge_queue_unavailable", "control_plane", "GitHub Merge Queue must be enabled for the selected provider");
+  }
+
+  return { targetBranch, requiredChecks };
+}
+
+function checkNative(workflow: WorkflowFact | undefined, blockers: ParallelReadinessBlocker[]): void {
+  if (!workflow) {
+    add(blockers, "missing_native_state_gate", "repository", "native merge-group state gate is missing");
+    return;
+  }
+  if (!hasEvent(workflow, "merge_group")) add(blockers, "missing_merge_group_event", "repository", "native state gate must listen to merge_group");
+  if (!hasEventType(workflow, "merge_group", "checks_requested")) add(blockers, "missing_checks_requested", "repository", "merge_group gate must handle checks_requested");
+  if (!hasBlockingMode(workflow, "check-merge-group")) add(blockers, "native_state_not_blocking", "repository", "native state gate must run blocking check-merge-group");
+  if (hasContinueOnError(workflow)) add(blockers, "native_state_continue_on_error", "repository", "native state gate must not continue on error");
+  checkActionPin(workflow, blockers);
+}
+
+function checkPortable(
+  transaction: WorkflowFact | undefined,
+  workflow: WorkflowFact | undefined,
+  blockers: ParallelReadinessBlocker[],
+): void {
+  if (!workflow) {
+    add(blockers, "missing_portable_coordinator", "repository", "portable coordinator workflow is missing");
+    return;
+  }
+  if (workflowPath(transaction) !== null && workflowPath(transaction) === workflowPath(workflow)) {
+    add(blockers, "coordinator_shares_transaction_workflow", "repository", "privileged coordinator must be separated from the PR transaction workflow");
+  }
+  if (!hasBlockingMode(workflow, "portable-coordinator")) add(blockers, "coordinator_not_blocking", "repository", "portable coordinator must use its blocking trusted mode");
+  if (hasContinueOnError(workflow)) add(blockers, "coordinator_continue_on_error", "repository", "portable coordinator must not continue on error");
+  if (hasCheckout(workflow)) add(blockers, "coordinator_checkout_forbidden", "repository", "privileged coordinator must not checkout repository content");
+  if (hasProjectExecution(workflow)) add(blockers, "coordinator_project_execution_forbidden", "repository", "privileged coordinator must not execute project build or test commands");
+  checkActionPin(workflow, blockers);
+}
+
+export function evaluateParallelReadiness(input: ParallelReadinessInput): ParallelReadinessReport {
+  const blockers: ParallelReadinessBlocker[] = [];
+  const all = workflows(input.integrationFacts);
+  const transaction = all.find((workflow) => workflow.role === "repo_guard_pr_gate");
+  const providerWorkflow = input.provider === "portable"
+    ? all.find((workflow) => workflow.role === "repo_guard_portable_coordinator")
+    : all.find((workflow) => workflow.role === "repo_guard_merge_group_gate");
+
+  if (!isObject(input.integrationFacts)) add(blockers, "invalid_integration_facts", "repository", "integration facts must be an object");
+  else if (array((input.integrationFacts as IntegrationFactsInput).errors).length > 0) add(blockers, "integration_extraction_failed", "repository", "integration extraction contains errors");
+
+  checkTransaction(transaction, blockers);
+  if (input.provider === "portable") checkPortable(transaction, providerWorkflow, blockers);
+  else checkNative(providerWorkflow, blockers);
+  const control = checkControlPlane(input.provider, input.controlPlaneFacts, blockers);
+
+  blockers.sort((left, right) => left.id.localeCompare(right.id));
+  return {
+    provider: input.provider,
+    ready: blockers.length === 0,
+    blockers,
+    evidence: {
+      repository: {
+        transactionWorkflow: workflowPath(transaction),
+        providerWorkflow: workflowPath(providerWorkflow),
+      },
+      control_plane: control,
+    },
+  };
+}

--- a/tests/test-parallel-readiness.mjs
+++ b/tests/test-parallel-readiness.mjs
@@ -1,0 +1,179 @@
+import { strict as assert } from "node:assert";
+import { extractIntegration } from "../dist/extractors/integration.mjs";
+import { evaluateParallelReadiness } from "../dist/parallel-readiness.mjs";
+
+const immutableSha = "0123456789abcdef0123456789abcdef01234567";
+
+function readFixture(files) {
+  return (path) => {
+    if (!Object.hasOwn(files, path)) throw new Error(`missing fixture ${path}`);
+    return files[path];
+  };
+}
+
+function workflow(id, path, role, mode, events, extra = {}) {
+  return {
+    id,
+    kind: "github_actions",
+    path,
+    role,
+    expect: {
+      events,
+      action: { uses: "netkeep80/repo-guard", ref_pinning: "sha" },
+      mode,
+      enforcement: "blocking",
+      ...extra,
+    },
+  };
+}
+
+function transactionYaml(ref = immutableSha) {
+  return [
+    "name: transaction", "on:", "  pull_request:", "    types: [opened, synchronize, reopened, ready_for_review]",
+    "permissions:", "  contents: read", "  pull-requests: read", "jobs:", "  validate:", "    runs-on: ubuntu-latest", "    steps:",
+    "      - uses: actions/checkout@v6", "        with:", "          fetch-depth: 0",
+    `      - uses: netkeep80/repo-guard@${ref}`, "        with:", "          mode: check-pr", "          enforcement: blocking", "",
+  ].join("\n");
+}
+
+function nativeYaml({ mergeGroup = true, checksRequested = true } = {}) {
+  return [
+    "name: state", "on:",
+    ...(mergeGroup ? ["  merge_group:", ...(checksRequested ? ["    types: [checks_requested]"] : [])] : ["  pull_request:"]),
+    "permissions:", "  contents: read", "jobs:", "  validate:", "    runs-on: ubuntu-latest", "    steps:",
+    "      - uses: actions/checkout@v6", "        with:", "          fetch-depth: 0",
+    `      - uses: netkeep80/repo-guard@${immutableSha}`, "        with:", "          mode: check-merge-group", "          enforcement: blocking", "",
+  ].join("\n");
+}
+
+function portableYaml({ checkout = false, unsafeRun = false } = {}) {
+  return [
+    "name: coordinator", "on:", "  workflow_dispatch:", "permissions:", "  contents: write", "  pull-requests: write", "jobs:",
+    "  integrate:", "    runs-on: ubuntu-latest", "    steps:",
+    ...(checkout ? ["      - uses: actions/checkout@v6"] : []),
+    `      - uses: netkeep80/repo-guard@${immutableSha}`, "        with:", "          mode: portable-coordinator", "          enforcement: blocking",
+    ...(unsafeRun ? ["      - run: npm test"] : []), "",
+  ].join("\n");
+}
+
+function integration(provider, options = {}) {
+  const transaction = workflow("transaction", ".github/workflows/transaction.yml", "repo_guard_pr_gate", "check-pr", ["pull_request"]);
+  const selected = provider === "github_merge_queue"
+    ? workflow("state", ".github/workflows/state.yml", "repo_guard_merge_group_gate", "check-merge-group", ["merge_group"], { event_types: ["checks_requested"] })
+    : workflow("coordinator", ".github/workflows/coordinator.yml", "repo_guard_portable_coordinator", "portable-coordinator", ["workflow_dispatch"]);
+  const policy = { integration: { workflows: [transaction, selected] } };
+  const files = {
+    ".github/workflows/transaction.yml": transactionYaml(options.mutableAction ? "main" : immutableSha),
+    ...(provider === "github_merge_queue"
+      ? { ".github/workflows/state.yml": nativeYaml(options) }
+      : { ".github/workflows/coordinator.yml": portableYaml(options) }),
+  };
+  return extractIntegration(policy, {
+    repoRoot: "/tmp/repo",
+    trackedFiles: Object.keys(files),
+    readFile: readFixture(files),
+  });
+}
+
+const commonControl = {
+  targetBranch: "main",
+  requiredChecks: ["CI / validate", "CI / smoke-pack"],
+  pullRequestRequired: true,
+  requiredChecksEnforced: true,
+  noBypass: true,
+};
+
+function ids(report) {
+  return report.blockers.map((item) => item.id);
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "github_merge_queue",
+    integrationFacts: integration("github_merge_queue"),
+    controlPlaneFacts: { ...commonControl, mergeQueueEnabled: true },
+  });
+  assert.equal(report.provider, "github_merge_queue");
+  assert.equal(report.ready, true);
+  assert.deepEqual(report.blockers, []);
+  assert.equal(report.evidence.repository.transactionWorkflow, ".github/workflows/transaction.yml");
+  assert.equal(report.evidence.repository.providerWorkflow, ".github/workflows/state.yml");
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "github_merge_queue",
+    integrationFacts: integration("github_merge_queue", { mergeGroup: false }),
+    controlPlaneFacts: { ...commonControl, mergeQueueEnabled: true },
+  });
+  assert.ok(ids(report).includes("missing_merge_group_event"));
+  assert.equal(report.ready, false);
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "github_merge_queue",
+    integrationFacts: integration("github_merge_queue", { checksRequested: false }),
+    controlPlaneFacts: { ...commonControl, mergeQueueEnabled: true },
+  });
+  assert.ok(ids(report).includes("missing_checks_requested"));
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "portable",
+    integrationFacts: integration("portable"),
+    controlPlaneFacts: { ...commonControl, upToDateRequired: true },
+  });
+  assert.equal(report.ready, true);
+  assert.deepEqual(report.blockers, []);
+  assert.equal(report.evidence.repository.providerWorkflow, ".github/workflows/coordinator.yml");
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "portable",
+    integrationFacts: integration("portable", { checkout: true }),
+    controlPlaneFacts: { ...commonControl, upToDateRequired: true },
+  });
+  assert.ok(ids(report).includes("coordinator_checkout_forbidden"));
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "portable",
+    integrationFacts: integration("portable", { unsafeRun: true }),
+    controlPlaneFacts: { ...commonControl, upToDateRequired: true },
+  });
+  assert.ok(ids(report).includes("coordinator_project_execution_forbidden"));
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "portable",
+    integrationFacts: integration("portable", { mutableAction: true }),
+    controlPlaneFacts: { ...commonControl, upToDateRequired: true },
+  });
+  assert.ok(ids(report).includes("mutable_action_ref"));
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "portable",
+    integrationFacts: integration("portable"),
+    controlPlaneFacts: { ...commonControl, upToDateRequired: null },
+  });
+  assert.ok(ids(report).includes("unknown_up_to_date_requirement"));
+  assert.equal(report.ready, false);
+}
+
+{
+  const report = evaluateParallelReadiness({
+    provider: "github_merge_queue",
+    integrationFacts: integration("portable"),
+    controlPlaneFacts: { ...commonControl, mergeQueueEnabled: true },
+  });
+  assert.ok(ids(report).includes("missing_native_state_gate"));
+}
+
+console.log("All parallel readiness tests passed");


### PR DESCRIPTION
## Краткое описание

Implements the bounded pure-readiness core of #325. It reuses the existing integration extractor facts and adds no GitHub I/O, provider enablement, workflow generation, doctor CLI wiring, schema migration, or coordinator mutation surface. Public integration DSL/schema wiring remains for the next #309 slice.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/parallel-readiness.mts
  - dist/parallel-readiness.mjs
  - tests/test-parallel-readiness.mjs
budgets:
  max_new_docs: 0
  max_new_files: 3
  max_net_added_lines: 1000
anchors:
  affects:
    - "#304"
    - "#309"
    - "#325"
  implements:
    - "#325"
  verifies:
    - "pure provider readiness projection over existing integration facts"
must_touch:
  - tests/**
must_not_touch:
  - .github/**
  - repo-policy.json
  - schemas/**
  - action.yml
  - src/extractors/integration.mts
  - src/checks/**
  - src/doctor.mts
  - src/init.mts
  - src/github-merge-group.mts
  - src/portable-integration/**
expected_effects:
  - Existing integration extraction remains the sole workflow parsing boundary.
  - Pure readiness evaluates portable and GitHub Merge Queue repository facts plus normalized control-plane facts.
  - Unknown required control-plane facts fail closed with finite blocker ids.
  - Portable readiness rejects privileged checkout and project execution.
  - Native readiness requires merge_group checks_requested and check-merge-group evidence.
  - Existing v2 commands, policy schema, workflows, and provider enablement remain unchanged.
```

## TDD

First RED commit: `55189059defa9748e58a03bc2159e00d638b6cc2` adds the behavioral contract before `dist/parallel-readiness.mjs` exists.

Refs #304, #309, #325.