### PR TITLE
[Parallel P4b2] Add read-only parallel doctor control plane

### DIFF
--- a/dist/github-control-plane.mjs
+++ b/dist/github-control-plane.mjs
@@ -1,0 +1,163 @@
+import { execFileSync } from "node:child_process";
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const PARALLEL_RULE_TYPES = new Set(["pull_request", "required_status_checks", "merge_queue"]);
+function fail(error, message) {
+    return { ok: false, error, message };
+}
+function isRecord(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function defaultRun(command, args, options = {}) {
+    return execFileSync(command, args, {
+        cwd: options.cwd,
+        encoding: "utf-8",
+        stdio: "pipe",
+        timeout: 30000,
+    });
+}
+function errorText(error) {
+    if (!isRecord(error))
+        return String(error);
+    const stderr = typeof error.stderr === "string" ? error.stderr.trim() : "";
+    const message = typeof error.message === "string" ? error.message.trim() : "";
+    return [stderr, message].filter(Boolean).join("\n") || "unknown command failure";
+}
+function parseJson(text, label) {
+    try {
+        return { ok: true, value: JSON.parse(text) };
+    }
+    catch (error) {
+        return fail("malformed_github_response", `${label}: ${error.message}`);
+    }
+}
+function repositoryFromRemote(remote) {
+    const value = remote.trim();
+    for (const pattern of [
+        /^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/,
+        /^https?:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+        /^ssh:\/\/git@github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+    ]) {
+        const match = pattern.exec(value);
+        if (match)
+            return `${match[1]}/${match[2]}`;
+    }
+    return null;
+}
+function resolveRepository(input, run) {
+    const fromEnv = input.env?.GITHUB_REPOSITORY;
+    if (fromEnv !== undefined) {
+        if (!REPOSITORY.test(fromEnv))
+            return fail("invalid_repository", "GITHUB_REPOSITORY must use owner/name form");
+        return { ok: true, repository: fromEnv };
+    }
+    try {
+        const repository = repositoryFromRemote(run("git", ["remote", "get-url", "origin"], { cwd: input.repoRoot }));
+        return repository ? { ok: true, repository } : fail("repository_not_resolved", "origin must be a github.com owner/name repository");
+    }
+    catch (error) {
+        return fail("repository_not_resolved", `cannot read origin: ${errorText(error)}`);
+    }
+}
+function apiJson(run, repoRoot, endpoint, extraArgs = []) {
+    try {
+        const parsed = parseJson(run("gh", ["api", endpoint, ...extraArgs], { cwd: repoRoot }), endpoint);
+        return parsed.ok ? parsed : parsed;
+    }
+    catch (error) {
+        return fail("github_api_error", errorText(error));
+    }
+}
+function readBranchProtection(run, repoRoot, repository, branch, errors) {
+    const endpoint = `repos/${repository}/branches/${encodeURIComponent(branch)}/protection`;
+    try {
+        const parsed = parseJson(run("gh", ["api", endpoint], { cwd: repoRoot }), endpoint);
+        if (!parsed.ok || !isRecord(parsed.value)) {
+            errors.push({ id: "branch_protection_api_error", message: parsed.ok ? "branch protection response must be an object" : parsed.message });
+            return { complete: false, protected: null, data: null };
+        }
+        return { complete: true, protected: true, data: parsed.value };
+    }
+    catch (error) {
+        const text = errorText(error);
+        if (/Branch not protected/i.test(text) && /404/.test(text))
+            return { complete: true, protected: false, data: null };
+        errors.push({ id: "branch_protection_api_error", message: text });
+        return { complete: false, protected: null, data: null };
+    }
+}
+function readActiveRules(run, repoRoot, repository, branch, errors) {
+    const endpoint = `repos/${repository}/rules/branches/${encodeURIComponent(branch)}`;
+    const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+    if (!response.ok) {
+        errors.push({ id: "active_branch_rules_api_error", message: response.message });
+        return { complete: false, rules: null };
+    }
+    if (!Array.isArray(response.value)) {
+        errors.push({ id: "active_branch_rules_api_error", message: "active branch rules response must be an array" });
+        return { complete: false, rules: null };
+    }
+    const pages = response.value;
+    if (pages.every(Array.isArray))
+        return { complete: true, rules: pages.flat() };
+    return { complete: true, rules: pages };
+}
+function activeRulesetIds(rules) {
+    const ids = new Set();
+    for (const rule of rules) {
+        if (!isRecord(rule) || !PARALLEL_RULE_TYPES.has(rule.type))
+            continue;
+        if (Number.isInteger(rule.ruleset_id) && rule.ruleset_id >= 0)
+            ids.add(rule.ruleset_id);
+    }
+    return [...ids].sort((left, right) => left - right);
+}
+function readRulesets(run, repoRoot, repository, activeRules, errors) {
+    if (!activeRules.complete || !activeRules.rules)
+        return { complete: false, items: null };
+    const ids = activeRulesetIds(activeRules.rules);
+    const items = [];
+    let complete = true;
+    for (const id of ids) {
+        const response = apiJson(run, repoRoot, `repos/${repository}/rulesets/${id}`);
+        if (!response.ok) {
+            complete = false;
+            errors.push({ id: "ruleset_api_error", message: `ruleset ${id}: ${response.message}` });
+            continue;
+        }
+        items.push(response.value);
+    }
+    return { complete, items: complete ? items : items };
+}
+export function readGitHubControlPlane(input) {
+    if (input.provider !== "portable" && input.provider !== "github_merge_queue") {
+        return fail("invalid_provider", "provider must be portable or github_merge_queue");
+    }
+    if (typeof input.repoRoot !== "string" || input.repoRoot.length === 0)
+        return fail("invalid_repo_root", "repoRoot must be a non-empty string");
+    const run = input.run ?? defaultRun;
+    const repositoryResult = resolveRepository({ ...input, env: input.env ?? process.env }, run);
+    if (!repositoryResult.ok)
+        return repositoryResult;
+    const repository = repositoryResult.repository;
+    const metadata = apiJson(run, input.repoRoot, `repos/${repository}`);
+    if (!metadata.ok)
+        return fail("repository_metadata_api_error", metadata.message);
+    if (!isRecord(metadata.value) || typeof metadata.value.default_branch !== "string" || metadata.value.default_branch.length === 0) {
+        return fail("repository_metadata_malformed", "repository metadata must contain default_branch");
+    }
+    const defaultBranch = metadata.value.default_branch;
+    const errors = [];
+    const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
+    const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
+    const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
+    return {
+        ok: true,
+        provider: input.provider,
+        repository,
+        defaultBranch,
+        branchProtection,
+        activeBranchRules,
+        rulesets,
+        errors,
+    };
+}

--- a/dist/parallel-doctor.mjs
+++ b/dist/parallel-doctor.mjs
@@ -1,4 +1,60 @@
+import { readGitHubControlPlane } from "./github-control-plane.mjs";
+import { createIntegrationAnalysisReport } from "./integration-validator.mjs";
+import { normalizeGitHubControlPlane } from "./parallel-control-plane.mjs";
+import { evaluateParallelReadiness } from "./parallel-readiness.mjs";
 const PARALLEL_PROVIDERS = new Set(["portable", "github_merge_queue"]);
+const PARALLEL_FORMATS = new Set(["text", "json"]);
+function option(args, name, fallback) {
+    const index = args.indexOf(name);
+    return index < 0 ? fallback : args[index + 1] ?? fallback;
+}
+function addBlocker(blockers, blocker) {
+    if (!blockers.some((item) => item.id === blocker.id))
+        blockers.push(blocker);
+}
+function controlPlaneProjection(provider, controlPlaneRead) {
+    if (!controlPlaneRead.ok) {
+        return {
+            facts: {},
+            diagnostic: {
+                repository: null,
+                defaultBranch: null,
+                adapterErrors: [{ id: controlPlaneRead.error, message: controlPlaneRead.message }],
+                normalizationError: null,
+                normalizationEvidence: null,
+            },
+        };
+    }
+    const normalized = normalizeGitHubControlPlane({
+        provider,
+        repository: controlPlaneRead.repository,
+        defaultBranch: controlPlaneRead.defaultBranch,
+        branchProtection: controlPlaneRead.branchProtection,
+        activeBranchRules: controlPlaneRead.activeBranchRules,
+        rulesets: controlPlaneRead.rulesets,
+    });
+    return normalized.ok
+        ? {
+            facts: normalized.facts,
+            diagnostic: {
+                repository: controlPlaneRead.repository,
+                defaultBranch: controlPlaneRead.defaultBranch,
+                adapterErrors: controlPlaneRead.errors,
+                normalizationError: null,
+                normalizationEvidence: normalized.evidence,
+            },
+        }
+        : {
+            facts: {},
+            diagnostic: {
+                repository: controlPlaneRead.repository,
+                defaultBranch: controlPlaneRead.defaultBranch,
+                adapterErrors: controlPlaneRead.errors,
+                normalizationError: { id: normalized.error, message: normalized.message },
+                normalizationEvidence: null,
+            },
+        };
+}
 export function parseParallelProvider(args) {
     const index = args.indexOf("--parallel");
     if (index < 0)
@@ -9,7 +65,85 @@ export function parseParallelProvider(args) {
     }
     return value;
 }
-export async function runParallelDoctor(_roots, args) {
+export function createParallelDoctorReport(input) {
+    const controlPlane = controlPlaneProjection(input.provider, input.controlPlaneRead);
+    const readiness = evaluateParallelReadiness({
+        provider: input.provider,
+        integrationFacts: input.integrationFacts,
+        controlPlaneFacts: controlPlane.facts,
+    });
+    const blockers = [...readiness.blockers];
+    if (!input.integrationValid) {
+        addBlocker(blockers, {
+            id: "repository_validation_failed",
+            source: "repository",
+            message: "repository policy/integration validation failed",
+        });
+    }
+    blockers.sort((left, right) => left.id.localeCompare(right.id));
+    return {
+        command: "doctor --parallel",
+        provider: readiness.provider,
+        ready: blockers.length === 0,
+        blockers,
+        evidence: readiness.evidence,
+        diagnostics: {
+            integrationValid: input.integrationValid,
+            integrationMessage: input.integrationMessage ?? null,
+            controlPlane: controlPlane.diagnostic,
+        },
+    };
+}
+export function renderParallelDoctorReport(report, format) {
+    if (format === "json")
+        return JSON.stringify(report, null, 2);
+    if (format !== "text")
+        throw new Error(`Unsupported parallel doctor format: ${format}`);
+    const targetBranch = report.evidence.control_plane.targetBranch ?? "unknown";
+    const requiredChecks = report.evidence.control_plane.requiredChecks?.join(", ") ?? "unknown";
+    const lines = [
+        `repo-guard doctor --parallel ${report.provider}`,
+        "",
+        report.ready ? "READY" : "NOT READY",
+        `target branch: ${targetBranch}`,
+        `required checks: ${requiredChecks}`,
+    ];
+    if (report.blockers.length > 0) {
+        lines.push("blockers:");
+        for (const blocker of report.blockers)
+            lines.push(`  - ${blocker.source}/${blocker.id}: ${blocker.message}`);
+    }
+    const diagnosticErrors = report.diagnostics.controlPlane.adapterErrors;
+    if (diagnosticErrors.length > 0) {
+        lines.push("control-plane adapter errors:");
+        for (const error of diagnosticErrors)
+            lines.push(`  - ${error.id}: ${error.message}`);
+    }
+    if (report.diagnostics.controlPlane.normalizationError) {
+        const error = report.diagnostics.controlPlane.normalizationError;
+        lines.push(`control-plane normalization error: ${error.id}: ${error.message}`);
+    }
+    if (report.diagnostics.integrationMessage)
+        lines.push(`integration validation: ${report.diagnostics.integrationMessage}`);
+    return lines.join("\n");
+}
+export async function runParallelDoctor(roots, args) {
     const provider = parseParallelProvider(args);
-    throw new Error(`Parallel doctor for ${provider} requires control-plane adapter`);
+    const format = option(args, "--format", "text");
+    if (!PARALLEL_FORMATS.has(format))
+        throw new Error(`Unsupported parallel doctor format: ${format}`);
+    const integrationReport = createIntegrationAnalysisReport(roots, { format: "json" });
+    const integrationValid = integrationReport.fatal !== true && integrationReport.exitCode === 0;
+    const integrationFacts = integrationReport.integration ?? {};
+    const integrationMessage = integrationReport.fatal ? integrationReport.message ?? "integration analysis failed" : null;
+    const controlPlaneRead = readGitHubControlPlane({ repoRoot: roots.repoRoot, provider });
+    const report = createParallelDoctorReport({
+        provider,
+        integrationFacts,
+        integrationValid,
+        integrationMessage,
+        controlPlaneRead,
+    });
+    console.log(renderParallelDoctorReport(report, format));
+    return report.ready ? 0 : 1;
 }

--- a/dist/parallel-doctor.mjs
+++ b/dist/parallel-doctor.mjs
@@ -1,0 +1,15 @@
+const PARALLEL_PROVIDERS = new Set(["portable", "github_merge_queue"]);
+export function parseParallelProvider(args) {
+    const index = args.indexOf("--parallel");
+    if (index < 0)
+        throw new Error("--parallel requires a value");
+    const value = args[index + 1];
+    if (!value || !PARALLEL_PROVIDERS.has(value)) {
+        throw new Error(`Unsupported parallel provider: ${value ?? ""}`);
+    }
+    return value;
+}
+export async function runParallelDoctor(_roots, args) {
+    const provider = parseParallelProvider(args);
+    throw new Error(`Parallel doctor for ${provider} requires control-plane adapter`);
+}

--- a/dist/parallel-doctor.mjs
+++ b/dist/parallel-doctor.mjs
@@ -99,12 +99,16 @@ export function renderParallelDoctorReport(report, format) {
         return JSON.stringify(report, null, 2);
     if (format !== "text")
         throw new Error(`Unsupported parallel doctor format: ${format}`);
+    const transactionWorkflow = report.evidence.repository.transactionWorkflow ?? "unknown";
+    const providerWorkflow = report.evidence.repository.providerWorkflow ?? "unknown";
     const targetBranch = report.evidence.control_plane.targetBranch ?? "unknown";
     const requiredChecks = report.evidence.control_plane.requiredChecks?.join(", ") ?? "unknown";
     const lines = [
         `repo-guard doctor --parallel ${report.provider}`,
         "",
         report.ready ? "READY" : "NOT READY",
+        `transaction workflow: ${transactionWorkflow}`,
+        `provider workflow: ${providerWorkflow}`,
         `target branch: ${targetBranch}`,
         `required checks: ${requiredChecks}`,
     ];

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -2,6 +2,7 @@
 import { realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { runParallelDoctor } from "./parallel-doctor.mjs";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
 const valueOptions = (...names) => Object.fromEntries(names.map((name) => [name, true]));
@@ -34,7 +35,9 @@ const COMMAND_SPECS = {
         options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
         run: async (roots, args) => args.includes("--integration")
             ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
-            : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
+            : args.includes("--parallel")
+                ? runParallelDoctor(roots, args)
+                : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
     },
     "validate-integration": {
         options: valueOptions("--format"), positionals: 0,

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -31,7 +31,7 @@ const COMMAND_SPECS = {
         run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
     },
     doctor: {
-        options: { "--integration": false, ...valueOptions("--format") }, positionals: 0,
+        options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
         run: async (roots, args) => args.includes("--integration")
             ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
             : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),

--- a/src/github-control-plane.mts
+++ b/src/github-control-plane.mts
@@ -1,0 +1,200 @@
+import { execFileSync } from "node:child_process";
+import type { ParallelReadinessProvider } from "./parallel-readiness.mjs";
+
+type Failure = { ok: false; error: string; message: string };
+type AdapterError = { id: string; message: string };
+type RunCommand = (command: string, args: string[], options?: { cwd?: string }) => string;
+
+type BranchProtectionEnvelope = {
+  complete: boolean;
+  protected: boolean | null;
+  data: Record<string, unknown> | null;
+};
+
+type ActiveBranchRulesEnvelope = {
+  complete: boolean;
+  rules: unknown[] | null;
+};
+
+type RulesetsEnvelope = {
+  complete: boolean;
+  items: unknown[] | null;
+};
+
+export type GitHubControlPlaneReadResult = Failure | {
+  ok: true;
+  provider: ParallelReadinessProvider;
+  repository: string;
+  defaultBranch: string;
+  branchProtection: BranchProtectionEnvelope;
+  activeBranchRules: ActiveBranchRulesEnvelope;
+  rulesets: RulesetsEnvelope;
+  errors: AdapterError[];
+};
+
+interface ReadInput {
+  repoRoot: string;
+  provider: ParallelReadinessProvider;
+  env?: Record<string, string | undefined>;
+  run?: RunCommand;
+}
+
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const PARALLEL_RULE_TYPES = new Set(["pull_request", "required_status_checks", "merge_queue"]);
+
+function fail(error: string, message: string): Failure {
+  return { ok: false, error, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function defaultRun(command: string, args: string[], options: { cwd?: string } = {}): string {
+  return execFileSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: 30000,
+  });
+}
+
+function errorText(error: unknown): string {
+  if (!isRecord(error)) return String(error);
+  const stderr = typeof error.stderr === "string" ? error.stderr.trim() : "";
+  const message = typeof error.message === "string" ? error.message.trim() : "";
+  return [stderr, message].filter(Boolean).join("\n") || "unknown command failure";
+}
+
+function parseJson(text: string, label: string): { ok: true; value: unknown } | Failure {
+  try { return { ok: true, value: JSON.parse(text) }; }
+  catch (error: unknown) { return fail("malformed_github_response", `${label}: ${(error as Error).message}`); }
+}
+
+function repositoryFromRemote(remote: string): string | null {
+  const value = remote.trim();
+  for (const pattern of [
+    /^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/,
+    /^https?:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+    /^ssh:\/\/git@github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?\/?$/,
+  ]) {
+    const match = pattern.exec(value);
+    if (match) return `${match[1]}/${match[2]}`;
+  }
+  return null;
+}
+
+function resolveRepository(input: ReadInput, run: RunCommand): { ok: true; repository: string } | Failure {
+  const fromEnv = input.env?.GITHUB_REPOSITORY;
+  if (fromEnv !== undefined) {
+    if (!REPOSITORY.test(fromEnv)) return fail("invalid_repository", "GITHUB_REPOSITORY must use owner/name form");
+    return { ok: true, repository: fromEnv };
+  }
+  try {
+    const repository = repositoryFromRemote(run("git", ["remote", "get-url", "origin"], { cwd: input.repoRoot }));
+    return repository ? { ok: true, repository } : fail("repository_not_resolved", "origin must be a github.com owner/name repository");
+  } catch (error: unknown) {
+    return fail("repository_not_resolved", `cannot read origin: ${errorText(error)}`);
+  }
+}
+
+function apiJson(run: RunCommand, repoRoot: string, endpoint: string, extraArgs: string[] = []) {
+  try {
+    const parsed = parseJson(run("gh", ["api", endpoint, ...extraArgs], { cwd: repoRoot }), endpoint);
+    return parsed.ok ? parsed : parsed;
+  } catch (error: unknown) {
+    return fail("github_api_error", errorText(error));
+  }
+}
+
+function readBranchProtection(run: RunCommand, repoRoot: string, repository: string, branch: string, errors: AdapterError[]): BranchProtectionEnvelope {
+  const endpoint = `repos/${repository}/branches/${encodeURIComponent(branch)}/protection`;
+  try {
+    const parsed = parseJson(run("gh", ["api", endpoint], { cwd: repoRoot }), endpoint);
+    if (!parsed.ok || !isRecord(parsed.value)) {
+      errors.push({ id: "branch_protection_api_error", message: parsed.ok ? "branch protection response must be an object" : parsed.message });
+      return { complete: false, protected: null, data: null };
+    }
+    return { complete: true, protected: true, data: parsed.value };
+  } catch (error: unknown) {
+    const text = errorText(error);
+    if (/Branch not protected/i.test(text) && /404/.test(text)) return { complete: true, protected: false, data: null };
+    errors.push({ id: "branch_protection_api_error", message: text });
+    return { complete: false, protected: null, data: null };
+  }
+}
+
+function readActiveRules(run: RunCommand, repoRoot: string, repository: string, branch: string, errors: AdapterError[]): ActiveBranchRulesEnvelope {
+  const endpoint = `repos/${repository}/rules/branches/${encodeURIComponent(branch)}`;
+  const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+  if (!response.ok) {
+    errors.push({ id: "active_branch_rules_api_error", message: response.message });
+    return { complete: false, rules: null };
+  }
+  if (!Array.isArray(response.value)) {
+    errors.push({ id: "active_branch_rules_api_error", message: "active branch rules response must be an array" });
+    return { complete: false, rules: null };
+  }
+  const pages = response.value;
+  if (pages.every(Array.isArray)) return { complete: true, rules: (pages as unknown[][]).flat() };
+  return { complete: true, rules: pages };
+}
+
+function activeRulesetIds(rules: unknown[]): number[] {
+  const ids = new Set<number>();
+  for (const rule of rules) {
+    if (!isRecord(rule) || !PARALLEL_RULE_TYPES.has(rule.type as string)) continue;
+    if (Number.isInteger(rule.ruleset_id) && (rule.ruleset_id as number) >= 0) ids.add(rule.ruleset_id as number);
+  }
+  return [...ids].sort((left, right) => left - right);
+}
+
+function readRulesets(run: RunCommand, repoRoot: string, repository: string, activeRules: ActiveBranchRulesEnvelope, errors: AdapterError[]): RulesetsEnvelope {
+  if (!activeRules.complete || !activeRules.rules) return { complete: false, items: null };
+  const ids = activeRulesetIds(activeRules.rules);
+  const items: unknown[] = [];
+  let complete = true;
+  for (const id of ids) {
+    const response = apiJson(run, repoRoot, `repos/${repository}/rulesets/${id}`);
+    if (!response.ok) {
+      complete = false;
+      errors.push({ id: "ruleset_api_error", message: `ruleset ${id}: ${response.message}` });
+      continue;
+    }
+    items.push(response.value);
+  }
+  return { complete, items: complete ? items : items };
+}
+
+export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneReadResult {
+  if (input.provider !== "portable" && input.provider !== "github_merge_queue") {
+    return fail("invalid_provider", "provider must be portable or github_merge_queue");
+  }
+  if (typeof input.repoRoot !== "string" || input.repoRoot.length === 0) return fail("invalid_repo_root", "repoRoot must be a non-empty string");
+  const run = input.run ?? defaultRun;
+  const repositoryResult = resolveRepository({ ...input, env: input.env ?? process.env }, run);
+  if (!repositoryResult.ok) return repositoryResult;
+  const repository = repositoryResult.repository;
+
+  const metadata = apiJson(run, input.repoRoot, `repos/${repository}`);
+  if (!metadata.ok) return fail("repository_metadata_api_error", metadata.message);
+  if (!isRecord(metadata.value) || typeof metadata.value.default_branch !== "string" || metadata.value.default_branch.length === 0) {
+    return fail("repository_metadata_malformed", "repository metadata must contain default_branch");
+  }
+  const defaultBranch = metadata.value.default_branch;
+  const errors: AdapterError[] = [];
+  const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
+  const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
+  const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
+
+  return {
+    ok: true,
+    provider: input.provider,
+    repository,
+    defaultBranch,
+    branchProtection,
+    activeBranchRules,
+    rulesets,
+    errors,
+  };
+}

--- a/src/parallel-doctor.mts
+++ b/src/parallel-doctor.mts
@@ -1,0 +1,18 @@
+import type { ParallelReadinessProvider } from "./parallel-readiness.mjs";
+
+const PARALLEL_PROVIDERS = new Set<ParallelReadinessProvider>(["portable", "github_merge_queue"]);
+
+export function parseParallelProvider(args: string[]): ParallelReadinessProvider {
+  const index = args.indexOf("--parallel");
+  if (index < 0) throw new Error("--parallel requires a value");
+  const value = args[index + 1];
+  if (!value || !PARALLEL_PROVIDERS.has(value as ParallelReadinessProvider)) {
+    throw new Error(`Unsupported parallel provider: ${value ?? ""}`);
+  }
+  return value as ParallelReadinessProvider;
+}
+
+export async function runParallelDoctor(_roots: unknown, args: string[]): Promise<number> {
+  const provider = parseParallelProvider(args);
+  throw new Error(`Parallel doctor for ${provider} requires control-plane adapter`);
+}

--- a/src/parallel-doctor.mts
+++ b/src/parallel-doctor.mts
@@ -154,12 +154,16 @@ export function renderParallelDoctorReport(report: ParallelDoctorReport, format:
   if (format === "json") return JSON.stringify(report, null, 2);
   if (format !== "text") throw new Error(`Unsupported parallel doctor format: ${format as string}`);
 
+  const transactionWorkflow = report.evidence.repository.transactionWorkflow ?? "unknown";
+  const providerWorkflow = report.evidence.repository.providerWorkflow ?? "unknown";
   const targetBranch = report.evidence.control_plane.targetBranch ?? "unknown";
   const requiredChecks = report.evidence.control_plane.requiredChecks?.join(", ") ?? "unknown";
   const lines = [
     `repo-guard doctor --parallel ${report.provider}`,
     "",
     report.ready ? "READY" : "NOT READY",
+    `transaction workflow: ${transactionWorkflow}`,
+    `provider workflow: ${providerWorkflow}`,
     `target branch: ${targetBranch}`,
     `required checks: ${requiredChecks}`,
   ];

--- a/src/parallel-doctor.mts
+++ b/src/parallel-doctor.mts
@@ -1,6 +1,113 @@
-import type { ParallelReadinessProvider } from "./parallel-readiness.mjs";
+import type { GitHubControlPlaneReadResult } from "./github-control-plane.mjs";
+import { readGitHubControlPlane } from "./github-control-plane.mjs";
+import { createIntegrationAnalysisReport } from "./integration-validator.mjs";
+import type { ParallelControlPlaneNormalizationResult } from "./parallel-control-plane.mjs";
+import { normalizeGitHubControlPlane } from "./parallel-control-plane.mjs";
+import type {
+  ParallelReadinessBlocker,
+  ParallelReadinessProvider,
+  ParallelReadinessReport,
+} from "./parallel-readiness.mjs";
+import { evaluateParallelReadiness } from "./parallel-readiness.mjs";
 
 const PARALLEL_PROVIDERS = new Set<ParallelReadinessProvider>(["portable", "github_merge_queue"]);
+const PARALLEL_FORMATS = new Set(["text", "json"]);
+
+type ParallelDoctorRoots = Parameters<typeof createIntegrationAnalysisReport>[0];
+type ParallelDoctorFormat = "text" | "json";
+
+type ControlPlaneDiagnostic = {
+  repository: string | null;
+  defaultBranch: string | null;
+  adapterErrors: Array<{ id: string; message: string }>;
+  normalizationError: { id: string; message: string } | null;
+  normalizationEvidence: unknown;
+};
+
+export interface ParallelDoctorReport extends ParallelReadinessReport {
+  command: "doctor --parallel";
+  diagnostics: {
+    integrationValid: boolean;
+    integrationMessage: string | null;
+    controlPlane: ControlPlaneDiagnostic;
+  };
+}
+
+interface CreateParallelDoctorReportInput {
+  provider: ParallelReadinessProvider;
+  integrationFacts: unknown;
+  integrationValid: boolean;
+  integrationMessage?: string | null;
+  controlPlaneRead: GitHubControlPlaneReadResult;
+}
+
+interface IntegrationReportProjection {
+  fatal?: boolean;
+  message?: string;
+  exitCode?: number;
+  integration?: unknown;
+}
+
+function option(args: readonly string[], name: string, fallback: string): string {
+  const index = args.indexOf(name);
+  return index < 0 ? fallback : args[index + 1] ?? fallback;
+}
+
+function addBlocker(blockers: ParallelReadinessBlocker[], blocker: ParallelReadinessBlocker): void {
+  if (!blockers.some((item) => item.id === blocker.id)) blockers.push(blocker);
+}
+
+function controlPlaneProjection(
+  provider: ParallelReadinessProvider,
+  controlPlaneRead: GitHubControlPlaneReadResult,
+): {
+  facts: unknown;
+  diagnostic: ControlPlaneDiagnostic;
+} {
+  if (!controlPlaneRead.ok) {
+    return {
+      facts: {},
+      diagnostic: {
+        repository: null,
+        defaultBranch: null,
+        adapterErrors: [{ id: controlPlaneRead.error, message: controlPlaneRead.message }],
+        normalizationError: null,
+        normalizationEvidence: null,
+      },
+    };
+  }
+
+  const normalized: ParallelControlPlaneNormalizationResult = normalizeGitHubControlPlane({
+    provider,
+    repository: controlPlaneRead.repository,
+    defaultBranch: controlPlaneRead.defaultBranch,
+    branchProtection: controlPlaneRead.branchProtection,
+    activeBranchRules: controlPlaneRead.activeBranchRules,
+    rulesets: controlPlaneRead.rulesets,
+  });
+
+  return normalized.ok
+    ? {
+        facts: normalized.facts,
+        diagnostic: {
+          repository: controlPlaneRead.repository,
+          defaultBranch: controlPlaneRead.defaultBranch,
+          adapterErrors: controlPlaneRead.errors,
+          normalizationError: null,
+          normalizationEvidence: normalized.evidence,
+        },
+      }
+    : {
+        facts: {},
+        diagnostic: {
+          repository: controlPlaneRead.repository,
+          defaultBranch: controlPlaneRead.defaultBranch,
+          adapterErrors: controlPlaneRead.errors,
+          normalizationError: { id: normalized.error, message: normalized.message },
+          normalizationEvidence: null,
+        },
+      };
+}
 
 export function parseParallelProvider(args: string[]): ParallelReadinessProvider {
   const index = args.indexOf("--parallel");
@@ -12,7 +119,84 @@ export function parseParallelProvider(args: string[]): ParallelReadinessProvider
   return value as ParallelReadinessProvider;
 }
 
-export async function runParallelDoctor(_roots: unknown, args: string[]): Promise<number> {
+export function createParallelDoctorReport(input: CreateParallelDoctorReportInput): ParallelDoctorReport {
+  const controlPlane = controlPlaneProjection(input.provider, input.controlPlaneRead);
+  const readiness = evaluateParallelReadiness({
+    provider: input.provider,
+    integrationFacts: input.integrationFacts,
+    controlPlaneFacts: controlPlane.facts,
+  });
+  const blockers = [...readiness.blockers];
+  if (!input.integrationValid) {
+    addBlocker(blockers, {
+      id: "repository_validation_failed",
+      source: "repository",
+      message: "repository policy/integration validation failed",
+    });
+  }
+  blockers.sort((left, right) => left.id.localeCompare(right.id));
+
+  return {
+    command: "doctor --parallel",
+    provider: readiness.provider,
+    ready: blockers.length === 0,
+    blockers,
+    evidence: readiness.evidence,
+    diagnostics: {
+      integrationValid: input.integrationValid,
+      integrationMessage: input.integrationMessage ?? null,
+      controlPlane: controlPlane.diagnostic,
+    },
+  };
+}
+
+export function renderParallelDoctorReport(report: ParallelDoctorReport, format: ParallelDoctorFormat): string {
+  if (format === "json") return JSON.stringify(report, null, 2);
+  if (format !== "text") throw new Error(`Unsupported parallel doctor format: ${format as string}`);
+
+  const targetBranch = report.evidence.control_plane.targetBranch ?? "unknown";
+  const requiredChecks = report.evidence.control_plane.requiredChecks?.join(", ") ?? "unknown";
+  const lines = [
+    `repo-guard doctor --parallel ${report.provider}`,
+    "",
+    report.ready ? "READY" : "NOT READY",
+    `target branch: ${targetBranch}`,
+    `required checks: ${requiredChecks}`,
+  ];
+  if (report.blockers.length > 0) {
+    lines.push("blockers:");
+    for (const blocker of report.blockers) lines.push(`  - ${blocker.source}/${blocker.id}: ${blocker.message}`);
+  }
+  const diagnosticErrors = report.diagnostics.controlPlane.adapterErrors;
+  if (diagnosticErrors.length > 0) {
+    lines.push("control-plane adapter errors:");
+    for (const error of diagnosticErrors) lines.push(`  - ${error.id}: ${error.message}`);
+  }
+  if (report.diagnostics.controlPlane.normalizationError) {
+    const error = report.diagnostics.controlPlane.normalizationError;
+    lines.push(`control-plane normalization error: ${error.id}: ${error.message}`);
+  }
+  if (report.diagnostics.integrationMessage) lines.push(`integration validation: ${report.diagnostics.integrationMessage}`);
+  return lines.join("\n");
+}
+
+export async function runParallelDoctor(roots: ParallelDoctorRoots, args: string[]): Promise<number> {
   const provider = parseParallelProvider(args);
-  throw new Error(`Parallel doctor for ${provider} requires control-plane adapter`);
+  const format = option(args, "--format", "text");
+  if (!PARALLEL_FORMATS.has(format)) throw new Error(`Unsupported parallel doctor format: ${format}`);
+
+  const integrationReport = createIntegrationAnalysisReport(roots, { format: "json" }) as IntegrationReportProjection;
+  const integrationValid = integrationReport.fatal !== true && integrationReport.exitCode === 0;
+  const integrationFacts = integrationReport.integration ?? {};
+  const integrationMessage = integrationReport.fatal ? integrationReport.message ?? "integration analysis failed" : null;
+  const controlPlaneRead = readGitHubControlPlane({ repoRoot: roots.repoRoot, provider });
+  const report = createParallelDoctorReport({
+    provider,
+    integrationFacts,
+    integrationValid,
+    integrationMessage,
+    controlPlaneRead,
+  });
+  console.log(renderParallelDoctorReport(report, format as ParallelDoctorFormat));
+  return report.ready ? 0 : 1;
 }

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -3,6 +3,7 @@
 import { realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { runParallelDoctor } from "./parallel-doctor.mjs";
 
 interface CliRoots {
   packageRoot: string;
@@ -50,7 +51,9 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
     options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
     run: async (roots, args) => args.includes("--integration")
       ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
-      : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
+      : args.includes("--parallel")
+        ? runParallelDoctor(roots, args)
+        : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
   },
   "validate-integration": {
     options: valueOptions("--format"), positionals: 0,

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -47,7 +47,7 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
     run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
   },
   doctor: {
-    options: { "--integration": false, ...valueOptions("--format") }, positionals: 0,
+    options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
     run: async (roots, args) => args.includes("--integration")
       ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
       : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),

--- a/tests/test-github-control-plane.mjs
+++ b/tests/test-github-control-plane.mjs
@@ -1,0 +1,137 @@
+import { strict as assert } from "node:assert";
+import { readGitHubControlPlane } from "../dist/github-control-plane.mjs";
+
+function commandError(stderr, status = 1) {
+  const error = new Error(stderr);
+  error.status = status;
+  error.stderr = stderr;
+  return error;
+}
+
+function fakeRunner(fixtures) {
+  const calls = [];
+  const run = (command, args) => {
+    calls.push({ command, args: [...args] });
+    if (command === "git") {
+      const value = fixtures.gitOrigin;
+      if (value instanceof Error) throw value;
+      if (value === undefined) throw new Error(`unexpected git call: ${args.join(" ")}`);
+      return value;
+    }
+    assert.equal(command, "gh");
+    assert.equal(args[0], "api", "control-plane adapter must use read-only gh api invocations");
+    assert.equal(args.some((arg) => ["POST", "PUT", "PATCH", "DELETE"].includes(arg.toUpperCase())), false);
+    const endpoint = args[1];
+    const value = fixtures.api?.[endpoint];
+    if (value instanceof Error) throw value;
+    if (value === undefined) throw new Error(`unexpected gh api endpoint: ${endpoint}`);
+    return typeof value === "string" ? value : JSON.stringify(value);
+  };
+  return { run, calls };
+}
+
+function read(fixtures, overrides = {}) {
+  const fake = fakeRunner(fixtures);
+  const result = readGitHubControlPlane({
+    repoRoot: "/repo",
+    provider: "portable",
+    env: { GITHUB_REPOSITORY: "netkeep80/example" },
+    run: fake.run,
+    ...overrides,
+  });
+  return { result, calls: fake.calls };
+}
+
+{
+  const { result, calls } = read({
+    api: {
+      "repos/netkeep80/example": { default_branch: "main" },
+      "repos/netkeep80/example/branches/main/protection": commandError("Branch not protected (HTTP 404)"),
+      "repos/netkeep80/example/rules/branches/main": [[]],
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.repository, "netkeep80/example");
+  assert.equal(result.defaultBranch, "main");
+  assert.deepEqual(result.branchProtection, { complete: true, protected: false, data: null });
+  assert.deepEqual(result.activeBranchRules, { complete: true, rules: [] });
+  assert.deepEqual(result.rulesets, { complete: true, items: [] });
+  assert.deepEqual(result.errors, []);
+  assert.equal(calls.every((call) => call.command === "gh"), true);
+}
+
+{
+  const protection = {
+    required_status_checks: { strict: true, contexts: ["CI / validate"], checks: [] },
+    required_pull_request_reviews: { bypass_pull_request_allowances: { users: [], teams: [], apps: [] } },
+    enforce_admins: { enabled: true },
+  };
+  const { result } = read({
+    api: {
+      "repos/netkeep80/example": { default_branch: "main" },
+      "repos/netkeep80/example/branches/main/protection": protection,
+      "repos/netkeep80/example/rules/branches/main": [[]],
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.branchProtection, { complete: true, protected: true, data: protection });
+}
+
+{
+  const activeRules = [
+    { type: "pull_request", ruleset_id: 41 },
+    {
+      type: "required_status_checks",
+      ruleset_id: 41,
+      parameters: {
+        strict_required_status_checks_policy: true,
+        required_status_checks: [{ context: "CI / validate", integration_id: null }],
+      },
+    },
+  ];
+  const detail = { id: 41, enforcement: "active", bypass_actors: [] };
+  const { result } = read({
+    api: {
+      "repos/netkeep80/example": { default_branch: "main" },
+      "repos/netkeep80/example/branches/main/protection": commandError("Branch not protected (HTTP 404)"),
+      "repos/netkeep80/example/rules/branches/main": [activeRules],
+      "repos/netkeep80/example/rulesets/41": detail,
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.activeBranchRules, { complete: true, rules: activeRules });
+  assert.deepEqual(result.rulesets, { complete: true, items: [detail] });
+}
+
+{
+  const { result } = read({
+    api: {
+      "repos/netkeep80/example": { default_branch: "main" },
+      "repos/netkeep80/example/branches/main/protection": commandError("Resource not accessible by integration (HTTP 403)"),
+      "repos/netkeep80/example/rules/branches/main": commandError("Resource not accessible by integration (HTTP 403)"),
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.branchProtection, { complete: false, protected: null, data: null });
+  assert.deepEqual(result.activeBranchRules, { complete: false, rules: null });
+  assert.deepEqual(result.rulesets, { complete: false, items: null });
+  assert.ok(result.errors.some((item) => item.id === "branch_protection_api_error"));
+  assert.ok(result.errors.some((item) => item.id === "active_branch_rules_api_error"));
+}
+
+{
+  const fake = fakeRunner({
+    gitOrigin: "git@github.com:netkeep80/example.git\n",
+    api: {
+      "repos/netkeep80/example": { default_branch: "main" },
+      "repos/netkeep80/example/branches/main/protection": commandError("Branch not protected (HTTP 404)"),
+      "repos/netkeep80/example/rules/branches/main": [[]],
+    },
+  });
+  const result = readGitHubControlPlane({ repoRoot: "/repo", provider: "portable", env: {}, run: fake.run });
+  assert.equal(result.ok, true);
+  assert.equal(result.repository, "netkeep80/example");
+  assert.deepEqual(fake.calls[0], { command: "git", args: ["remote", "get-url", "origin"] });
+}
+
+console.log("All GitHub control-plane adapter tests passed");

--- a/tests/test-parallel-doctor.mjs
+++ b/tests/test-parallel-doctor.mjs
@@ -1,5 +1,7 @@
+import { strict as assert } from "node:assert";
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
+import { createParallelDoctorReport, renderParallelDoctorReport } from "../dist/parallel-doctor.mjs";
 
 const projectRoot = resolve(new URL("..", import.meta.url).pathname);
 const cli = resolve(projectRoot, "dist/repo-guard.mjs");
@@ -42,6 +44,53 @@ function run(args) {
   return { code: result.status ?? 1, stdout: result.stdout || "", stderr: result.stderr || "" };
 }
 
+function readyIntegrationFacts() {
+  return {
+    workflows: [
+      {
+        path: ".github/workflows/ci.yml",
+        role: "repo_guard_pr_gate",
+        expect: { mode: "check-pr", enforcement: "blocking" },
+        triggerEvents: ["pull_request"],
+        actionUses: [{ uses: "./" }],
+        stepInputs: [{ inputs: { mode: "check-pr", enforcement: "blocking" } }],
+        continueOnError: [],
+      },
+      {
+        path: ".github/workflows/parallel.yml",
+        role: "repo_guard_portable_coordinator",
+        expect: { mode: "portable-coordinator", enforcement: "blocking" },
+        actionUses: [{ uses: "./" }],
+        stepInputs: [{ inputs: { mode: "portable-coordinator", enforcement: "blocking" } }],
+        continueOnError: [],
+        runCommands: [],
+      },
+    ],
+    errors: [],
+  };
+}
+
+function readyControlPlaneRead() {
+  return {
+    ok: true,
+    provider: "portable",
+    repository: "netkeep80/example",
+    defaultBranch: "main",
+    branchProtection: {
+      complete: true,
+      protected: true,
+      data: {
+        required_status_checks: { strict: true, contexts: ["CI / validate"], checks: [] },
+        required_pull_request_reviews: { bypass_pull_request_allowances: { users: [], teams: [], apps: [] } },
+        enforce_admins: { enabled: true },
+      },
+    },
+    activeBranchRules: { complete: true, rules: [] },
+    rulesets: { complete: true, items: [] },
+    errors: [],
+  };
+}
+
 console.log("\n--- doctor --parallel requires an explicit provider value ---");
 {
   const result = run(["doctor", "--parallel"]);
@@ -55,6 +104,53 @@ console.log("\n--- doctor --parallel rejects unsupported providers ---");
   const result = run(["doctor", "--parallel", "bogus"]);
   expect("unsupported provider exits non-zero", result.code, 1);
   expectIncludes("unsupported provider is explicit", result.stderr, "Unsupported parallel provider: bogus");
+}
+
+console.log("\n--- parallel doctor composes canonical repository and control-plane readiness ---");
+{
+  const report = createParallelDoctorReport({
+    provider: "portable",
+    integrationFacts: readyIntegrationFacts(),
+    integrationValid: true,
+    controlPlaneRead: readyControlPlaneRead(),
+  });
+  assert.equal(report.provider, "portable");
+  assert.equal(report.ready, true);
+  assert.deepEqual(report.blockers, []);
+  assert.equal(report.evidence.repository.transactionWorkflow, ".github/workflows/ci.yml");
+  assert.equal(report.evidence.repository.providerWorkflow, ".github/workflows/parallel.yml");
+  assert.equal(report.evidence.control_plane.targetBranch, "main");
+  assert.deepEqual(report.evidence.control_plane.requiredChecks, ["CI / validate"]);
+  assert.equal(report.diagnostics.controlPlane.repository, "netkeep80/example");
+  assert.deepEqual(report.diagnostics.controlPlane.adapterErrors, []);
+
+  const json = JSON.parse(renderParallelDoctorReport(report, "json"));
+  assert.equal(json.provider, "portable");
+  assert.equal(json.ready, true);
+  assert.deepEqual(json.blockers, []);
+
+  const text = renderParallelDoctorReport(report, "text");
+  assert.match(text, /repo-guard doctor --parallel portable/);
+  assert.match(text, /READY/);
+  assert.match(text, /target branch: main/);
+  assert.match(text, /required checks: CI \/ validate/);
+}
+
+console.log("\n--- parallel doctor fails closed when GitHub control-plane read fails ---");
+{
+  const report = createParallelDoctorReport({
+    provider: "portable",
+    integrationFacts: readyIntegrationFacts(),
+    integrationValid: true,
+    controlPlaneRead: { ok: false, error: "repository_metadata_api_error", message: "HTTP 403" },
+  });
+  assert.equal(report.ready, false);
+  assert.ok(report.blockers.some((item) => item.id === "unknown_target_branch" && item.source === "control_plane"));
+  assert.ok(report.blockers.some((item) => item.id === "unknown_required_checks" && item.source === "control_plane"));
+  assert.deepEqual(report.diagnostics.controlPlane.adapterErrors, [{ id: "repository_metadata_api_error", message: "HTTP 403" }]);
+  const text = renderParallelDoctorReport(report, "text");
+  assert.match(text, /NOT READY/);
+  assert.match(text, /control_plane\/unknown_target_branch/);
 }
 
 console.log("\n=========================");

--- a/tests/test-parallel-doctor.mjs
+++ b/tests/test-parallel-doctor.mjs
@@ -50,6 +50,13 @@ console.log("\n--- doctor --parallel requires an explicit provider value ---");
   expectNotIncludes("parallel option is not rejected as unknown", result.stderr, "Unknown option for doctor: --parallel");
 }
 
+console.log("\n--- doctor --parallel rejects unsupported providers ---");
+{
+  const result = run(["doctor", "--parallel", "bogus"]);
+  expect("unsupported provider exits non-zero", result.code, 1);
+  expectIncludes("unsupported provider is explicit", result.stderr, "Unsupported parallel provider: bogus");
+}
+
 console.log("\n=========================");
 if (failures > 0) {
   console.error(`${failures} test(s) FAILED`);

--- a/tests/test-parallel-doctor.mjs
+++ b/tests/test-parallel-doctor.mjs
@@ -132,6 +132,8 @@ console.log("\n--- parallel doctor composes canonical repository and control-pla
   const text = renderParallelDoctorReport(report, "text");
   assert.match(text, /repo-guard doctor --parallel portable/);
   assert.match(text, /READY/);
+  assert.match(text, /transaction workflow: \.github\/workflows\/ci\.yml/);
+  assert.match(text, /provider workflow: \.github\/workflows\/parallel\.yml/);
   assert.match(text, /target branch: main/);
   assert.match(text, /required checks: CI \/ validate/);
 }

--- a/tests/test-parallel-doctor.mjs
+++ b/tests/test-parallel-doctor.mjs
@@ -1,0 +1,58 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const projectRoot = resolve(new URL("..", import.meta.url).pathname);
+const cli = resolve(projectRoot, "dist/repo-guard.mjs");
+let failures = 0;
+
+function expect(label, actual, expected) {
+  const passed = actual === expected;
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectIncludes(label, actual, expected) {
+  const passed = actual.includes(expected);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected to include: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectNotIncludes(label, actual, expected) {
+  const passed = !actual.includes(expected);
+  console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
+  if (!passed) {
+    failures++;
+    console.error(`  expected not to include: ${JSON.stringify(expected)}, got: ${JSON.stringify(actual)}`);
+  }
+}
+
+function run(args) {
+  const result = spawnSync(process.execPath, [cli, ...args], {
+    cwd: projectRoot,
+    encoding: "utf-8",
+    env: process.env,
+  });
+  if (result.error) throw result.error;
+  return { code: result.status ?? 1, stdout: result.stdout || "", stderr: result.stderr || "" };
+}
+
+console.log("\n--- doctor --parallel requires an explicit provider value ---");
+{
+  const result = run(["doctor", "--parallel"]);
+  expect("missing provider exits non-zero", result.code, 1);
+  expectIncludes("parallel option is recognized as value-taking", result.stderr, "--parallel requires a value");
+  expectNotIncludes("parallel option is not rejected as unknown", result.stderr, "Unknown option for doctor: --parallel");
+}
+
+console.log("\n=========================");
+if (failures > 0) {
+  console.error(`${failures} test(s) FAILED`);
+  process.exit(1);
+}
+console.log("All parallel doctor tests passed");


### PR DESCRIPTION
## Краткое описание

Добавляет explicit `doctor --parallel <provider>` поверх read-only GitHub control plane. Этот PR переиспользует существующие integration facts, P4b1 normalizer и canonical readiness evaluator; никаких control-plane writes, provider enforcement, coordinator/init scaffold или self-host rollout здесь нет.

Part of #328

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/repo-guard.mts
  - dist/repo-guard.mjs
  - src/github-control-plane.mts
  - dist/github-control-plane.mjs
  - src/parallel-doctor.mts
  - dist/parallel-doctor.mjs
  - tests/test-parallel-doctor.mjs
  - tests/test-github-control-plane.mjs
budgets: {}
anchors:
  affects:
    - "#328"
  implements: []
  verifies: []
must_touch:
  - tests/test-parallel-doctor.mjs
must_not_touch:
  - src/doctor.mts
  - src/portable-integration/**
  - .github/workflows/**
  - repo-policy.json
  - schemas/**
expected_effects:
  - doctor --parallel требует явный provider portable или github_merge_queue.
  - Parallel doctor читает GitHub control plane только read-only и fail-closed нормализует неполные evidence.
  - Parallel doctor переиспользует extractIntegration(), normalizeGitHubControlPlane() и evaluateParallelReadiness().
  - Legacy doctor и provider enforcement не изменяются.
```