### PR TITLE
[Parallel P4d2] Generate native merge-queue init scaffold

### DIFF
--- a/dist/init.mjs
+++ b/dist/init.mjs
@@ -10,46 +10,58 @@ const PRESETS = {
     tooling: ["tooling", ["*.bak"], ["README.md"], { max_new_docs: 2, max_new_files: 15, max_net_added_lines: 2000 }, [{ if_changed: ["src/**"], must_change_any: ["tests/**"] }]],
     documentation: ["documentation", [], ["README.md"], { max_new_docs: 10, max_new_files: 20 }, []],
 };
-function parallelIntegration(mode, ref) {
+function parallelIntegration(provider, mode, ref) {
     const ref_pinning = FULL_SHA.test(ref) ? "sha" : "tag";
-    return {
-        workflows: [
-            {
-                id: "repo-guard-pr-gate",
-                kind: "github_actions",
-                path: ".github/workflows/repo-guard.yml",
-                role: "repo_guard_pr_gate",
-                expect: {
-                    events: ["pull_request"],
-                    event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
-                    action: { uses: ACTION, ref_pinning },
-                    mode: "check-pr",
-                    enforcement: mode,
-                    permissions: { contents: "read", "pull-requests": "read", issues: "read" },
-                    token_env: ["GH_TOKEN"],
-                },
-            },
-            {
-                id: "repo-guard-portable-coordinator",
-                kind: "github_actions",
-                path: ".github/workflows/repo-guard-portable-coordinator.yml",
-                role: "repo_guard_portable_coordinator",
-                expect: {
-                    events: ["workflow_dispatch"],
-                    action: { uses: ACTION, ref_pinning },
-                    mode: "portable-coordinator",
-                    enforcement: "blocking",
-                    permissions: { contents: "write", "pull-requests": "write", checks: "read" },
-                    token_env: ["GH_TOKEN"],
-                },
-            },
-        ],
+    const transaction = {
+        id: "repo-guard-pr-gate",
+        kind: "github_actions",
+        path: ".github/workflows/repo-guard.yml",
+        role: "repo_guard_pr_gate",
+        expect: {
+            events: ["pull_request"],
+            event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
+            action: { uses: ACTION, ref_pinning },
+            mode: "check-pr",
+            enforcement: mode,
+            permissions: { contents: "read", "pull-requests": "read", issues: "read" },
+            token_env: ["GH_TOKEN"],
+        },
     };
+    const providerWorkflow = provider === "portable"
+        ? {
+            id: "repo-guard-portable-coordinator",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard-portable-coordinator.yml",
+            role: "repo_guard_portable_coordinator",
+            expect: {
+                events: ["workflow_dispatch"],
+                action: { uses: ACTION, ref_pinning },
+                mode: "portable-coordinator",
+                enforcement: "blocking",
+                permissions: { contents: "write", "pull-requests": "write", checks: "read" },
+                token_env: ["GH_TOKEN"],
+            },
+        }
+        : {
+            id: "repo-guard-merge-group",
+            kind: "github_actions",
+            path: ".github/workflows/repo-guard-merge-group.yml",
+            role: "repo_guard_merge_group_gate",
+            expect: {
+                events: ["merge_group"],
+                event_types: ["checks_requested"],
+                action: { uses: ACTION, ref_pinning },
+                mode: "check-merge-group",
+                enforcement: "blocking",
+                permissions: { contents: "read" },
+            },
+        };
+    return { workflows: [transaction, providerWorkflow] };
 }
 function buildPolicy(name, mode, parallel = null, ref = null) {
     const [repository_kind, forbidden, canonical_docs, diff_rules, cochange_rules] = PRESETS[name];
     const policy = { policy_format_version: "0.3.0", repository_kind, enforcement: { mode }, paths: { forbidden, canonical_docs, governance_paths: ["repo-policy.json"] }, diff_rules, content_rules: [], cochange_rules };
-    return parallel === "portable" && ref ? { ...policy, integration: parallelIntegration(mode, ref) } : policy;
+    return parallel && ref ? { ...policy, integration: parallelIntegration(parallel, mode, ref) } : policy;
 }
 function packageVersion(packageRoot) {
     const version = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf-8")).version;
@@ -139,6 +151,22 @@ jobs:
         env:
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 `;
+const nativeMergeGroupWorkflow = (ref) => `name: Merge-group state repo-guard
+on:
+  merge_group:
+    types: [checks_requested]
+permissions:
+  contents: read
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Проверить состояние merge-group
+        uses: ${ACTION}@${ref}
+        with: { mode: check-merge-group, enforcement: blocking }
+`;
 const prTemplate = () => `## Краткое описание
 
 ## Намерение изменения
@@ -202,7 +230,7 @@ function writeIfAbsent(path, content, created, skipped) {
     writeFileSync(path, content, "utf-8");
     created.push(path);
 }
-const usage = `Usage: repo-guard init --action-ref <40-char-sha|vX.Y.Z> [--preset <preset>] [--mode <mode>] [--parallel portable]\nPresets: application, library, tooling, documentation`;
+const usage = `Usage: repo-guard init --action-ref <40-char-sha|vX.Y.Z> [--preset <preset>] [--mode <mode>] [--parallel <portable|github_merge_queue>]\nPresets: application, library, tooling, documentation`;
 export function runInit(roots, args = []) {
     let preset = "application", mode = roots.enforcementMode || "enforce", actionRef = null, parallel = null;
     for (let i = 0; i < args.length; i++) {
@@ -213,7 +241,7 @@ export function runInit(roots, args = []) {
             else if (option === "--action-ref")
                 actionRef = value;
             else if (option === "--parallel") {
-                if (value !== "portable") {
+                if (value !== "portable" && value !== "github_merge_queue") {
                     console.error(`Unknown parallel provider: ${value}\n${usage}`);
                     return 1;
                 }
@@ -254,9 +282,11 @@ export function runInit(roots, args = []) {
     }
     const created = [], skipped = [], root = roots.repoRoot, ref = refCheck.ref;
     writeIfAbsent(resolve(root, "repo-policy.json"), `${JSON.stringify(buildPolicy(preset, enforcement.mode, parallel, ref), null, 2)}\n`, created, skipped);
-    writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), parallel === "portable" ? parallelTransactionWorkflow(enforcement.mode, ref) : workflow(enforcement.mode, ref), created, skipped);
+    writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), parallel ? parallelTransactionWorkflow(enforcement.mode, ref) : workflow(enforcement.mode, ref), created, skipped);
     if (parallel === "portable")
         writeIfAbsent(resolve(root, ".github/workflows/repo-guard-portable-coordinator.yml"), portableCoordinatorWorkflow(ref), created, skipped);
+    if (parallel === "github_merge_queue")
+        writeIfAbsent(resolve(root, ".github/workflows/repo-guard-merge-group.yml"), nativeMergeGroupWorkflow(ref), created, skipped);
     writeIfAbsent(resolve(root, ".github/PULL_REQUEST_TEMPLATE.md"), prTemplate(), created, skipped);
     writeIfAbsent(resolve(root, ".github/ISSUE_TEMPLATE/change-intent.yml"), issueTemplate(), created, skipped);
     console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcement.mode}, action-ref: ${ref}${parallel ? `, parallel: ${parallel}` : ""})`);

--- a/src/init.mts
+++ b/src/init.mts
@@ -14,29 +14,28 @@ const PRESETS = {
 
 type PresetName = keyof typeof PRESETS;
 type EnforcementInput = Parameters<typeof normalizeEnforcementMode>[0];
-type ParallelProvider = "portable";
+type ParallelProvider = "portable" | "github_merge_queue";
 interface InitRoots { packageRoot: string; repoRoot: string; enforcementMode?: EnforcementInput; }
 
-function parallelIntegration(mode: string, ref: string) {
+function parallelIntegration(provider: ParallelProvider, mode: string, ref: string) {
   const ref_pinning = FULL_SHA.test(ref) ? "sha" : "tag";
-  return {
-    workflows: [
-      {
-        id: "repo-guard-pr-gate",
-        kind: "github_actions",
-        path: ".github/workflows/repo-guard.yml",
-        role: "repo_guard_pr_gate",
-        expect: {
-          events: ["pull_request"],
-          event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
-          action: { uses: ACTION, ref_pinning },
-          mode: "check-pr",
-          enforcement: mode,
-          permissions: { contents: "read", "pull-requests": "read", issues: "read" },
-          token_env: ["GH_TOKEN"],
-        },
-      },
-      {
+  const transaction = {
+    id: "repo-guard-pr-gate",
+    kind: "github_actions",
+    path: ".github/workflows/repo-guard.yml",
+    role: "repo_guard_pr_gate",
+    expect: {
+      events: ["pull_request"],
+      event_types: ["opened", "synchronize", "reopened", "ready_for_review"],
+      action: { uses: ACTION, ref_pinning },
+      mode: "check-pr",
+      enforcement: mode,
+      permissions: { contents: "read", "pull-requests": "read", issues: "read" },
+      token_env: ["GH_TOKEN"],
+    },
+  };
+  const providerWorkflow = provider === "portable"
+    ? {
         id: "repo-guard-portable-coordinator",
         kind: "github_actions",
         path: ".github/workflows/repo-guard-portable-coordinator.yml",
@@ -49,15 +48,28 @@ function parallelIntegration(mode: string, ref: string) {
           permissions: { contents: "write", "pull-requests": "write", checks: "read" },
           token_env: ["GH_TOKEN"],
         },
-      },
-    ],
-  };
+      }
+    : {
+        id: "repo-guard-merge-group",
+        kind: "github_actions",
+        path: ".github/workflows/repo-guard-merge-group.yml",
+        role: "repo_guard_merge_group_gate",
+        expect: {
+          events: ["merge_group"],
+          event_types: ["checks_requested"],
+          action: { uses: ACTION, ref_pinning },
+          mode: "check-merge-group",
+          enforcement: "blocking",
+          permissions: { contents: "read" },
+        },
+      };
+  return { workflows: [transaction, providerWorkflow] };
 }
 
 function buildPolicy(name: PresetName, mode: string, parallel: ParallelProvider | null = null, ref: string | null = null) {
   const [repository_kind, forbidden, canonical_docs, diff_rules, cochange_rules] = PRESETS[name];
   const policy = { policy_format_version: "0.3.0", repository_kind, enforcement: { mode }, paths: { forbidden, canonical_docs, governance_paths: ["repo-policy.json"] }, diff_rules, content_rules: [], cochange_rules };
-  return parallel === "portable" && ref ? { ...policy, integration: parallelIntegration(mode, ref) } : policy;
+  return parallel && ref ? { ...policy, integration: parallelIntegration(parallel, mode, ref) } : policy;
 }
 function packageVersion(packageRoot: string): string {
   const version = (JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf-8")) as { version?: unknown }).version;
@@ -142,6 +154,22 @@ jobs:
         env:
           GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
 `;
+const nativeMergeGroupWorkflow = (ref: string) => `name: Merge-group state repo-guard
+on:
+  merge_group:
+    types: [checks_requested]
+permissions:
+  contents: read
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Проверить состояние merge-group
+        uses: ${ACTION}@${ref}
+        with: { mode: check-merge-group, enforcement: blocking }
+`;
 const prTemplate = () => `## Краткое описание
 
 ## Намерение изменения
@@ -202,7 +230,7 @@ function writeIfAbsent(path: string, content: string, created: string[], skipped
   if (existsSync(path)) return skipped.push(path);
   mkdirSync(dirname(path), { recursive: true }); writeFileSync(path, content, "utf-8"); created.push(path);
 }
-const usage = `Usage: repo-guard init --action-ref <40-char-sha|vX.Y.Z> [--preset <preset>] [--mode <mode>] [--parallel portable]\nPresets: application, library, tooling, documentation`;
+const usage = `Usage: repo-guard init --action-ref <40-char-sha|vX.Y.Z> [--preset <preset>] [--mode <mode>] [--parallel <portable|github_merge_queue>]\nPresets: application, library, tooling, documentation`;
 
 export function runInit(roots: InitRoots, args: string[] = []) {
   let preset = "application", mode: EnforcementInput = roots.enforcementMode || "enforce", actionRef: unknown = null, parallel: ParallelProvider | null = null;
@@ -212,7 +240,7 @@ export function runInit(roots: InitRoots, args: string[] = []) {
       if (option === "--preset") preset = value;
       else if (option === "--action-ref") actionRef = value;
       else if (option === "--parallel") {
-        if (value !== "portable") { console.error(`Unknown parallel provider: ${value}\n${usage}`); return 1; }
+        if (value !== "portable" && value !== "github_merge_queue") { console.error(`Unknown parallel provider: ${value}\n${usage}`); return 1; }
         parallel = value;
       } else mode = value;
     } else if (args[i] === "--help") { console.log(usage); return 0; }
@@ -228,8 +256,9 @@ export function runInit(roots: InitRoots, args: string[] = []) {
 
   const created: string[] = [], skipped: string[] = [], root = roots.repoRoot, ref = refCheck.ref as string;
   writeIfAbsent(resolve(root, "repo-policy.json"), `${JSON.stringify(buildPolicy(preset as PresetName, enforcement.mode, parallel, ref), null, 2)}\n`, created, skipped);
-  writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), parallel === "portable" ? parallelTransactionWorkflow(enforcement.mode, ref) : workflow(enforcement.mode, ref), created, skipped);
+  writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), parallel ? parallelTransactionWorkflow(enforcement.mode, ref) : workflow(enforcement.mode, ref), created, skipped);
   if (parallel === "portable") writeIfAbsent(resolve(root, ".github/workflows/repo-guard-portable-coordinator.yml"), portableCoordinatorWorkflow(ref), created, skipped);
+  if (parallel === "github_merge_queue") writeIfAbsent(resolve(root, ".github/workflows/repo-guard-merge-group.yml"), nativeMergeGroupWorkflow(ref), created, skipped);
   writeIfAbsent(resolve(root, ".github/PULL_REQUEST_TEMPLATE.md"), prTemplate(), created, skipped);
   writeIfAbsent(resolve(root, ".github/ISSUE_TEMPLATE/change-intent.yml"), issueTemplate(), created, skipped);
 

--- a/tests/test-init-native.mjs
+++ b/tests/test-init-native.mjs
@@ -1,0 +1,108 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import Ajv from "ajv";
+import { integrationConstraintEntries } from "../dist/checks/integration-constraints.mjs";
+import { extractIntegration } from "../dist/extractors/integration.mjs";
+import { evaluateParallelReadiness } from "../dist/parallel-readiness.mjs";
+
+const root = resolve(new URL("..", import.meta.url).pathname);
+const cli = resolve(root, "dist/repo-guard.mjs");
+const schema = JSON.parse(readFileSync(resolve(root, "schemas/repo-policy.schema.json"), "utf-8"));
+const immutableSha = "0123456789abcdef0123456789abcdef01234567";
+const validate = new Ajv({ allErrors: true }).compile(schema);
+const temp = () => mkdtempSync(join(tmpdir(), "repo-guard-native-init-"));
+const run = (args, cwd = root) => spawnSync(process.execPath, [cli, ...args], { cwd, encoding: "utf-8" });
+const runInit = (dir) => run(["--repo-root", dir, "init", "--action-ref", immutableSha, "--parallel", "github_merge_queue"]);
+const statePath = ".github/workflows/repo-guard-merge-group.yml";
+const nativePaths = [
+  "repo-policy.json",
+  ".github/workflows/repo-guard.yml",
+  statePath,
+  ".github/PULL_REQUEST_TEMPLATE.md",
+  ".github/ISSUE_TEMPLATE/change-intent.yml",
+];
+
+describe("repo-guard init github_merge_queue", () => {
+  it("generates the canonical PR transaction and merge-group state scaffold", () => {
+    const dir = temp(), result = runInit(dir);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    for (const path of nativePaths) assert.equal(existsSync(join(dir, path)), true, path);
+
+    const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
+    assert.equal(validate(policy), true, JSON.stringify(validate.errors));
+    assert.deepEqual(policy.integration?.workflows?.map(({ path, role, expect }) => ({ path, role, mode: expect?.mode })), [
+      { path: ".github/workflows/repo-guard.yml", role: "repo_guard_pr_gate", mode: "check-pr" },
+      { path: statePath, role: "repo_guard_merge_group_gate", mode: "check-merge-group" },
+    ]);
+
+    const stateContract = policy.integration.workflows.find(({ role }) => role === "repo_guard_merge_group_gate");
+    assert.deepEqual(stateContract.expect.events, ["merge_group"]);
+    assert.deepEqual(stateContract.expect.event_types, ["checks_requested"]);
+    assert.deepEqual(stateContract.expect.permissions, { contents: "read" });
+
+    const state = readFileSync(join(dir, statePath), "utf-8");
+    assert.match(state, /^\s*merge_group:$/m);
+    assert.match(state, /^\s*types: \[checks_requested\]$/m);
+    assert.match(state, new RegExp(`netkeep80/repo-guard@${immutableSha}`));
+    assert.match(state, /mode: check-merge-group/);
+    assert.match(state, /^\s*contents: read$/m);
+    assert.doesNotMatch(state, /workflow_dispatch/);
+    assert.doesNotMatch(state, /branch[_ -]?protection|ruleset|\bbypass\b/i);
+  });
+
+  it("passes canonical integration validation and native repository readiness", () => {
+    const dir = temp();
+    assert.equal(runInit(dir).status, 0);
+    const validation = run(["--repo-root", dir, "validate-integration"]);
+    assert.equal(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+    assert.match(validation.stdout, /PASS: integration-workflows/);
+
+    const policy = JSON.parse(readFileSync(join(dir, "repo-policy.json"), "utf-8"));
+    const trackedFiles = policy.integration.workflows.map(({ path }) => path);
+    const integrationFacts = extractIntegration(policy, {
+      repoRoot: dir,
+      trackedFiles,
+      readFile: (path) => readFileSync(join(dir, path), "utf-8"),
+    });
+    const workflowCheck = integrationConstraintEntries(integrationFacts).find(({ name }) => name === "integration-workflows")?.check;
+    assert.equal(workflowCheck?.ok, true, JSON.stringify(workflowCheck?.details));
+
+    const readiness = evaluateParallelReadiness({
+      provider: "github_merge_queue",
+      integrationFacts,
+      controlPlaneFacts: {
+        targetBranch: "main",
+        requiredChecks: ["policy-check"],
+        pullRequestRequired: true,
+        requiredChecksEnforced: true,
+        noBypass: true,
+        mergeQueueEnabled: true,
+      },
+    });
+    assert.equal(readiness.ready, true, JSON.stringify(readiness.blockers));
+    assert.deepEqual(readiness.blockers, []);
+    assert.equal(readiness.evidence.repository.transactionWorkflow, ".github/workflows/repo-guard.yml");
+    assert.equal(readiness.evidence.repository.providerWorkflow, statePath);
+  });
+
+  it("is idempotent and never rewrites a partial existing merge-group workflow", () => {
+    const dir = temp();
+    assert.equal(runInit(dir).status, 0);
+    const first = Object.fromEntries(nativePaths.map((path) => [path, readFileSync(join(dir, path), "utf-8")]));
+    const second = runInit(dir);
+    assert.equal(second.status, 0);
+    for (const path of nativePaths) assert.equal(readFileSync(join(dir, path), "utf-8"), first[path], path);
+
+    const partialDir = temp(), state = join(partialDir, statePath);
+    mkdirSync(join(partialDir, ".github/workflows"), { recursive: true });
+    writeFileSync(state, "custom merge-group workflow\n", "utf-8");
+    const partial = runInit(partialDir);
+    assert.equal(partial.status, 0);
+    assert.equal(readFileSync(state, "utf-8"), "custom merge-group workflow\n");
+    assert.match(partial.stdout, /Skipped \(already exist\):[\s\S]*repo-guard-merge-group\.yml/);
+  });
+});


### PR DESCRIPTION
## Краткое описание

P4d2 из #333: добавляет второй opt-in init provider `github_merge_queue`, генерирующий существующий PR transaction gate и отдельный merge-group state gate через уже принятые integration roles/modes. Начинаем с test-only RED commit; production-код будет добавлен только после подтверждённого RED.

Part of #333.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/init.mts
  - dist/init.mjs
  - tests/test-init-native.mjs
budgets: {}
anchors:
  affects:
    - "#333"
  implements:
    - "#333"
  verifies:
    - "#333"
must_touch:
  - src/init.mts
  - tests/test-init-native.mjs
must_not_touch:
  - repo-policy.json
  - .github/workflows/**
  - schemas/**
  - action.yml
  - src/parallel-readiness.mts
  - src/github-control-plane.mts
expected_effects:
  - "`init --parallel github_merge_queue` генерирует deterministic PR transaction + merge-group state scaffold через canonical integration contracts."
  - "Merge-group state workflow слушает `merge_group: checks_requested`, запускает `check-merge-group` и использует только минимальные read permissions."
  - "Legacy init и portable provider остаются совместимыми; init не включает GitHub Merge Queue, branch protection или rulesets."
```
