### PR TITLE
[Parallel P4a-b] Publish parallel integration DSL and repository constraints

### DIFF
--- a/dist/checks/integration-constraints.mjs
+++ b/dist/checks/integration-constraints.mjs
@@ -1,4 +1,5 @@
 import { compareSets } from "./relation-kernel.mjs";
+import { evaluateParallelReadiness } from "../parallel-readiness.mjs";
 import { matchesAny } from "../utils/path-patterns.mjs";
 const object = (value) => value && typeof value === "object" && !Array.isArray(value) ? value : {};
 const array = (value) => Array.isArray(value) ? value : [];
@@ -138,6 +139,17 @@ function workflowDetails(workflow) {
                 details.push(detail(workflow, fact, "repo_guard_pr_gate workflow must not run repo-guard directly from a temporary clone"));
     return details;
 }
+function parallelReadinessDetails(integration) {
+    const providerRoles = [
+        ["github_merge_queue", "repo_guard_merge_group_gate"],
+        ["portable", "repo_guard_portable_coordinator"],
+    ];
+    return providerRoles.flatMap(([provider, role]) => array(integration.workflows).some((workflow) => workflow.role === role)
+        ? evaluateParallelReadiness({ provider, integrationFacts: integration, controlPlaneFacts: {} }).blockers
+            .filter((blocker) => blocker.source === "repository")
+            .map((blocker) => `${provider} [${blocker.id}]: ${blocker.message}`)
+        : []);
+}
 export function checkWorkflowPathCoverage(integration, binding, referencedPaths) {
     const workflow = array(integration.workflows).find((item) => item.id === binding.workflow);
     if (!workflow)
@@ -165,7 +177,7 @@ function templateDetails(template) {
 function missingMentions(doc, facts, label) { return (facts || []).filter((mention) => !mention.present).map((mention) => `${doc.path}: missing required ${label} "${mention.term}"`); }
 export function integrationConstraintEntries(integration = {}) {
     const artifacts = array(integration.errors).map((error) => `${error.section}${error.id ? `:${error.id}` : ""}${error.path ? ` (${error.path})` : ""}: ${error.message}`);
-    const workflows = array(integration.workflows).flatMap(workflowDetails);
+    const workflows = [...array(integration.workflows).flatMap(workflowDetails), ...parallelReadinessDetails(integration)];
     const templates = array(integration.templates).flatMap(templateDetails);
     const docs = array(integration.docs).flatMap((doc) => [...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"), ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention")]);
     const profiles = array(integration.profiles).flatMap((profile) => profile.profileNameReferences?.length ? [] : [`${profile.docPath}: profile "${profile.id}" is not mentioned`]);

--- a/dist/parallel-readiness.mjs
+++ b/dist/parallel-readiness.mjs
@@ -170,10 +170,14 @@ export function evaluateParallelReadiness(input) {
     const providerWorkflow = input.provider === "portable"
         ? all.find((workflow) => workflow.role === "repo_guard_portable_coordinator")
         : all.find((workflow) => workflow.role === "repo_guard_merge_group_gate");
+    const hasNativeProvider = all.some((workflow) => workflow.role === "repo_guard_merge_group_gate");
+    const hasPortableProvider = all.some((workflow) => workflow.role === "repo_guard_portable_coordinator");
     if (!isObject(input.integrationFacts))
         add(blockers, "invalid_integration_facts", "repository", "integration facts must be an object");
     else if (array(input.integrationFacts.errors).length > 0)
         add(blockers, "integration_extraction_failed", "repository", "integration extraction contains errors");
+    if (hasNativeProvider && hasPortableProvider)
+        add(blockers, "provider_role_conflict", "repository", "parallel provider roles must not declare both native merge-group gate and portable coordinator");
     checkTransaction(transaction, blockers);
     if (input.provider === "portable")
         checkPortable(transaction, providerWorkflow, blockers);

--- a/schemas/repo-policy.schema.json
+++ b/schemas/repo-policy.schema.json
@@ -678,7 +678,7 @@
         "path": { "$ref": "#/definitions/non_empty_string" },
         "role": {
           "type": "string",
-          "enum": ["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate", "ci_gate"],
+          "enum": ["repo_guard_advisory", "repo_guard_policy_validation", "repo_guard_pr_gate", "repo_guard_merge_group_gate", "repo_guard_portable_coordinator", "ci_gate"],
           "description": "Supported integration role for this workflow."
         },
         "expect": { "$ref": "#/definitions/integration_workflow_expectation" },
@@ -695,7 +695,7 @@
         "action": { "$ref": "#/definitions/integration_workflow_action_expectation" },
         "mode": {
           "type": "string",
-          "enum": ["check-pr", "check-diff"]
+          "enum": ["check-pr", "check-diff", "check-merge-group", "portable-coordinator"]
         },
         "enforcement": {
           "type": "string",

--- a/src/checks/integration-constraints.mts
+++ b/src/checks/integration-constraints.mts
@@ -1,4 +1,5 @@
 import { compareSets } from "./relation-kernel.mjs";
+import { evaluateParallelReadiness } from "../parallel-readiness.mjs";
 import { matchesAny } from "../utils/path-patterns.mjs";
 
 type RefPinning = "any" | "local" | "sha" | "semver" | "tag" | "ref" | string;
@@ -189,6 +190,18 @@ function workflowDetails(workflow: WorkflowFact): string[] {
   return details;
 }
 
+function parallelReadinessDetails(integration: IntegrationFacts): string[] {
+  const providerRoles = [
+    ["github_merge_queue", "repo_guard_merge_group_gate"],
+    ["portable", "repo_guard_portable_coordinator"],
+  ] as const;
+  return providerRoles.flatMap(([provider, role]) => array(integration.workflows).some((workflow) => workflow.role === role)
+    ? evaluateParallelReadiness({ provider, integrationFacts: integration, controlPlaneFacts: {} }).blockers
+      .filter((blocker) => blocker.source === "repository")
+      .map((blocker) => `${provider} [${blocker.id}]: ${blocker.message}`)
+    : []);
+}
+
 export function checkWorkflowPathCoverage(integration: IntegrationFacts, binding: WorkflowPathCoverageBinding, referencedPaths: string[]) {
   const workflow = array(integration.workflows).find((item) => item.id === binding.workflow);
   if (!workflow) return { ok: false, message: `evidence workflow "${binding.workflow}" is unavailable in extracted integration facts`, data: { workflow: binding.workflow, covers: binding.covers, referenced_paths: referencedPaths, uncovered_paths: referencedPaths } };
@@ -211,7 +224,7 @@ function missingMentions(doc: DocFact, facts: MentionFact[] | undefined, label: 
 
 export function integrationConstraintEntries(integration: IntegrationFacts = {}): IntegrationCheckEntry[] {
   const artifacts = array(integration.errors).map((error) => `${error.section}${error.id ? `:${error.id}` : ""}${error.path ? ` (${error.path})` : ""}: ${error.message}`);
-  const workflows = array(integration.workflows).flatMap(workflowDetails);
+  const workflows = [...array(integration.workflows).flatMap(workflowDetails), ...parallelReadinessDetails(integration)];
   const templates = array(integration.templates).flatMap(templateDetails);
   const docs = array(integration.docs).flatMap((doc) => [...missingMentions(doc, doc.mentions, "mention"), ...missingMentions(doc, doc.fileReferences, "file reference"), ...missingMentions(doc, doc.profileMentions, "profile mention"), ...missingMentions(doc, doc.changeIntentFieldMentions, "ChangeIntent field mention")]);
   const profiles = array(integration.profiles).flatMap((profile) => profile.profileNameReferences?.length ? [] : [`${profile.docPath}: profile "${profile.id}" is not mentioned`]);

--- a/src/parallel-readiness.mts
+++ b/src/parallel-readiness.mts
@@ -117,7 +117,6 @@ function workflowPath(workflow: WorkflowFact | undefined): string | null {
 function hasEvent(workflow: WorkflowFact, event: string): boolean {
   return array(workflow.triggerEvents).includes(event);
 }
-
 function hasEventType(workflow: WorkflowFact, event: string, type: string): boolean {
   return array(workflow.triggerEventTypes).some((fact) => {
     if (!isObject(fact)) return false;
@@ -266,9 +265,12 @@ export function evaluateParallelReadiness(input: ParallelReadinessInput): Parall
   const providerWorkflow = input.provider === "portable"
     ? all.find((workflow) => workflow.role === "repo_guard_portable_coordinator")
     : all.find((workflow) => workflow.role === "repo_guard_merge_group_gate");
+  const hasNativeProvider = all.some((workflow) => workflow.role === "repo_guard_merge_group_gate");
+  const hasPortableProvider = all.some((workflow) => workflow.role === "repo_guard_portable_coordinator");
 
   if (!isObject(input.integrationFacts)) add(blockers, "invalid_integration_facts", "repository", "integration facts must be an object");
   else if (array((input.integrationFacts as IntegrationFactsInput).errors).length > 0) add(blockers, "integration_extraction_failed", "repository", "integration extraction contains errors");
+  if (hasNativeProvider && hasPortableProvider) add(blockers, "provider_role_conflict", "repository", "parallel provider roles must not declare both native merge-group gate and portable coordinator");
 
   checkTransaction(transaction, blockers);
   if (input.provider === "portable") checkPortable(transaction, providerWorkflow, blockers);

--- a/tests/test-parallel-readiness.mjs
+++ b/tests/test-parallel-readiness.mjs
@@ -1,8 +1,16 @@
 import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Ajv from "ajv";
+import { integrationConstraintEntries } from "../dist/checks/integration-constraints.mjs";
 import { extractIntegration } from "../dist/extractors/integration.mjs";
 import { evaluateParallelReadiness } from "../dist/parallel-readiness.mjs";
 
 const immutableSha = "0123456789abcdef0123456789abcdef01234567";
+const projectRoot = resolve(new URL("..", import.meta.url).pathname);
+const schema = JSON.parse(readFileSync(resolve(projectRoot, "schemas/repo-policy.schema.json"), "utf-8"));
+const validPolicy = JSON.parse(readFileSync(resolve(projectRoot, "tests/fixtures/valid-policy.json"), "utf-8"));
+const validatePolicy = new Ajv({ allErrors: true }).compile(schema);
 
 function readFixture(files) {
   return (path) => {
@@ -32,7 +40,8 @@ function transactionYaml(ref = immutableSha) {
     "name: transaction", "on:", "  pull_request:", "    types: [opened, synchronize, reopened, ready_for_review]",
     "permissions:", "  contents: read", "  pull-requests: read", "jobs:", "  validate:", "    runs-on: ubuntu-latest", "    steps:",
     "      - uses: actions/checkout@v6", "        with:", "          fetch-depth: 0",
-    `      - uses: netkeep80/repo-guard@${ref}`, "        with:", "          mode: check-pr", "          enforcement: blocking", "",
+    `      - uses: netkeep80/repo-guard@${ref}`, "        with:", "          mode: check-pr", "          enforcement: blocking",
+    "        env:", "          GH_TOKEN: ${{ github.token }}", "",
   ].join("\n");
 }
 
@@ -73,6 +82,31 @@ function integration(provider, options = {}) {
     trackedFiles: Object.keys(files),
     readFile: readFixture(files),
   });
+}
+
+function parallelPolicy(role, mode) {
+  return {
+    ...validPolicy,
+    integration: {
+      workflows: [{
+        id: "parallel-gate",
+        kind: "github_actions",
+        path: ".github/workflows/parallel.yml",
+        role,
+        expect: { mode },
+      }],
+    },
+  };
+}
+
+function workflowConstraint(provider, options = {}) {
+  const entry = integrationConstraintEntries(integration(provider, options)).find((item) => item.name === "integration-workflows");
+  assert.ok(entry, "integration-workflows constraint entry must exist");
+  return entry.check;
+}
+
+function constraintDetails(check) {
+  return Array.isArray(check.details) ? check.details : [];
 }
 
 const commonControl = {
@@ -174,6 +208,36 @@ function ids(report) {
     controlPlaneFacts: { ...commonControl, mergeQueueEnabled: true },
   });
   assert.ok(ids(report).includes("missing_native_state_gate"));
+}
+
+for (const [role, mode] of [
+  ["repo_guard_merge_group_gate", "check-merge-group"],
+  ["repo_guard_portable_coordinator", "portable-coordinator"],
+]) {
+  const ok = validatePolicy(parallelPolicy(role, mode));
+  assert.equal(ok, true, `${role}/${mode} must be public schema-valid: ${JSON.stringify(validatePolicy.errors)}`);
+}
+
+{
+  const check = workflowConstraint("github_merge_queue");
+  assert.equal(check.ok, true, `native repository facts must satisfy integration constraints: ${JSON.stringify(check.details)}`);
+}
+
+{
+  const check = workflowConstraint("github_merge_queue", { mergeGroup: false });
+  assert.equal(check.ok, false);
+  assert.ok(constraintDetails(check).some((detail) => detail.includes("missing_merge_group_event")), "native repository blocker id must be surfaced by the Constraint Program");
+}
+
+{
+  const check = workflowConstraint("portable");
+  assert.equal(check.ok, true, `portable repository facts must satisfy integration constraints: ${JSON.stringify(check.details)}`);
+}
+
+{
+  const check = workflowConstraint("portable", { unsafeRun: true });
+  assert.equal(check.ok, false);
+  assert.ok(constraintDetails(check).some((detail) => detail.includes("coordinator_project_execution_forbidden")), "portable repository blocker id must be surfaced by the Constraint Program");
 }
 
 console.log("All parallel readiness tests passed");

--- a/tests/test-parallel-readiness.mjs
+++ b/tests/test-parallel-readiness.mjs
@@ -84,6 +84,23 @@ function integration(provider, options = {}) {
   });
 }
 
+function mixedIntegration() {
+  const transaction = workflow("transaction", ".github/workflows/transaction.yml", "repo_guard_pr_gate", "check-pr", ["pull_request"]);
+  const state = workflow("state", ".github/workflows/state.yml", "repo_guard_merge_group_gate", "check-merge-group", ["merge_group"], { event_types: ["checks_requested"] });
+  const coordinator = workflow("coordinator", ".github/workflows/coordinator.yml", "repo_guard_portable_coordinator", "portable-coordinator", ["workflow_dispatch"]);
+  const policy = { integration: { workflows: [transaction, state, coordinator] } };
+  const files = {
+    ".github/workflows/transaction.yml": transactionYaml(),
+    ".github/workflows/state.yml": nativeYaml(),
+    ".github/workflows/coordinator.yml": portableYaml(),
+  };
+  return extractIntegration(policy, {
+    repoRoot: "/tmp/repo",
+    trackedFiles: Object.keys(files),
+    readFile: readFixture(files),
+  });
+}
+
 function parallelPolicy(role, mode) {
   return {
     ...validPolicy,
@@ -238,6 +255,12 @@ for (const [role, mode] of [
   const check = workflowConstraint("portable", { unsafeRun: true });
   assert.equal(check.ok, false);
   assert.ok(constraintDetails(check).some((detail) => detail.includes("coordinator_project_execution_forbidden")), "portable repository blocker id must be surfaced by the Constraint Program");
+}
+
+{
+  const check = integrationConstraintEntries(mixedIntegration()).find((item) => item.name === "integration-workflows")?.check;
+  assert.equal(check?.ok, false);
+  assert.ok(constraintDetails(check).some((detail) => detail.includes("provider_role_conflict")), "declaring both parallel provider roles must fail closed");
 }
 
 console.log("All parallel readiness tests passed");


### PR DESCRIPTION
## Краткое описание

Публикует additive integration DSL для parallel providers и проводит repository-controlled readiness через существующий Constraint Program без второго YAML parser и без GitHub control-plane I/O.

Resolves #325

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - schemas/repo-policy.schema.json
  - src/checks/integration-constraints.mts
  - dist/checks/integration-constraints.mjs
  - src/parallel-readiness.mts
  - dist/parallel-readiness.mjs
  - tests/test-parallel-readiness.mjs
budgets: {}
anchors:
  affects:
    - "#325"
  implements: []
  verifies: []
must_touch:
  - tests/test-parallel-readiness.mjs
must_not_touch:
  - src/doctor.mts
  - src/portable-integration/**
  - .github/workflows/**
expected_effects:
  - Новые parallel workflow roles и modes становятся публично schema-valid.
  - Constraint Program переиспользует canonical readiness evaluator только для repository blockers.
  - Одновременное объявление native и portable provider roles fail-closed через canonical readiness evaluator.
  - External control-plane readiness остаётся за пределами этого PR.
```