### PR TITLE
[Parallel P4c] Publish trusted portable coordinator runtime

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,9 @@ inputs:
   mode:
     description: >
       Command mode. Use `check-pr` to validate a pull request against policy
-      and ChangeIntent (requires GitHub Actions PR event context). Use `check-diff`
-      to validate a local diff between two refs.
+      and ChangeIntent (requires GitHub Actions PR event context), `check-diff`
+      to validate a local diff between two refs, or `portable-coordinator` to
+      run the trusted portable integration coordinator.
     required: false
     default: "check-pr"
 
@@ -51,6 +52,44 @@ inputs:
     required: false
     default: ""
 
+  repository:
+    description: >
+      Trusted repository identity (`owner/name`) for `mode: portable-coordinator`.
+      If empty, the coordinator may use trusted `GITHUB_REPOSITORY`.
+    required: false
+    default: ""
+
+  ready-label:
+    description: "Trusted READY label for `mode: portable-coordinator`."
+    required: false
+    default: ""
+
+  merge-method:
+    description: >
+      Merge method for `mode: portable-coordinator`: `merge`, `squash`, or
+      `rebase`.
+    required: false
+    default: ""
+
+  transaction-checks:
+    description: >
+      Required transaction check names for `mode: portable-coordinator`, one
+      check name per line.
+    required: false
+    default: ""
+
+  state-checks:
+    description: >
+      Required state check names for `mode: portable-coordinator`, one check
+      name per line.
+    required: false
+    default: ""
+
+  format:
+    description: "Portable coordinator evidence format: `text` or `json`."
+    required: false
+    default: "text"
+
   node-version:
     description: "Node.js version to use when running repo-guard."
     required: false
@@ -88,47 +127,82 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ env.GH_TOKEN }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_READY_LABEL: ${{ inputs.ready-label }}
+        INPUT_MERGE_METHOD: ${{ inputs.merge-method }}
+        INPUT_TRANSACTION_CHECKS: ${{ inputs.transaction-checks }}
+        INPUT_STATE_CHECKS: ${{ inputs.state-checks }}
+        INPUT_FORMAT: ${{ inputs.format }}
       run: |
         set +e
 
-        # Always run the checked, generated runtime shipped with the Action.
-        BIN="node ${GITHUB_ACTION_PATH}/dist/repo-guard.mjs"
+        if [ "$INPUT_MODE" = "portable-coordinator" ]; then
+          # Privileged coordinator inputs stay data: build argv as a Bash array.
+          CMD=(node "${GITHUB_ACTION_PATH}/dist/repo-guard.mjs" portable-coordinator)
 
-        # Build the command
-        CMD="$BIN"
-
-        # Append --repo-root if provided; fall back to GITHUB_WORKSPACE
-        REPO_ROOT="${{ inputs.repo-root }}"
-        if [ -z "$REPO_ROOT" ]; then
-          REPO_ROOT="${GITHUB_WORKSPACE:-$PWD}"
-        fi
-        CMD="$CMD --repo-root $REPO_ROOT"
-
-        # Append enforcement behavior and command mode / sub-command
-        ENFORCEMENT="${{ inputs.enforcement }}"
-        if [ -n "$ENFORCEMENT" ]; then
-          CMD="$CMD --enforcement $ENFORCEMENT"
-        fi
-
-        MODE="${{ inputs.mode }}"
-        CMD="$CMD $MODE"
-
-        # Append check-diff specific flags
-        if [ "$MODE" = "check-diff" ]; then
-          if [ -n "${{ inputs.base }}" ]; then
-            CMD="$CMD --base ${{ inputs.base }}"
+          if [ -n "$INPUT_REPOSITORY" ]; then
+            CMD+=(--repository "$INPUT_REPOSITORY")
           fi
-          if [ -n "${{ inputs.head }}" ]; then
-            CMD="$CMD --head ${{ inputs.head }}"
-          fi
-          if [ -n "${{ inputs.change-intent }}" ]; then
-            CMD="$CMD --change-intent ${{ inputs.change-intent }}"
-          fi
-        fi
+          CMD+=(--ready-label "$INPUT_READY_LABEL")
+          CMD+=(--merge-method "$INPUT_MERGE_METHOD")
+          CMD+=(--format "$INPUT_FORMAT")
 
-        echo "Running: $CMD"
-        OUTPUT=$($CMD 2>&1)
-        EXIT_CODE=$?
+          while IFS= read -r CHECK; do
+            if [ -n "$CHECK" ]; then
+              CMD+=(--transaction-check "$CHECK")
+            fi
+          done <<< "$INPUT_TRANSACTION_CHECKS"
+
+          while IFS= read -r CHECK; do
+            if [ -n "$CHECK" ]; then
+              CMD+=(--state-check "$CHECK")
+            fi
+          done <<< "$INPUT_STATE_CHECKS"
+
+          echo "Running portable coordinator"
+          OUTPUT=$("${CMD[@]}" 2>&1)
+          EXIT_CODE=$?
+        else
+          # Always run the checked, generated runtime shipped with the Action.
+          BIN="node ${GITHUB_ACTION_PATH}/dist/repo-guard.mjs"
+
+          # Build the command
+          CMD="$BIN"
+
+          # Append --repo-root if provided; fall back to GITHUB_WORKSPACE
+          REPO_ROOT="${{ inputs.repo-root }}"
+          if [ -z "$REPO_ROOT" ]; then
+            REPO_ROOT="${GITHUB_WORKSPACE:-$PWD}"
+          fi
+          CMD="$CMD --repo-root $REPO_ROOT"
+
+          # Append enforcement behavior and command mode / sub-command
+          ENFORCEMENT="${{ inputs.enforcement }}"
+          if [ -n "$ENFORCEMENT" ]; then
+            CMD="$CMD --enforcement $ENFORCEMENT"
+          fi
+
+          MODE="${{ inputs.mode }}"
+          CMD="$CMD $MODE"
+
+          # Append check-diff specific flags
+          if [ "$MODE" = "check-diff" ]; then
+            if [ -n "${{ inputs.base }}" ]; then
+              CMD="$CMD --base ${{ inputs.base }}"
+            fi
+            if [ -n "${{ inputs.head }}" ]; then
+              CMD="$CMD --head ${{ inputs.head }}"
+            fi
+            if [ -n "${{ inputs.change-intent }}" ]; then
+              CMD="$CMD --change-intent ${{ inputs.change-intent }}"
+            fi
+          fi
+
+          echo "Running: $CMD"
+          OUTPUT=$($CMD 2>&1)
+          EXIT_CODE=$?
+        fi
 
         echo "$OUTPUT"
 

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { runTrustedPortableCoordinator, } from "./trusted-command.mjs";
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const EXACT_SHA = /^[0-9a-f]{40}$/i;
 const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
 const FORMATS = new Set(["text", "json"]);
 const SINGLETON_OPTIONS = new Set(["--repository", "--ready-label", "--merge-method", "--format"]);
@@ -16,6 +17,12 @@ function normalizeChecks(values) {
 }
 function isObject(value) {
     return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function exactSha(value, label) {
+    if (typeof value !== "string" || !EXACT_SHA.test(value)) {
+        throw new Error(`malformed_github_response: ${label} must be an exact commit SHA`);
+    }
+    return value;
 }
 function defaultRun(command, args) {
     return execFileSync(command, args, {
@@ -48,6 +55,67 @@ function createReadyInventoryReader(repository, run) {
         return {
             complete: true,
             pages: pages.map((page) => page.map(normalizeInventoryItem)),
+        };
+    };
+}
+function createCandidateReader(repository, run) {
+    return async (prNumber) => {
+        const repositoryEndpoint = `repos/${repository}`;
+        const metadata = parseRuntimeJson(run("gh", ["api", repositoryEndpoint]), repositoryEndpoint);
+        if (!isObject(metadata) || typeof metadata.default_branch !== "string" || metadata.default_branch.length === 0) {
+            throw new Error("malformed_github_response: repository default_branch is required");
+        }
+        const branchEndpoint = `repos/${repository}/branches/${encodeURIComponent(metadata.default_branch)}`;
+        const branch = parseRuntimeJson(run("gh", ["api", branchEndpoint]), branchEndpoint);
+        if (!isObject(branch) || !isObject(branch.commit)) {
+            throw new Error("malformed_github_response: default branch commit is required");
+        }
+        const currentMainSha = exactSha(branch.commit.sha, "default branch commit sha");
+        const pullEndpoint = `repos/${repository}/pulls/${prNumber}`;
+        const pullRequest = parseRuntimeJson(run("gh", ["api", pullEndpoint]), pullEndpoint);
+        if (!isObject(pullRequest) || !isObject(pullRequest.head)) {
+            throw new Error("malformed_github_response: pull request head is required");
+        }
+        const headSha = exactSha(pullRequest.head.sha, "pull request head sha");
+        const compareEndpoint = `repos/${repository}/compare/${currentMainSha}...${headSha}`;
+        const comparison = parseRuntimeJson(run("gh", ["api", compareEndpoint]), compareEndpoint);
+        if (!isObject(comparison)) {
+            throw new Error("malformed_github_response: compare response must be an object");
+        }
+        const checksEndpoint = `repos/${repository}/commits/${headSha}/check-runs?filter=latest&per_page=100`;
+        const checkPages = parseRuntimeJson(run("gh", ["api", checksEndpoint, "--paginate", "--slurp"]), checksEndpoint);
+        if (!Array.isArray(checkPages) || checkPages.length === 0) {
+            throw new Error("malformed_github_response: check-runs pagination must be a non-empty array of pages");
+        }
+        let totalCount = null;
+        const runs = [];
+        for (const page of checkPages) {
+            if (!isObject(page) || !Number.isInteger(page.total_count) || page.total_count < 0 || !Array.isArray(page.check_runs)) {
+                throw new Error("malformed_github_response: each check-runs page requires total_count and check_runs");
+            }
+            if (totalCount === null)
+                totalCount = page.total_count;
+            else if (page.total_count !== totalCount) {
+                throw new Error("malformed_github_response: check-runs pages disagree on total_count");
+            }
+            runs.push(...page.check_runs);
+        }
+        if (runs.length !== totalCount) {
+            throw new Error("incomplete_github_response: check-runs pagination is incomplete");
+        }
+        return {
+            currentMainSha,
+            pullRequest,
+            compare: {
+                mainSha: currentMainSha,
+                headSha,
+                status: comparison.status,
+            },
+            checkRuns: {
+                complete: true,
+                headSha,
+                runs,
+            },
         };
     };
 }
@@ -153,7 +221,7 @@ export async function runPortableCoordinatorCommand(_roots, args, env = process.
     const readReadyInventory = dependencies.readReadyInventory
         ?? createReadyInventoryReader(parsed.value.repository, run);
     const readCandidate = dependencies.readCandidate
-        ?? (async () => { throw new Error("candidate GitHub runtime is not wired"); });
+        ?? createCandidateReader(parsed.value.repository, run);
     const evidence = await runTrustedPortableCoordinator({
         repository: parsed.value.repository,
         readyLabel: parsed.value.readyLabel,

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { runTrustedPortableCoordinator, } from "./trusted-command.mjs";
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
@@ -16,6 +17,13 @@ function normalizeChecks(values) {
 function isObject(value) {
     return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+function defaultRun(command, args) {
+    return execFileSync(command, args, {
+        encoding: "utf-8",
+        stdio: "pipe",
+        timeout: 30000,
+    });
+}
 function parseRuntimeJson(text, label) {
     try {
         return JSON.parse(text);
@@ -26,8 +34,6 @@ function parseRuntimeJson(text, label) {
     }
 }
 function createReadyInventoryReader(repository, run) {
-    if (run === undefined)
-        return undefined;
     return async () => {
         const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
         const pages = parseRuntimeJson(run("gh", ["api", endpoint, "--paginate", "--slurp"]), endpoint);
@@ -135,8 +141,9 @@ export async function runPortableCoordinatorCommand(_roots, args, env = process.
     const parsed = parsePortableCoordinatorArgs(args, env);
     if (!parsed.ok)
         throw new Error(`${parsed.error}: ${parsed.message}`);
+    const run = dependencies.run ?? defaultRun;
     const readReadyInventory = dependencies.readReadyInventory
-        ?? createReadyInventoryReader(parsed.value.repository, dependencies.run);
+        ?? createReadyInventoryReader(parsed.value.repository, run);
     const readCandidate = dependencies.readCandidate
         ?? (async () => { throw new Error("candidate GitHub runtime is not wired"); });
     const evidence = await runTrustedPortableCoordinator({

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -40,6 +40,12 @@ function parseRuntimeJson(text, label) {
         throw new Error(`malformed_github_response: ${label}: ${message}`);
     }
 }
+function processErrorOutput(error) {
+    if (!isObject(error) || typeof error.stdout !== "string" || error.stdout.length === 0) {
+        return null;
+    }
+    return error.stdout;
+}
 function parseIncludedGitHubResponse(output) {
     const separator = output.match(/\r?\n\r?\n/);
     if (separator === null || separator.index === undefined) {
@@ -147,7 +153,17 @@ function createMutationTransport(run) {
             for (const [key, value] of Object.entries(request.body)) {
                 args.push("--raw-field", `${key}=${value}`);
             }
-            return parseIncludedGitHubResponse(run("gh", args));
+            let output;
+            try {
+                output = run("gh", args);
+            }
+            catch (error) {
+                const recovered = processErrorOutput(error);
+                if (recovered === null)
+                    throw error;
+                output = recovered;
+            }
+            return parseIncludedGitHubResponse(output);
         },
     };
 }

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -1,0 +1,81 @@
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
+const FORMATS = new Set(["text", "json"]);
+const SINGLETON_OPTIONS = new Set(["--repository", "--ready-label", "--merge-method", "--format"]);
+const REPEATABLE_OPTIONS = new Set(["--transaction-check", "--state-check"]);
+function fail(error, message) {
+    return { ok: false, error, message };
+}
+function nonEmpty(value) {
+    return typeof value === "string" && value.length > 0;
+}
+function normalizeChecks(values) {
+    return [...new Set(values)].sort().map((name) => ({ name }));
+}
+export function parsePortableCoordinatorArgs(args, env = process.env) {
+    const singletons = new Map();
+    const transaction = [];
+    const state = [];
+    for (let index = 0; index < args.length; index++) {
+        const option = args[index];
+        if (!SINGLETON_OPTIONS.has(option) && !REPEATABLE_OPTIONS.has(option)) {
+            return fail("unknown_option", `unknown portable coordinator option: ${option}`);
+        }
+        const value = args[++index];
+        if (!nonEmpty(value) || value.startsWith("--")) {
+            return fail("missing_option_value", `${option} requires a value`);
+        }
+        if (option === "--transaction-check") {
+            transaction.push(value);
+            continue;
+        }
+        if (option === "--state-check") {
+            state.push(value);
+            continue;
+        }
+        if (singletons.has(option)) {
+            return fail("duplicate_option", `${option} may be specified only once`);
+        }
+        singletons.set(option, value);
+    }
+    const repository = singletons.get("--repository") ?? env.GITHUB_REPOSITORY;
+    if (!nonEmpty(repository)) {
+        return fail("missing_repository", "repository must be provided explicitly or by GITHUB_REPOSITORY");
+    }
+    if (!REPOSITORY.test(repository)) {
+        return fail("malformed_repository", "repository identity must be owner/name");
+    }
+    const readyLabel = singletons.get("--ready-label");
+    if (!nonEmpty(readyLabel)) {
+        return fail("missing_ready_label", "READY label must be provided explicitly");
+    }
+    const mergeMethod = singletons.get("--merge-method");
+    if (!nonEmpty(mergeMethod) || !MERGE_METHODS.has(mergeMethod)) {
+        return fail("invalid_merge_method", "merge method must be merge, squash, or rebase");
+    }
+    const transactionChecks = normalizeChecks(transaction);
+    if (transactionChecks.length === 0) {
+        return fail("missing_transaction_checks", "at least one transaction check is required");
+    }
+    const stateChecks = normalizeChecks(state);
+    if (stateChecks.length === 0) {
+        return fail("missing_state_checks", "at least one state check is required");
+    }
+    const rawFormat = singletons.get("--format") ?? "text";
+    if (!FORMATS.has(rawFormat)) {
+        return fail("invalid_format", "format must be text or json");
+    }
+    return {
+        ok: true,
+        value: {
+            repository,
+            readyLabel,
+            mergeMethod: mergeMethod,
+            requiredChecks: {
+                transaction: transactionChecks,
+                state: stateChecks,
+            },
+            format: rawFormat,
+        },
+    };
+}

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -79,3 +79,9 @@ export function parsePortableCoordinatorArgs(args, env = process.env) {
         },
     };
 }
+export async function runPortableCoordinatorCommand(_roots, args, env = process.env) {
+    const parsed = parsePortableCoordinatorArgs(args, env);
+    if (!parsed.ok)
+        throw new Error(`${parsed.error}: ${parsed.message}`);
+    throw new Error("portable coordinator runtime is not wired");
+}

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -33,6 +33,11 @@ function parseRuntimeJson(text, label) {
         throw new Error(`malformed_github_response: ${label}: ${message}`);
     }
 }
+function normalizeInventoryItem(value) {
+    if (!isObject(value) || value.mergeable !== undefined)
+        return value;
+    return { ...value, mergeable: null };
+}
 function createReadyInventoryReader(repository, run) {
     return async () => {
         const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
@@ -40,7 +45,10 @@ function createReadyInventoryReader(repository, run) {
         if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page))) {
             throw new Error("malformed_github_response: PR inventory pagination must be an array of pages");
         }
-        return { complete: true, pages };
+        return {
+            complete: true,
+            pages: pages.map((page) => page.map(normalizeInventoryItem)),
+        };
     };
 }
 function renderText(evidence) {

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -16,6 +16,27 @@ function normalizeChecks(values) {
 function isObject(value) {
     return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+function parseRuntimeJson(text, label) {
+    try {
+        return JSON.parse(text);
+    }
+    catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`malformed_github_response: ${label}: ${message}`);
+    }
+}
+function createReadyInventoryReader(repository, run) {
+    if (run === undefined)
+        return undefined;
+    return async () => {
+        const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
+        const pages = parseRuntimeJson(run("gh", ["api", endpoint, "--paginate", "--slurp"]), endpoint);
+        if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page))) {
+            throw new Error("malformed_github_response: PR inventory pagination must be an array of pages");
+        }
+        return { complete: true, pages };
+    };
+}
 function renderText(evidence) {
     const lines = [
         "repo-guard portable-coordinator",
@@ -114,13 +135,17 @@ export async function runPortableCoordinatorCommand(_roots, args, env = process.
     const parsed = parsePortableCoordinatorArgs(args, env);
     if (!parsed.ok)
         throw new Error(`${parsed.error}: ${parsed.message}`);
+    const readReadyInventory = dependencies.readReadyInventory
+        ?? createReadyInventoryReader(parsed.value.repository, dependencies.run);
+    const readCandidate = dependencies.readCandidate
+        ?? (async () => { throw new Error("candidate GitHub runtime is not wired"); });
     const evidence = await runTrustedPortableCoordinator({
         repository: parsed.value.repository,
         readyLabel: parsed.value.readyLabel,
         mergeMethod: parsed.value.mergeMethod,
         requiredChecks: parsed.value.requiredChecks,
-        readReadyInventory: dependencies.readReadyInventory,
-        readCandidate: dependencies.readCandidate,
+        readReadyInventory,
+        readCandidate,
         mutationTransport: dependencies.mutationTransport,
     });
     const output = parsed.value.format === "json"

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -40,6 +40,22 @@ function parseRuntimeJson(text, label) {
         throw new Error(`malformed_github_response: ${label}: ${message}`);
     }
 }
+function parseIncludedGitHubResponse(output) {
+    const separator = output.match(/\r?\n\r?\n/);
+    if (separator === null || separator.index === undefined) {
+        throw new Error("malformed_github_response: mutation response is missing HTTP headers");
+    }
+    const headers = output.slice(0, separator.index);
+    const statusMatch = headers.match(/^HTTP\/\S+\s+(\d{3})(?:\s|$)/m);
+    if (statusMatch === null) {
+        throw new Error("malformed_github_response: mutation response is missing HTTP status");
+    }
+    const bodyText = output.slice(separator.index + separator[0].length).trim();
+    return {
+        status: Number(statusMatch[1]),
+        body: bodyText.length === 0 ? null : parseRuntimeJson(bodyText, "mutation response body"),
+    };
+}
 function normalizeInventoryItem(value) {
     if (!isObject(value) || value.mergeable !== undefined)
         return value;
@@ -117,6 +133,22 @@ function createCandidateReader(repository, run) {
                 runs,
             },
         };
+    };
+}
+function createMutationTransport(run) {
+    return {
+        async request(request) {
+            const args = [
+                "api",
+                request.path.replace(/^\/+/, ""),
+                "--method", request.method,
+                "--include",
+            ];
+            for (const [key, value] of Object.entries(request.body)) {
+                args.push("--raw-field", `${key}=${value}`);
+            }
+            return parseIncludedGitHubResponse(run("gh", args));
+        },
     };
 }
 function renderText(evidence) {
@@ -222,6 +254,8 @@ export async function runPortableCoordinatorCommand(_roots, args, env = process.
         ?? createReadyInventoryReader(parsed.value.repository, run);
     const readCandidate = dependencies.readCandidate
         ?? createCandidateReader(parsed.value.repository, run);
+    const mutationTransport = dependencies.mutationTransport
+        ?? createMutationTransport(run);
     const evidence = await runTrustedPortableCoordinator({
         repository: parsed.value.repository,
         readyLabel: parsed.value.readyLabel,
@@ -229,7 +263,7 @@ export async function runPortableCoordinatorCommand(_roots, args, env = process.
         requiredChecks: parsed.value.requiredChecks,
         readReadyInventory,
         readCandidate,
-        mutationTransport: dependencies.mutationTransport,
+        mutationTransport,
     });
     const output = parsed.value.format === "json"
         ? JSON.stringify(evidence)

--- a/dist/portable-integration/public-command.mjs
+++ b/dist/portable-integration/public-command.mjs
@@ -1,3 +1,4 @@
+import { runTrustedPortableCoordinator, } from "./trusted-command.mjs";
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const MERGE_METHODS = new Set(["merge", "squash", "rebase"]);
 const FORMATS = new Set(["text", "json"]);
@@ -11,6 +12,36 @@ function nonEmpty(value) {
 }
 function normalizeChecks(values) {
     return [...new Set(values)].sort().map((name) => ({ name }));
+}
+function isObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function renderText(evidence) {
+    const lines = [
+        "repo-guard portable-coordinator",
+        `provider: ${evidence.provider}`,
+        `kind: ${evidence.kind}`,
+        `repository: ${evidence.repository ?? "unknown"}`,
+        `main_sha: ${evidence.main_sha ?? "unknown"}`,
+        `pr: ${evidence.pr ?? "none"}`,
+        `head_sha: ${evidence.head_sha ?? "unknown"}`,
+        `decision: ${evidence.decision ?? "none"}`,
+        `mutation: ${evidence.mutation}`,
+    ];
+    if (evidence.reason !== null)
+        lines.push(`reason: ${evidence.reason}`);
+    if (evidence.error !== undefined)
+        lines.push(`error: ${evidence.error}`);
+    if (evidence.message !== undefined)
+        lines.push(`message: ${evidence.message}`);
+    return lines.join("\n");
+}
+function exitCode(evidence) {
+    if (evidence.error !== undefined)
+        return 1;
+    if (isObject(evidence.result) && evidence.result.ok === false)
+        return 1;
+    return 0;
 }
 export function parsePortableCoordinatorArgs(args, env = process.env) {
     const singletons = new Map();
@@ -79,9 +110,22 @@ export function parsePortableCoordinatorArgs(args, env = process.env) {
         },
     };
 }
-export async function runPortableCoordinatorCommand(_roots, args, env = process.env) {
+export async function runPortableCoordinatorCommand(_roots, args, env = process.env, dependencies = {}) {
     const parsed = parsePortableCoordinatorArgs(args, env);
     if (!parsed.ok)
         throw new Error(`${parsed.error}: ${parsed.message}`);
-    throw new Error("portable coordinator runtime is not wired");
+    const evidence = await runTrustedPortableCoordinator({
+        repository: parsed.value.repository,
+        readyLabel: parsed.value.readyLabel,
+        mergeMethod: parsed.value.mergeMethod,
+        requiredChecks: parsed.value.requiredChecks,
+        readReadyInventory: dependencies.readReadyInventory,
+        readCandidate: dependencies.readCandidate,
+        mutationTransport: dependencies.mutationTransport,
+    });
+    const output = parsed.value.format === "json"
+        ? JSON.stringify(evidence)
+        : renderText(evidence);
+    (dependencies.writeOutput ?? console.log)(output);
+    return exitCode(evidence);
 }

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -39,6 +39,10 @@ const COMMAND_SPECS = {
                 ? runParallelDoctor(roots, args)
                 : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
     },
+    "portable-coordinator": {
+        options: valueOptions("--repository", "--ready-label", "--merge-method", "--transaction-check", "--state-check", "--format"), positionals: 0,
+        run: async () => { throw new Error("portable coordinator runtime is not wired"); },
+    },
     "validate-integration": {
         options: valueOptions("--format"), positionals: 0,
         run: async (roots, args) => (await import("./integration-validator.mjs")).runValidateIntegration(roots, args),

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -3,6 +3,7 @@ import { realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runParallelDoctor } from "./parallel-doctor.mjs";
+import { runPortableCoordinatorCommand } from "./portable-integration/public-command.mjs";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
 const valueOptions = (...names) => Object.fromEntries(names.map((name) => [name, true]));
@@ -41,7 +42,7 @@ const COMMAND_SPECS = {
     },
     "portable-coordinator": {
         options: valueOptions("--repository", "--ready-label", "--merge-method", "--transaction-check", "--state-check", "--format"), positionals: 0,
-        run: async () => { throw new Error("portable coordinator runtime is not wired"); },
+        run: (roots, args) => runPortableCoordinatorCommand(roots, args),
     },
     "validate-integration": {
         options: valueOptions("--format"), positionals: 0,

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -33,6 +33,7 @@ type RuntimeDependencies = {
 export type PortableCoordinatorArgsResult = Failure | Success;
 
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const EXACT_SHA = /^[0-9a-f]{40}$/i;
 const MERGE_METHODS = new Set<MergeMethod>(["merge", "squash", "rebase"]);
 const FORMATS = new Set<OutputFormat>(["text", "json"]);
 const SINGLETON_OPTIONS = new Set(["--repository", "--ready-label", "--merge-method", "--format"]);
@@ -52,6 +53,13 @@ function normalizeChecks(values: string[]): RequiredCheck[] {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactSha(value: unknown, label: string): string {
+  if (typeof value !== "string" || !EXACT_SHA.test(value)) {
+    throw new Error(`malformed_github_response: ${label} must be an exact commit SHA`);
+  }
+  return value;
 }
 
 function defaultRun(command: string, args: string[]): string {
@@ -89,6 +97,88 @@ function createReadyInventoryReader(repository: string, run: RunCommand) {
     return {
       complete: true,
       pages: pages.map((page) => (page as unknown[]).map(normalizeInventoryItem)),
+    };
+  };
+}
+
+function createCandidateReader(repository: string, run: RunCommand) {
+  return async (prNumber: number) => {
+    const repositoryEndpoint = `repos/${repository}`;
+    const metadata = parseRuntimeJson(
+      run("gh", ["api", repositoryEndpoint]),
+      repositoryEndpoint,
+    );
+    if (!isObject(metadata) || typeof metadata.default_branch !== "string" || metadata.default_branch.length === 0) {
+      throw new Error("malformed_github_response: repository default_branch is required");
+    }
+
+    const branchEndpoint = `repos/${repository}/branches/${encodeURIComponent(metadata.default_branch)}`;
+    const branch = parseRuntimeJson(
+      run("gh", ["api", branchEndpoint]),
+      branchEndpoint,
+    );
+    if (!isObject(branch) || !isObject(branch.commit)) {
+      throw new Error("malformed_github_response: default branch commit is required");
+    }
+    const currentMainSha = exactSha(branch.commit.sha, "default branch commit sha");
+
+    const pullEndpoint = `repos/${repository}/pulls/${prNumber}`;
+    const pullRequest = parseRuntimeJson(
+      run("gh", ["api", pullEndpoint]),
+      pullEndpoint,
+    );
+    if (!isObject(pullRequest) || !isObject(pullRequest.head)) {
+      throw new Error("malformed_github_response: pull request head is required");
+    }
+    const headSha = exactSha(pullRequest.head.sha, "pull request head sha");
+
+    const compareEndpoint = `repos/${repository}/compare/${currentMainSha}...${headSha}`;
+    const comparison = parseRuntimeJson(
+      run("gh", ["api", compareEndpoint]),
+      compareEndpoint,
+    );
+    if (!isObject(comparison)) {
+      throw new Error("malformed_github_response: compare response must be an object");
+    }
+
+    const checksEndpoint = `repos/${repository}/commits/${headSha}/check-runs?filter=latest&per_page=100`;
+    const checkPages = parseRuntimeJson(
+      run("gh", ["api", checksEndpoint, "--paginate", "--slurp"]),
+      checksEndpoint,
+    );
+    if (!Array.isArray(checkPages) || checkPages.length === 0) {
+      throw new Error("malformed_github_response: check-runs pagination must be a non-empty array of pages");
+    }
+
+    let totalCount: number | null = null;
+    const runs: unknown[] = [];
+    for (const page of checkPages) {
+      if (!isObject(page) || !Number.isInteger(page.total_count) || (page.total_count as number) < 0 || !Array.isArray(page.check_runs)) {
+        throw new Error("malformed_github_response: each check-runs page requires total_count and check_runs");
+      }
+      if (totalCount === null) totalCount = page.total_count as number;
+      else if (page.total_count !== totalCount) {
+        throw new Error("malformed_github_response: check-runs pages disagree on total_count");
+      }
+      runs.push(...page.check_runs);
+    }
+    if (runs.length !== totalCount) {
+      throw new Error("incomplete_github_response: check-runs pagination is incomplete");
+    }
+
+    return {
+      currentMainSha,
+      pullRequest,
+      compare: {
+        mainSha: currentMainSha,
+        headSha,
+        status: comparison.status,
+      },
+      checkRuns: {
+        complete: true,
+        headSha,
+        runs,
+      },
     };
   };
 }
@@ -209,7 +299,7 @@ export async function runPortableCoordinatorCommand(
   const readReadyInventory = dependencies.readReadyInventory
     ?? createReadyInventoryReader(parsed.value.repository, run);
   const readCandidate = dependencies.readCandidate
-    ?? (async () => { throw new Error("candidate GitHub runtime is not wired"); });
+    ?? createCandidateReader(parsed.value.repository, run);
 
   const evidence = await runTrustedPortableCoordinator({
     repository: parsed.value.repository,

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -20,7 +20,9 @@ type Success = {
     format: OutputFormat;
   };
 };
+type RunCommand = (command: string, args: string[]) => string;
 type RuntimeDependencies = {
+  run?: RunCommand;
   readReadyInventory?: () => Promise<unknown>;
   readCandidate?: (prNumber: number) => Promise<unknown>;
   mutationTransport?: unknown;
@@ -49,6 +51,30 @@ function normalizeChecks(values: string[]): RequiredCheck[] {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseRuntimeJson(text: string, label: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`malformed_github_response: ${label}: ${message}`);
+  }
+}
+
+function createReadyInventoryReader(repository: string, run: RunCommand | undefined) {
+  if (run === undefined) return undefined;
+  return async () => {
+    const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
+    const pages = parseRuntimeJson(
+      run("gh", ["api", endpoint, "--paginate", "--slurp"]),
+      endpoint,
+    );
+    if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page))) {
+      throw new Error("malformed_github_response: PR inventory pagination must be an array of pages");
+    }
+    return { complete: true, pages };
+  };
 }
 
 function renderText(evidence: TrustedPortableCoordinatorEvidence): string {
@@ -163,13 +189,18 @@ export async function runPortableCoordinatorCommand(
   const parsed = parsePortableCoordinatorArgs(args, env);
   if (!parsed.ok) throw new Error(`${parsed.error}: ${parsed.message}`);
 
+  const readReadyInventory = dependencies.readReadyInventory
+    ?? createReadyInventoryReader(parsed.value.repository, dependencies.run);
+  const readCandidate = dependencies.readCandidate
+    ?? (async () => { throw new Error("candidate GitHub runtime is not wired"); });
+
   const evidence = await runTrustedPortableCoordinator({
     repository: parsed.value.repository,
     readyLabel: parsed.value.readyLabel,
     mergeMethod: parsed.value.mergeMethod,
     requiredChecks: parsed.value.requiredChecks,
-    readReadyInventory: dependencies.readReadyInventory,
-    readCandidate: dependencies.readCandidate,
+    readReadyInventory,
+    readCandidate,
     mutationTransport: dependencies.mutationTransport,
   });
 

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -114,3 +114,13 @@ export function parsePortableCoordinatorArgs(
     },
   };
 }
+
+export async function runPortableCoordinatorCommand(
+  _roots: unknown,
+  args: string[],
+  env: Record<string, string | undefined> = process.env,
+): Promise<number> {
+  const parsed = parsePortableCoordinatorArgs(args, env);
+  if (!parsed.ok) throw new Error(`${parsed.error}: ${parsed.message}`);
+  throw new Error("portable coordinator runtime is not wired");
+}

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -22,6 +22,11 @@ type Success = {
   };
 };
 type RunCommand = (command: string, args: string[]) => string;
+type GitHubMutationRequest = {
+  method: "PUT";
+  path: string;
+  body: Record<string, string>;
+};
 type RuntimeDependencies = {
   run?: RunCommand;
   readReadyInventory?: () => Promise<unknown>;
@@ -77,6 +82,23 @@ function parseRuntimeJson(text: string, label: string): unknown {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`malformed_github_response: ${label}: ${message}`);
   }
+}
+
+function parseIncludedGitHubResponse(output: string): { status: number; body: unknown } {
+  const separator = output.match(/\r?\n\r?\n/);
+  if (separator === null || separator.index === undefined) {
+    throw new Error("malformed_github_response: mutation response is missing HTTP headers");
+  }
+  const headers = output.slice(0, separator.index);
+  const statusMatch = headers.match(/^HTTP\/\S+\s+(\d{3})(?:\s|$)/m);
+  if (statusMatch === null) {
+    throw new Error("malformed_github_response: mutation response is missing HTTP status");
+  }
+  const bodyText = output.slice(separator.index + separator[0].length).trim();
+  return {
+    status: Number(statusMatch[1]),
+    body: bodyText.length === 0 ? null : parseRuntimeJson(bodyText, "mutation response body"),
+  };
 }
 
 function normalizeInventoryItem(value: unknown): unknown {
@@ -180,6 +202,23 @@ function createCandidateReader(repository: string, run: RunCommand) {
         runs,
       },
     };
+  };
+}
+
+function createMutationTransport(run: RunCommand) {
+  return {
+    async request(request: GitHubMutationRequest) {
+      const args = [
+        "api",
+        request.path.replace(/^\/+/, ""),
+        "--method", request.method,
+        "--include",
+      ];
+      for (const [key, value] of Object.entries(request.body)) {
+        args.push("--raw-field", `${key}=${value}`);
+      }
+      return parseIncludedGitHubResponse(run("gh", args));
+    },
   };
 }
 
@@ -300,6 +339,8 @@ export async function runPortableCoordinatorCommand(
     ?? createReadyInventoryReader(parsed.value.repository, run);
   const readCandidate = dependencies.readCandidate
     ?? createCandidateReader(parsed.value.repository, run);
+  const mutationTransport = dependencies.mutationTransport
+    ?? createMutationTransport(run);
 
   const evidence = await runTrustedPortableCoordinator({
     repository: parsed.value.repository,
@@ -308,7 +349,7 @@ export async function runPortableCoordinatorCommand(
     requiredChecks: parsed.value.requiredChecks,
     readReadyInventory,
     readCandidate,
-    mutationTransport: dependencies.mutationTransport,
+    mutationTransport,
   });
 
   const output = parsed.value.format === "json"

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -1,3 +1,8 @@
+import {
+  runTrustedPortableCoordinator,
+  type TrustedPortableCoordinatorEvidence,
+} from "./trusted-command.mjs";
+
 type MergeMethod = "merge" | "squash" | "rebase";
 type OutputFormat = "text" | "json";
 type RequiredCheck = { name: string };
@@ -14,6 +19,12 @@ type Success = {
     };
     format: OutputFormat;
   };
+};
+type RuntimeDependencies = {
+  readReadyInventory?: () => Promise<unknown>;
+  readCandidate?: (prNumber: number) => Promise<unknown>;
+  mutationTransport?: unknown;
+  writeOutput?: (text: string) => void;
 };
 
 export type PortableCoordinatorArgsResult = Failure | Success;
@@ -34,6 +45,34 @@ function nonEmpty(value: string | undefined): value is string {
 
 function normalizeChecks(values: string[]): RequiredCheck[] {
   return [...new Set(values)].sort().map((name) => ({ name }));
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function renderText(evidence: TrustedPortableCoordinatorEvidence): string {
+  const lines = [
+    "repo-guard portable-coordinator",
+    `provider: ${evidence.provider}`,
+    `kind: ${evidence.kind}`,
+    `repository: ${evidence.repository ?? "unknown"}`,
+    `main_sha: ${evidence.main_sha ?? "unknown"}`,
+    `pr: ${evidence.pr ?? "none"}`,
+    `head_sha: ${evidence.head_sha ?? "unknown"}`,
+    `decision: ${evidence.decision ?? "none"}`,
+    `mutation: ${evidence.mutation}`,
+  ];
+  if (evidence.reason !== null) lines.push(`reason: ${evidence.reason}`);
+  if (evidence.error !== undefined) lines.push(`error: ${evidence.error}`);
+  if (evidence.message !== undefined) lines.push(`message: ${evidence.message}`);
+  return lines.join("\n");
+}
+
+function exitCode(evidence: TrustedPortableCoordinatorEvidence): number {
+  if (evidence.error !== undefined) return 1;
+  if (isObject(evidence.result) && evidence.result.ok === false) return 1;
+  return 0;
 }
 
 export function parsePortableCoordinatorArgs(
@@ -119,8 +158,24 @@ export async function runPortableCoordinatorCommand(
   _roots: unknown,
   args: string[],
   env: Record<string, string | undefined> = process.env,
+  dependencies: RuntimeDependencies = {},
 ): Promise<number> {
   const parsed = parsePortableCoordinatorArgs(args, env);
   if (!parsed.ok) throw new Error(`${parsed.error}: ${parsed.message}`);
-  throw new Error("portable coordinator runtime is not wired");
+
+  const evidence = await runTrustedPortableCoordinator({
+    repository: parsed.value.repository,
+    readyLabel: parsed.value.readyLabel,
+    mergeMethod: parsed.value.mergeMethod,
+    requiredChecks: parsed.value.requiredChecks,
+    readReadyInventory: dependencies.readReadyInventory,
+    readCandidate: dependencies.readCandidate,
+    mutationTransport: dependencies.mutationTransport,
+  });
+
+  const output = parsed.value.format === "json"
+    ? JSON.stringify(evidence)
+    : renderText(evidence);
+  (dependencies.writeOutput ?? console.log)(output);
+  return exitCode(evidence);
 }

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   runTrustedPortableCoordinator,
   type TrustedPortableCoordinatorEvidence,
@@ -53,6 +54,14 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function defaultRun(command: string, args: string[]): string {
+  return execFileSync(command, args, {
+    encoding: "utf-8",
+    stdio: "pipe",
+    timeout: 30000,
+  });
+}
+
 function parseRuntimeJson(text: string, label: string): unknown {
   try {
     return JSON.parse(text);
@@ -62,8 +71,7 @@ function parseRuntimeJson(text: string, label: string): unknown {
   }
 }
 
-function createReadyInventoryReader(repository: string, run: RunCommand | undefined) {
-  if (run === undefined) return undefined;
+function createReadyInventoryReader(repository: string, run: RunCommand) {
   return async () => {
     const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
     const pages = parseRuntimeJson(
@@ -189,8 +197,9 @@ export async function runPortableCoordinatorCommand(
   const parsed = parsePortableCoordinatorArgs(args, env);
   if (!parsed.ok) throw new Error(`${parsed.error}: ${parsed.message}`);
 
+  const run = dependencies.run ?? defaultRun;
   const readReadyInventory = dependencies.readReadyInventory
-    ?? createReadyInventoryReader(parsed.value.repository, dependencies.run);
+    ?? createReadyInventoryReader(parsed.value.repository, run);
   const readCandidate = dependencies.readCandidate
     ?? (async () => { throw new Error("candidate GitHub runtime is not wired"); });
 

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -71,6 +71,11 @@ function parseRuntimeJson(text: string, label: string): unknown {
   }
 }
 
+function normalizeInventoryItem(value: unknown): unknown {
+  if (!isObject(value) || value.mergeable !== undefined) return value;
+  return { ...value, mergeable: null };
+}
+
 function createReadyInventoryReader(repository: string, run: RunCommand) {
   return async () => {
     const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
@@ -81,7 +86,10 @@ function createReadyInventoryReader(repository: string, run: RunCommand) {
     if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page))) {
       throw new Error("malformed_github_response: PR inventory pagination must be an array of pages");
     }
-    return { complete: true, pages };
+    return {
+      complete: true,
+      pages: pages.map((page) => (page as unknown[]).map(normalizeInventoryItem)),
+    };
   };
 }
 

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -1,0 +1,116 @@
+type MergeMethod = "merge" | "squash" | "rebase";
+type OutputFormat = "text" | "json";
+type RequiredCheck = { name: string };
+type Failure = { ok: false; error: string; message: string };
+type Success = {
+  ok: true;
+  value: {
+    repository: string;
+    readyLabel: string;
+    mergeMethod: MergeMethod;
+    requiredChecks: {
+      transaction: RequiredCheck[];
+      state: RequiredCheck[];
+    };
+    format: OutputFormat;
+  };
+};
+
+export type PortableCoordinatorArgsResult = Failure | Success;
+
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MERGE_METHODS = new Set<MergeMethod>(["merge", "squash", "rebase"]);
+const FORMATS = new Set<OutputFormat>(["text", "json"]);
+const SINGLETON_OPTIONS = new Set(["--repository", "--ready-label", "--merge-method", "--format"]);
+const REPEATABLE_OPTIONS = new Set(["--transaction-check", "--state-check"]);
+
+function fail(error: string, message: string): Failure {
+  return { ok: false, error, message };
+}
+
+function nonEmpty(value: string | undefined): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function normalizeChecks(values: string[]): RequiredCheck[] {
+  return [...new Set(values)].sort().map((name) => ({ name }));
+}
+
+export function parsePortableCoordinatorArgs(
+  args: string[],
+  env: Record<string, string | undefined> = process.env,
+): PortableCoordinatorArgsResult {
+  const singletons = new Map<string, string>();
+  const transaction: string[] = [];
+  const state: string[] = [];
+
+  for (let index = 0; index < args.length; index++) {
+    const option = args[index];
+    if (!SINGLETON_OPTIONS.has(option) && !REPEATABLE_OPTIONS.has(option)) {
+      return fail("unknown_option", `unknown portable coordinator option: ${option}`);
+    }
+    const value = args[++index];
+    if (!nonEmpty(value) || value.startsWith("--")) {
+      return fail("missing_option_value", `${option} requires a value`);
+    }
+
+    if (option === "--transaction-check") {
+      transaction.push(value);
+      continue;
+    }
+    if (option === "--state-check") {
+      state.push(value);
+      continue;
+    }
+    if (singletons.has(option)) {
+      return fail("duplicate_option", `${option} may be specified only once`);
+    }
+    singletons.set(option, value);
+  }
+
+  const repository = singletons.get("--repository") ?? env.GITHUB_REPOSITORY;
+  if (!nonEmpty(repository)) {
+    return fail("missing_repository", "repository must be provided explicitly or by GITHUB_REPOSITORY");
+  }
+  if (!REPOSITORY.test(repository)) {
+    return fail("malformed_repository", "repository identity must be owner/name");
+  }
+
+  const readyLabel = singletons.get("--ready-label");
+  if (!nonEmpty(readyLabel)) {
+    return fail("missing_ready_label", "READY label must be provided explicitly");
+  }
+
+  const mergeMethod = singletons.get("--merge-method");
+  if (!nonEmpty(mergeMethod) || !MERGE_METHODS.has(mergeMethod as MergeMethod)) {
+    return fail("invalid_merge_method", "merge method must be merge, squash, or rebase");
+  }
+
+  const transactionChecks = normalizeChecks(transaction);
+  if (transactionChecks.length === 0) {
+    return fail("missing_transaction_checks", "at least one transaction check is required");
+  }
+  const stateChecks = normalizeChecks(state);
+  if (stateChecks.length === 0) {
+    return fail("missing_state_checks", "at least one state check is required");
+  }
+
+  const rawFormat = singletons.get("--format") ?? "text";
+  if (!FORMATS.has(rawFormat as OutputFormat)) {
+    return fail("invalid_format", "format must be text or json");
+  }
+
+  return {
+    ok: true,
+    value: {
+      repository,
+      readyLabel,
+      mergeMethod: mergeMethod as MergeMethod,
+      requiredChecks: {
+        transaction: transactionChecks,
+        state: stateChecks,
+      },
+      format: rawFormat as OutputFormat,
+    },
+  };
+}

--- a/src/portable-integration/public-command.mts
+++ b/src/portable-integration/public-command.mts
@@ -84,6 +84,13 @@ function parseRuntimeJson(text: string, label: string): unknown {
   }
 }
 
+function processErrorOutput(error: unknown): string | null {
+  if (!isObject(error) || typeof error.stdout !== "string" || error.stdout.length === 0) {
+    return null;
+  }
+  return error.stdout;
+}
+
 function parseIncludedGitHubResponse(output: string): { status: number; body: unknown } {
   const separator = output.match(/\r?\n\r?\n/);
   if (separator === null || separator.index === undefined) {
@@ -217,7 +224,16 @@ function createMutationTransport(run: RunCommand) {
       for (const [key, value] of Object.entries(request.body)) {
         args.push("--raw-field", `${key}=${value}`);
       }
-      return parseIncludedGitHubResponse(run("gh", args));
+
+      let output: string;
+      try {
+        output = run("gh", args);
+      } catch (error) {
+        const recovered = processErrorOutput(error);
+        if (recovered === null) throw error;
+        output = recovered;
+      }
+      return parseIncludedGitHubResponse(output);
     },
   };
 }

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -4,6 +4,7 @@ import { realpathSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runParallelDoctor } from "./parallel-doctor.mjs";
+import { runPortableCoordinatorCommand } from "./portable-integration/public-command.mjs";
 
 interface CliRoots {
   packageRoot: string;
@@ -57,7 +58,7 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
   },
   "portable-coordinator": {
     options: valueOptions("--repository", "--ready-label", "--merge-method", "--transaction-check", "--state-check", "--format"), positionals: 0,
-    run: async () => { throw new Error("portable coordinator runtime is not wired"); },
+    run: (roots, args) => runPortableCoordinatorCommand(roots, args),
   },
   "validate-integration": {
     options: valueOptions("--format"), positionals: 0,

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -55,6 +55,10 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
         ? runParallelDoctor(roots, args)
         : ((await import("./doctor.mjs")).runDoctor(roots).fails > 0 ? 1 : 0),
   },
+  "portable-coordinator": {
+    options: valueOptions("--repository", "--ready-label", "--merge-method", "--transaction-check", "--state-check", "--format"), positionals: 0,
+    run: async () => { throw new Error("portable coordinator runtime is not wired"); },
+  },
   "validate-integration": {
     options: valueOptions("--format"), positionals: 0,
     run: async (roots, args) => (await import("./integration-validator.mjs")).runValidateIntegration(roots, args),

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { COMMANDS, runCli } from "../dist/repo-guard.mjs";
+import { runPortableCoordinatorCommand } from "../dist/portable-integration/public-command.mjs";
 
 assert.equal(COMMANDS.includes("portable-coordinator"), true, "public CLI exposes portable-coordinator command");
 
@@ -17,4 +18,74 @@ try {
     errors.length = 0; assert.equal(await runCli(args), 1); assert.match(errors.join("\n"), pattern);
   }
 } finally { console.error = originalError; }
-console.log("Declarative CLI grammar returns errors without terminating imported callers.");
+
+const mainSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const headSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const mergeSha = "cccccccccccccccccccccccccccccccccccccccc";
+const mergePr = {
+  number: 7,
+  draft: false,
+  mergeable: true,
+  base: { ref: "main", sha: mainSha },
+  head: { ref: "feature", sha: headSha, repo: { full_name: "netkeep80/example" } },
+  labels: [{ name: "repo-guard:ready" }],
+};
+const mergeCalls = [];
+const mergeOutput = [];
+const mergeExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    readReadyInventory: async () => ({ complete: true, pages: [[mergePr]] }),
+    readCandidate: async () => ({
+      currentMainSha: mainSha,
+      pullRequest: mergePr,
+      compare: { mainSha, headSha, status: "ahead" },
+      checkRuns: {
+        complete: true,
+        headSha,
+        runs: [
+          { name: "tx", head_sha: headSha, status: "completed", conclusion: "success" },
+          { name: "state", head_sha: headSha, status: "completed", conclusion: "success" },
+        ],
+      },
+    }),
+    run: (command, args) => {
+      mergeCalls.push([command, args]);
+      return `HTTP/2 200 OK\ncontent-type: application/json\n\n${JSON.stringify({ merged: true, sha: mergeSha })}`;
+    },
+    writeOutput: (text) => mergeOutput.push(text),
+  },
+);
+assert.equal(mergeExit, 0, "public portable coordinator accepts a canonical exact-head merge");
+assert.deepEqual(mergeCalls, [[
+  "gh",
+  [
+    "api",
+    "repos/netkeep80/example/pulls/7/merge",
+    "--method", "PUT",
+    "--include",
+    "--raw-field", `sha=${headSha}`,
+    "--raw-field", "merge_method=squash",
+  ],
+]], "public mutation transport preserves exact merge head and merge method without a shell");
+const mergeEvidence = JSON.parse(mergeOutput[0]);
+assert.equal(mergeEvidence.decision, "merge");
+assert.equal(mergeEvidence.mutation, "merge");
+assert.deepEqual(mergeEvidence.result, {
+  ok: true,
+  kind: "merged",
+  expectedHeadSha: headSha,
+  mergeSha,
+  mergeMethod: "squash",
+});
+
+console.log("Declarative CLI grammar and exact public merge transport contract passed.");

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -10,6 +10,7 @@ const cases = [
   [["check-diff", "--base"], /--base requires a value/], [["check-diff", "--change-intent"], /--change-intent requires a value/],
   [["check-diff", "--contract", "legacy.json"], /Unknown option for check-diff/], [["check-pr", "extra"], /Unexpected argument for check-pr/],
   [["validate", "one.json", "two.json"], /Unexpected argument for validate/], [["init", "--bogus"], /Unknown option for init/],
+  [["portable-coordinator", "--repository", "not-a-repo", "--ready-label", "ready", "--merge-method", "merge", "--transaction-check", "tx", "--state-check", "state"], /malformed_repository/],
 ];
 try {
   for (const [args, pattern] of cases) {

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { runCli } from "../dist/repo-guard.mjs";
+import { COMMANDS, runCli } from "../dist/repo-guard.mjs";
+
+assert.equal(COMMANDS.includes("portable-coordinator"), true, "public CLI exposes portable-coordinator command");
 
 const originalError = console.error, errors = [];
 console.error = (...args) => errors.push(args.join(" "));

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -78,7 +78,7 @@ assert.deepEqual(mergeCalls, [[
   ],
 ]], "public mutation transport preserves exact merge head and merge method without a shell");
 const mergeEvidence = JSON.parse(mergeOutput[0]);
-assert.equal(mergeEvidence.decision, "merge");
+assert.equal(mergeEvidence.decision, "merge_exact_head");
 assert.equal(mergeEvidence.mutation, "merge");
 assert.deepEqual(mergeEvidence.result, {
   ok: true,

--- a/tests/test-cli-runtime.mjs
+++ b/tests/test-cli-runtime.mjs
@@ -79,7 +79,7 @@ assert.deepEqual(mergeCalls, [[
 ]], "public mutation transport preserves exact merge head and merge method without a shell");
 const mergeEvidence = JSON.parse(mergeOutput[0]);
 assert.equal(mergeEvidence.decision, "merge_exact_head");
-assert.equal(mergeEvidence.mutation, "merge");
+assert.equal(mergeEvidence.mutation, "merge_exact_head");
 assert.deepEqual(mergeEvidence.result, {
   ok: true,
   kind: "merged",

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -95,4 +95,35 @@ assert.deepEqual(JSON.parse(output[0]), {
   result: null,
 });
 
+const runtimeCalls = [];
+const runtimeOutput = [];
+const runtimeIdleExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    run: (command, args) => {
+      runtimeCalls.push([command, args]);
+      if (command === "gh" && args.join(" ") === "api repos/netkeep80/example/pulls?state=open&per_page=100 --paginate --slurp") {
+        return "[[]]";
+      }
+      throw new Error(`unexpected runtime command: ${command} ${args.join(" ")}`);
+    },
+    writeOutput: (text) => runtimeOutput.push(text),
+  },
+);
+assert.equal(runtimeIdleExit, 0, "default GitHub runtime can complete an empty READY inventory pass");
+assert.deepEqual(runtimeCalls, [[
+  "gh",
+  ["api", "repos/netkeep80/example/pulls?state=open&per_page=100", "--paginate", "--slurp"],
+]], "default GitHub runtime uses one complete read-only paginated PR inventory request");
+assert.equal(JSON.parse(runtimeOutput[0]).kind, "idle");
+
 console.log("Portable public coordinator trusted CLI parsing/runtime composition contract passed.");

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -349,6 +349,56 @@ assert.deepEqual(mutationEvidence.result, {
   rereadRequired: true,
 });
 
+let conflictCalls = 0;
+const conflictOutput = [];
+const conflictExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    readReadyInventory: async () => ({ complete: true, pages: [[mutationPr]] }),
+    readCandidate: async () => ({
+      currentMainSha: mutationMainSha,
+      pullRequest: mutationPr,
+      compare: {
+        mainSha: mutationMainSha,
+        headSha: mutationHeadSha,
+        status: "behind",
+      },
+      checkRuns: {
+        complete: true,
+        headSha: mutationHeadSha,
+        runs: [
+          { name: "tx", head_sha: mutationHeadSha, status: "completed", conclusion: "success" },
+          { name: "state", head_sha: mutationHeadSha, status: "completed", conclusion: "success" },
+        ],
+      },
+    }),
+    run: () => {
+      conflictCalls++;
+      const error = new Error("gh api returned 409");
+      error.stdout = "HTTP/2 409 Conflict\ncontent-type: application/json\n\n{\"message\":\"branch moved\"}";
+      throw error;
+    },
+    writeOutput: (text) => conflictOutput.push(text),
+  },
+);
+assert.equal(conflictExit, 1, "a canonical GitHub update conflict remains a non-zero coordinator result");
+assert.equal(conflictCalls, 1, "the default mutation transport performs exactly one GitHub mutation attempt");
+const conflictEvidence = JSON.parse(conflictOutput[0]);
+assert.deepEqual(conflictEvidence.result, {
+  ok: false,
+  error: "conflict",
+  message: "update-branch conflicts with current repository state: branch moved",
+}, "non-zero gh output is recovered as an HTTP response for the canonical writer");
+
 const fakeGhDir = mkdtempSync(join(tmpdir(), "repo-guard-p4c-gh-"));
 const fakeGhPath = join(fakeGhDir, "gh");
 writeFileSync(fakeGhPath, `#!/usr/bin/env node

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   parsePortableCoordinatorArgs,
+  runPortableCoordinatorCommand,
 } from "../dist/portable-integration/public-command.mjs";
 
 const explicit = parsePortableCoordinatorArgs([
@@ -54,4 +55,44 @@ for (const [label, args, env, error] of [
   assert.equal(result.ok ? null : result.error, error, label);
 }
 
-console.log("Portable public coordinator trusted CLI parsing contract passed.");
+const output = [];
+let candidateReads = 0;
+let mutations = 0;
+const idleExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    readReadyInventory: async () => ({ complete: true, pages: [[]] }),
+    readCandidate: async () => { candidateReads++; throw new Error("idle runtime must not read a candidate"); },
+    mutationTransport: {
+      request: async () => { mutations++; throw new Error("idle runtime must not mutate"); },
+    },
+    writeOutput: (text) => output.push(text),
+  },
+);
+assert.equal(idleExit, 0, "complete empty READY inventory is a successful idle pass");
+assert.equal(candidateReads, 0, "idle runtime performs no candidate reads");
+assert.equal(mutations, 0, "idle runtime performs no mutations");
+assert.equal(output.length, 1, "idle runtime emits one deterministic evidence document");
+assert.deepEqual(JSON.parse(output[0]), {
+  provider: "portable",
+  kind: "idle",
+  repository: "netkeep80/example",
+  main_sha: null,
+  pr: null,
+  head_sha: null,
+  decision: null,
+  reason: null,
+  mutation: "none",
+  result: null,
+});
+
+console.log("Portable public coordinator trusted CLI parsing/runtime composition contract passed.");

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -129,6 +129,48 @@ assert.deepEqual(runtimeCalls, [[
 ]], "injected GitHub runtime uses one complete read-only paginated PR inventory request");
 assert.equal(JSON.parse(runtimeOutput[0]).kind, "idle");
 
+const mainSha = "1111111111111111111111111111111111111111";
+const headSha = "2222222222222222222222222222222222222222";
+let realisticCandidateReads = 0;
+const realisticOutput = [];
+const realisticExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    run: (command, args) => {
+      if (command === "gh" && args.join(" ") === "api repos/netkeep80/example/pulls?state=open&per_page=100 --paginate --slurp") {
+        return JSON.stringify([[
+          {
+            number: 7,
+            draft: false,
+            base: { ref: "main", sha: mainSha },
+            head: { ref: "feature", sha: headSha, repo: { full_name: "netkeep80/example" } },
+            labels: [{ name: "repo-guard:ready" }],
+          },
+        ]]);
+      }
+      throw new Error(`unexpected realistic inventory command: ${command} ${args.join(" ")}`);
+    },
+    readCandidate: async (prNumber) => {
+      realisticCandidateReads++;
+      assert.equal(prNumber, 7);
+      throw new Error("candidate sentinel after inventory normalization");
+    },
+    writeOutput: (text) => realisticOutput.push(text),
+  },
+);
+assert.equal(realisticExit, 1, "candidate sentinel remains fail-closed");
+assert.equal(realisticCandidateReads, 1, "GitHub list payload without mergeable reaches candidate loading");
+assert.equal(JSON.parse(realisticOutput[0]).error, "candidate_load_error");
+
 const fakeGhDir = mkdtempSync(join(tmpdir(), "repo-guard-p4c-gh-"));
 const fakeGhPath = join(fakeGhDir, "gh");
 writeFileSync(fakeGhPath, `#!/usr/bin/env node

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   parsePortableCoordinatorArgs,
   runPortableCoordinatorCommand,
@@ -119,11 +122,44 @@ const runtimeIdleExit = await runPortableCoordinatorCommand(
     writeOutput: (text) => runtimeOutput.push(text),
   },
 );
-assert.equal(runtimeIdleExit, 0, "default GitHub runtime can complete an empty READY inventory pass");
+assert.equal(runtimeIdleExit, 0, "injected GitHub runtime can complete an empty READY inventory pass");
 assert.deepEqual(runtimeCalls, [[
   "gh",
   ["api", "repos/netkeep80/example/pulls?state=open&per_page=100", "--paginate", "--slurp"],
-]], "default GitHub runtime uses one complete read-only paginated PR inventory request");
+]], "injected GitHub runtime uses one complete read-only paginated PR inventory request");
 assert.equal(JSON.parse(runtimeOutput[0]).kind, "idle");
+
+const fakeGhDir = mkdtempSync(join(tmpdir(), "repo-guard-p4c-gh-"));
+const fakeGhPath = join(fakeGhDir, "gh");
+writeFileSync(fakeGhPath, `#!/usr/bin/env node
+const expected = ["api", "repos/netkeep80/example/pulls?state=open&per_page=100", "--paginate", "--slurp"];
+if (JSON.stringify(process.argv.slice(2)) !== JSON.stringify(expected)) process.exit(73);
+process.stdout.write("[[]]");
+`);
+chmodSync(fakeGhPath, 0o755);
+const originalPath = process.env.PATH;
+const defaultOutput = [];
+try {
+  process.env.PATH = `${fakeGhDir}:${originalPath ?? ""}`;
+  const defaultExit = await runPortableCoordinatorCommand(
+    {},
+    [
+      "--repository", "netkeep80/example",
+      "--ready-label", "repo-guard:ready",
+      "--merge-method", "squash",
+      "--transaction-check", "tx",
+      "--state-check", "state",
+      "--format", "json",
+    ],
+    {},
+    { writeOutput: (text) => defaultOutput.push(text) },
+  );
+  assert.equal(defaultExit, 0, "default runtime executes gh directly and completes an empty inventory pass");
+  assert.equal(JSON.parse(defaultOutput[0]).kind, "idle");
+} finally {
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  rmSync(fakeGhDir, { recursive: true, force: true });
+}
 
 console.log("Portable public coordinator trusted CLI parsing/runtime composition contract passed.");

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -275,6 +275,80 @@ assert.deepEqual(JSON.parse(candidateOutput[0]), {
   result: null,
 });
 
+const mutationMainSha = "3333333333333333333333333333333333333333";
+const mutationOldMainSha = "0000000000000000000000000000000000000000";
+const mutationHeadSha = "4444444444444444444444444444444444444444";
+const mutationCalls = [];
+const mutationOutput = [];
+const mutationPr = {
+  number: 7,
+  draft: false,
+  mergeable: true,
+  base: { ref: "main", sha: mutationOldMainSha },
+  head: { ref: "feature", sha: mutationHeadSha, repo: { full_name: "netkeep80/example" } },
+  labels: [{ name: "repo-guard:ready" }],
+};
+const mutationExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    readReadyInventory: async () => ({ complete: true, pages: [[mutationPr]] }),
+    readCandidate: async (prNumber) => {
+      assert.equal(prNumber, 7);
+      return {
+        currentMainSha: mutationMainSha,
+        pullRequest: mutationPr,
+        compare: {
+          mainSha: mutationMainSha,
+          headSha: mutationHeadSha,
+          status: "behind",
+        },
+        checkRuns: {
+          complete: true,
+          headSha: mutationHeadSha,
+          runs: [
+            { name: "tx", head_sha: mutationHeadSha, status: "completed", conclusion: "success" },
+            { name: "state", head_sha: mutationHeadSha, status: "completed", conclusion: "success" },
+          ],
+        },
+      };
+    },
+    run: (command, args) => {
+      mutationCalls.push([command, args]);
+      return "HTTP/2 202 Accepted\ncontent-type: application/json\n\n{\"message\":\"scheduled\"}";
+    },
+    writeOutput: (text) => mutationOutput.push(text),
+  },
+);
+assert.equal(mutationExit, 0, "default mutation transport accepts the canonical exact-head refresh");
+assert.deepEqual(mutationCalls, [[
+  "gh",
+  [
+    "api",
+    "repos/netkeep80/example/pulls/7/update-branch",
+    "--method", "PUT",
+    "--include",
+    "--raw-field", `expected_head_sha=${mutationHeadSha}`,
+  ],
+]], "default mutation transport preserves the exact update-branch request without a shell");
+const mutationEvidence = JSON.parse(mutationOutput[0]);
+assert.equal(mutationEvidence.decision, "refresh_branch");
+assert.equal(mutationEvidence.mutation, "refresh_branch");
+assert.deepEqual(mutationEvidence.result, {
+  ok: true,
+  kind: "update_accepted",
+  expectedHeadSha: mutationHeadSha,
+  rereadRequired: true,
+});
+
 const fakeGhDir = mkdtempSync(join(tmpdir(), "repo-guard-p4c-gh-"));
 const fakeGhPath = join(fakeGhDir, "gh");
 writeFileSync(fakeGhPath, `#!/usr/bin/env node

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -171,6 +171,110 @@ assert.equal(realisticExit, 1, "candidate sentinel remains fail-closed");
 assert.equal(realisticCandidateReads, 1, "GitHub list payload without mergeable reaches candidate loading");
 assert.equal(JSON.parse(realisticOutput[0]).error, "candidate_load_error");
 
+const candidateCalls = [];
+const candidateOutput = [];
+let candidateMutations = 0;
+const candidateWaitExit = await runPortableCoordinatorCommand(
+  {},
+  [
+    "--repository", "netkeep80/example",
+    "--ready-label", "repo-guard:ready",
+    "--merge-method", "squash",
+    "--transaction-check", "tx",
+    "--state-check", "state",
+    "--format", "json",
+  ],
+  {},
+  {
+    run: (command, args) => {
+      candidateCalls.push([command, args]);
+      const invocation = `${command} ${args.join(" ")}`;
+      if (invocation === "gh api repos/netkeep80/example/pulls?state=open&per_page=100 --paginate --slurp") {
+        return JSON.stringify([[
+          {
+            number: 7,
+            draft: false,
+            base: { ref: "main", sha: mainSha },
+            head: { ref: "feature", sha: headSha, repo: { full_name: "netkeep80/example" } },
+            labels: [{ name: "repo-guard:ready" }],
+          },
+        ]]);
+      }
+      if (invocation === "gh api repos/netkeep80/example") {
+        return JSON.stringify({ default_branch: "main" });
+      }
+      if (invocation === "gh api repos/netkeep80/example/branches/main") {
+        return JSON.stringify({ commit: { sha: mainSha } });
+      }
+      if (invocation === "gh api repos/netkeep80/example/pulls/7") {
+        return JSON.stringify({
+          number: 7,
+          draft: false,
+          mergeable: true,
+          base: { ref: "main", sha: mainSha },
+          head: { ref: "feature", sha: headSha, repo: { full_name: "netkeep80/example" } },
+          labels: [{ name: "repo-guard:ready" }],
+        });
+      }
+      if (invocation === `gh api repos/netkeep80/example/compare/${mainSha}...${headSha}`) {
+        return JSON.stringify({ status: "ahead" });
+      }
+      if (invocation === `gh api repos/netkeep80/example/commits/${headSha}/check-runs?filter=latest&per_page=100 --paginate --slurp`) {
+        return JSON.stringify([
+          {
+            total_count: 2,
+            check_runs: [{
+              name: "tx",
+              head_sha: headSha,
+              status: "completed",
+              conclusion: "success",
+            }],
+          },
+          {
+            total_count: 2,
+            check_runs: [{
+              name: "state",
+              head_sha: headSha,
+              status: "in_progress",
+              conclusion: null,
+            }],
+          },
+        ]);
+      }
+      throw new Error(`unexpected candidate runtime command: ${invocation}`);
+    },
+    mutationTransport: {
+      request: async () => {
+        candidateMutations++;
+        throw new Error("pending candidate must not mutate");
+      },
+    },
+    writeOutput: (text) => candidateOutput.push(text),
+  },
+);
+assert.equal(candidateWaitExit, 0, "default candidate reader keeps pending exact-head candidate as a non-error wait");
+assert.deepEqual(candidateCalls, [
+  ["gh", ["api", "repos/netkeep80/example/pulls?state=open&per_page=100", "--paginate", "--slurp"]],
+  ["gh", ["api", "repos/netkeep80/example"]],
+  ["gh", ["api", "repos/netkeep80/example/branches/main"]],
+  ["gh", ["api", "repos/netkeep80/example/pulls/7"]],
+  ["gh", ["api", `repos/netkeep80/example/compare/${mainSha}...${headSha}`]],
+  ["gh", ["api", `repos/netkeep80/example/commits/${headSha}/check-runs?filter=latest&per_page=100`, "--paginate", "--slurp"]],
+], "default candidate reader resolves default branch, exact main, PR head, compare, and complete check pages in order");
+assert.equal(candidateMutations, 0, "pending exact-head candidate performs no writes");
+assert.deepEqual(JSON.parse(candidateOutput[0]), {
+  provider: "portable",
+  kind: "observed",
+  repository: "netkeep80/example",
+  main_sha: mainSha,
+  pr: 7,
+  head_sha: headSha,
+  decision: "wait_for_checks",
+  reason: "checks_pending",
+  mutation: "none",
+  result: null,
+});
+
 const fakeGhDir = mkdtempSync(join(tmpdir(), "repo-guard-p4c-gh-"));
 const fakeGhPath = join(fakeGhDir, "gh");
 writeFileSync(fakeGhPath, `#!/usr/bin/env node

--- a/tests/test-portable-public-command.mjs
+++ b/tests/test-portable-public-command.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import {
+  parsePortableCoordinatorArgs,
+} from "../dist/portable-integration/public-command.mjs";
+
+const explicit = parsePortableCoordinatorArgs([
+  "--repository", "netkeep80/example",
+  "--ready-label", "repo-guard:ready",
+  "--merge-method", "squash",
+  "--transaction-check", "repo-guard / transaction",
+  "--transaction-check", "build",
+  "--transaction-check", "build",
+  "--state-check", "repo-guard / state",
+  "--state-check", "integration",
+  "--format", "json",
+], { GITHUB_REPOSITORY: "ignored/repository" });
+
+assert.deepEqual(explicit, {
+  ok: true,
+  value: {
+    repository: "netkeep80/example",
+    readyLabel: "repo-guard:ready",
+    mergeMethod: "squash",
+    requiredChecks: {
+      transaction: [{ name: "build" }, { name: "repo-guard / transaction" }],
+      state: [{ name: "integration" }, { name: "repo-guard / state" }],
+    },
+    format: "json",
+  },
+});
+
+const fromEnv = parsePortableCoordinatorArgs([
+  "--ready-label", "ready",
+  "--merge-method", "merge",
+  "--transaction-check", "tx",
+  "--state-check", "state",
+], { GITHUB_REPOSITORY: "netkeep80/from-env" });
+assert.equal(fromEnv.ok, true);
+assert.equal(fromEnv.ok && fromEnv.value.repository, "netkeep80/from-env");
+assert.equal(fromEnv.ok && fromEnv.value.format, "text");
+
+for (const [label, args, env, error] of [
+  ["missing repository", ["--ready-label", "ready", "--merge-method", "merge", "--transaction-check", "tx", "--state-check", "state"], {}, "missing_repository"],
+  ["malformed repository", ["--repository", "not-a-repo", "--ready-label", "ready", "--merge-method", "merge", "--transaction-check", "tx", "--state-check", "state"], {}, "malformed_repository"],
+  ["missing ready label", ["--repository", "netkeep80/example", "--merge-method", "merge", "--transaction-check", "tx", "--state-check", "state"], {}, "missing_ready_label"],
+  ["invalid merge method", ["--repository", "netkeep80/example", "--ready-label", "ready", "--merge-method", "octopus", "--transaction-check", "tx", "--state-check", "state"], {}, "invalid_merge_method"],
+  ["missing transaction checks", ["--repository", "netkeep80/example", "--ready-label", "ready", "--merge-method", "merge", "--state-check", "state"], {}, "missing_transaction_checks"],
+  ["missing state checks", ["--repository", "netkeep80/example", "--ready-label", "ready", "--merge-method", "merge", "--transaction-check", "tx"], {}, "missing_state_checks"],
+  ["invalid format", ["--repository", "netkeep80/example", "--ready-label", "ready", "--merge-method", "merge", "--transaction-check", "tx", "--state-check", "state", "--format", "yaml"], {}, "invalid_format"],
+  ["unknown option", ["--repository", "netkeep80/example", "--ready-label", "ready", "--merge-method", "merge", "--transaction-check", "tx", "--state-check", "state", "--from-git-remote", "yes"], {}, "unknown_option"],
+]) {
+  const result = parsePortableCoordinatorArgs(args, env);
+  assert.equal(result.ok, false, label);
+  assert.equal(result.ok ? null : result.error, error, label);
+}
+
+console.log("Portable public coordinator trusted CLI parsing contract passed.");

--- a/tests/test-portable-trusted-command-recovery.mjs
+++ b/tests/test-portable-trusted-command-recovery.mjs
@@ -286,7 +286,7 @@ console.log("\n--- trusted portable coordinator recovery/security contract ---")
   }
   expect("trusted command delegates all mutations to guarded write adapter", source.includes("createGitHubWriteAdapter"), true);
   expect("trusted command reuses canonical GitHub read normalizers", source.includes("normalizeGitHubReadyInventory") && source.includes("normalizeGitHubCandidate"), true);
-  expect("portable trusted command is not a public CLI command", COMMANDS.some((command) => command.includes("portable")), false);
+  expect("portable trusted coordinator is exposed as an explicit public CLI command", COMMANDS.includes("portable-coordinator"), true);
 }
 
 console.log(`\n${failures === 0 ? "All trusted portable recovery/security tests passed" : `${failures} test(s) failed`}`);

--- a/tests/test-typescript-source-cutover.mjs
+++ b/tests/test-typescript-source-cutover.mjs
@@ -53,4 +53,39 @@ describe("strict TypeScript source cutover", () => {
     assert.doesNotMatch(source, /\b(?:branch protection|ruleset|bypass|admin)\b/i);
     assert.doesNotMatch(source, /from\s+"\.\/portable-integration\/(?:planner|coordinator-loop)\.mjs"/);
   });
+
+  it("wires portable-coordinator Action inputs through a trusted shell-safe array", () => {
+    const action = readFileSync(resolve(root, "action.yml"), "utf-8");
+
+    for (const input of ["repository", "ready-label", "merge-method", "transaction-checks", "state-checks", "format"]) {
+      assert.match(action, new RegExp(`\\n  ${input}:\\n`), `Action exposes ${input}`);
+    }
+    assert.match(action, /portable-coordinator/);
+
+    for (const [envName, input] of [
+      ["INPUT_MODE", "mode"],
+      ["INPUT_REPOSITORY", "repository"],
+      ["INPUT_READY_LABEL", "ready-label"],
+      ["INPUT_MERGE_METHOD", "merge-method"],
+      ["INPUT_TRANSACTION_CHECKS", "transaction-checks"],
+      ["INPUT_STATE_CHECKS", "state-checks"],
+      ["INPUT_FORMAT", "format"],
+    ]) {
+      assert.match(action, new RegExp(`${envName}: \\$\\{\\{ inputs\\.${input} \\}\\}`));
+    }
+
+    assert.match(action, /if \[ "\$INPUT_MODE" = "portable-coordinator" \]; then/);
+    assert.match(action, /CMD=\(node "\$\{GITHUB_ACTION_PATH\}\/dist\/repo-guard\.mjs" portable-coordinator\)/);
+    assert.match(action, /CMD\+=\(--repository "\$INPUT_REPOSITORY"\)/);
+    assert.match(action, /CMD\+=\(--ready-label "\$INPUT_READY_LABEL"\)/);
+    assert.match(action, /CMD\+=\(--merge-method "\$INPUT_MERGE_METHOD"\)/);
+    assert.match(action, /CMD\+=\(--format "\$INPUT_FORMAT"\)/);
+    assert.match(action, /CMD\+=\(--transaction-check "\$CHECK"\)/);
+    assert.match(action, /done <<< "\$INPUT_TRANSACTION_CHECKS"/);
+    assert.match(action, /CMD\+=\(--state-check "\$CHECK"\)/);
+    assert.match(action, /done <<< "\$INPUT_STATE_CHECKS"/);
+    assert.match(action, /OUTPUT=\$\("\$\{CMD\[@\]\}" 2>&1\)/);
+
+    assert.match(action, /CMD="\$CMD --repo-root \$REPO_ROOT"/, "legacy Action branch remains present");
+  });
 });

--- a/tests/test-typescript-source-cutover.mjs
+++ b/tests/test-typescript-source-cutover.mjs
@@ -35,4 +35,22 @@ describe("strict TypeScript source cutover", () => {
   it("keeps the built CLI command inventory explicit", () => {
     assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "check-merge-group", "status", "init", "doctor", "portable-coordinator", "validate-integration"]);
   });
+
+  it("keeps the privileged portable coordinator on the trusted execFile control-plane boundary", () => {
+    const source = readFileSync(resolve(root, "src/portable-integration/public-command.mts"), "utf-8");
+
+    assert.match(source, /import \{ execFileSync \} from "node:child_process";/);
+    assert.match(source, /runTrustedPortableCoordinator\(\{/);
+    assert.match(source, /run\("gh", \["api",/);
+
+    assert.doesNotMatch(source, /\bexecSync\b/);
+    assert.doesNotMatch(source, /\b(?:exec|spawn|spawnSync)\s*\(/);
+    assert.doesNotMatch(source, /shell\s*:\s*true/);
+    assert.doesNotMatch(source, /run\("git"/);
+    assert.doesNotMatch(source, /git\s+(?:remote|merge|rebase|push)\b/);
+    assert.doesNotMatch(source, /actions\/checkout/);
+    assert.doesNotMatch(source, /npm\s+(?:test|run)\b/);
+    assert.doesNotMatch(source, /\b(?:branch protection|ruleset|bypass|admin)\b/i);
+    assert.doesNotMatch(source, /from\s+"\.\/portable-integration\/(?:planner|coordinator-loop)\.mjs"/);
+  });
 });

--- a/tests/test-typescript-source-cutover.mjs
+++ b/tests/test-typescript-source-cutover.mjs
@@ -33,6 +33,6 @@ describe("strict TypeScript source cutover", () => {
   });
 
   it("keeps the built CLI command inventory explicit", () => {
-    assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "check-merge-group", "status", "init", "doctor", "validate-integration"]);
+    assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "check-merge-group", "status", "init", "doctor", "portable-coordinator", "validate-integration"]);
   });
 });


### PR DESCRIPTION
## Краткое описание

P4c из #331: публикует уже существующий trusted portable coordinator через additive CLI/Action facade, не меняя coordinator semantics и не включая self-host/control-plane enforcement.

Работа идёт строго TDD: public command vocabulary уже введён после подтверждённого RED; текущий expected RED фиксирует explicit TypeScript-source CLI inventory, который должен быть синхронизирован с новым additive command перед переходом к отдельному public runtime adapter contract.

Closes #331.

## Намерение изменения

GovernanceGrant для `action.yml` явно выдан связанной issue #331 и ограничен additive public Action wiring режима `portable-coordinator`.

```repo-guard-yaml
change_type: feature
scope:
  - src/repo-guard.mts
  - src/portable-integration/public-command.mts
  - dist/repo-guard.mjs
  - dist/portable-integration/public-command.mjs
  - tests/test-cli-runtime.mjs
  - tests/test-portable-public-command.mjs
  - tests/test-portable-trusted-command-recovery.mjs
  - tests/test-typescript-source-cutover.mjs
  - action.yml
budgets: {}
anchors:
  affects:
    - "#331"
  implements:
    - "#331"
  verifies:
    - "#331"
must_touch:
  - src/repo-guard.mts
  - tests/test-cli-runtime.mjs
must_not_touch:
  - repo-policy.json
  - .github/workflows/**
  - schemas/**
  - src/init.mts
expected_effects:
  - Публичный trusted portable-coordinator переиспользует существующий serialized protocol и exact-head GitHub mutations.
  - Privileged runtime не использует checkout, project execution, git merge/rebase/push или protection bypass.
  - Legacy CLI и Action modes остаются совместимыми.
```
