### PR TITLE
[Parallel P5a] Add pure migration planner and v2 compatibility corpus

### DIFF
--- a/dist/init.mjs
+++ b/dist/init.mjs
@@ -223,6 +223,19 @@ body:
         \`\`\`
     validations: { required: false }
 `;
+export function renderInitScaffold({ preset, mode, actionRef, parallel = null }) {
+    const rendered = {
+        "repo-policy.json": `${JSON.stringify(buildPolicy(preset, mode, parallel, actionRef), null, 2)}\n`,
+        ".github/workflows/repo-guard.yml": parallel ? parallelTransactionWorkflow(mode, actionRef) : workflow(mode, actionRef),
+    };
+    if (parallel === "portable")
+        rendered[".github/workflows/repo-guard-portable-coordinator.yml"] = portableCoordinatorWorkflow(actionRef);
+    if (parallel === "github_merge_queue")
+        rendered[".github/workflows/repo-guard-merge-group.yml"] = nativeMergeGroupWorkflow(actionRef);
+    rendered[".github/PULL_REQUEST_TEMPLATE.md"] = prTemplate();
+    rendered[".github/ISSUE_TEMPLATE/change-intent.yml"] = issueTemplate();
+    return rendered;
+}
 function writeIfAbsent(path, content, created, skipped) {
     if (existsSync(path))
         return skipped.push(path);
@@ -281,14 +294,9 @@ export function runInit(roots, args = []) {
         return 1;
     }
     const created = [], skipped = [], root = roots.repoRoot, ref = refCheck.ref;
-    writeIfAbsent(resolve(root, "repo-policy.json"), `${JSON.stringify(buildPolicy(preset, enforcement.mode, parallel, ref), null, 2)}\n`, created, skipped);
-    writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), parallel ? parallelTransactionWorkflow(enforcement.mode, ref) : workflow(enforcement.mode, ref), created, skipped);
-    if (parallel === "portable")
-        writeIfAbsent(resolve(root, ".github/workflows/repo-guard-portable-coordinator.yml"), portableCoordinatorWorkflow(ref), created, skipped);
-    if (parallel === "github_merge_queue")
-        writeIfAbsent(resolve(root, ".github/workflows/repo-guard-merge-group.yml"), nativeMergeGroupWorkflow(ref), created, skipped);
-    writeIfAbsent(resolve(root, ".github/PULL_REQUEST_TEMPLATE.md"), prTemplate(), created, skipped);
-    writeIfAbsent(resolve(root, ".github/ISSUE_TEMPLATE/change-intent.yml"), issueTemplate(), created, skipped);
+    const rendered = renderInitScaffold({ preset: preset, mode: enforcement.mode, actionRef: ref, parallel });
+    for (const [path, content] of Object.entries(rendered))
+        writeIfAbsent(resolve(root, path), content, created, skipped);
     console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcement.mode}, action-ref: ${ref}${parallel ? `, parallel: ${parallel}` : ""})`);
     if (created.length)
         console.log(`Created:\n${created.map((path) => `  ${relative(root, path)}`).join("\n")}`);

--- a/dist/migration-plan.mjs
+++ b/dist/migration-plan.mjs
@@ -1,0 +1,88 @@
+import { renderInitScaffold } from "./init.mjs";
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const PRESETS = ["application", "library", "tooling", "documentation"];
+const MODES = ["blocking", "advisory"];
+const IMMUTABLE_REF = /^(?:[0-9a-f]{40}|v\d+\.\d+\.\d+)$/i;
+function providerPath(provider) {
+    return provider === "portable" ? PORTABLE : NATIVE;
+}
+function externalSteps(provider) {
+    return provider === "portable"
+        ? [
+            { id: "branch_protection", message: "Configure required PR/state checks before enabling portable integration." },
+            { id: "ready_label", message: "Create and operationally reserve the repo-guard:ready label." },
+        ]
+        : [
+            { id: "merge_queue", message: "Enable GitHub Merge Queue only after repository readiness is green." },
+        ];
+}
+function scaffold(preset, mode, actionRef, parallel) {
+    return renderInitScaffold({ preset, mode, actionRef, parallel });
+}
+function matches(content, ...known) {
+    return typeof content === "string" && known.includes(content);
+}
+function resolveKnownScaffold(input) {
+    const currentPolicy = input.files[POLICY];
+    const currentTransaction = input.files[TRANSACTION];
+    const candidates = PRESETS.flatMap((preset) => MODES.map((mode) => {
+        const legacy = scaffold(preset, mode, input.actionRef, null);
+        const target = scaffold(preset, mode, input.actionRef, input.provider);
+        const policyKnown = matches(currentPolicy, legacy[POLICY], target[POLICY]);
+        const transactionKnown = matches(currentTransaction, legacy[TRANSACTION], target[TRANSACTION]);
+        return { preset, mode, legacy, target, policyKnown, transactionKnown };
+    }));
+    const exact = candidates.filter(({ policyKnown, transactionKnown }) => policyKnown && transactionKnown);
+    if (exact.length === 1)
+        return exact[0];
+    const policyIdentified = candidates.filter(({ policyKnown }) => policyKnown);
+    if (policyIdentified.length === 1)
+        return policyIdentified[0];
+    const transactionIdentified = candidates.filter(({ transactionKnown }) => transactionKnown);
+    return transactionIdentified.length === 1 ? transactionIdentified[0] : null;
+}
+function planKnownFile(path, before, legacy, target, blockers) {
+    if (before === target)
+        return { path, action: "unchanged", before, after: target };
+    if (before === legacy)
+        return { path, action: "replace", before, after: target };
+    blockers.push({ id: "custom_file", path, message: `${path} is not an exact repo-guard generated template; refusing to rewrite it.` });
+    return { path, action: "blocked", before, after: target };
+}
+function planProviderFile(path, before, target, blockers) {
+    if (before === target)
+        return { path, action: "unchanged", before, after: target };
+    if (before === null || before === undefined)
+        return { path, action: "create", before, after: target };
+    blockers.push({ id: "custom_file", path, message: `${path} already exists but is not the exact repo-guard generated template; refusing to rewrite it.` });
+    return { path, action: "blocked", before, after: target };
+}
+export function planParallelMigration(input) {
+    const blockers = [];
+    if (!IMMUTABLE_REF.test(input.actionRef)) {
+        blockers.push({ id: "invalid_action_ref", message: `Action ref ${input.actionRef} is mutable or ambiguous; use a full commit SHA or exact vX.Y.Z tag.` });
+        return { provider: input.provider, actionRef: input.actionRef, readyToApply: false, files: [], blockers, external: externalSteps(input.provider) };
+    }
+    const known = resolveKnownScaffold(input);
+    if (!known) {
+        blockers.push({ id: "unknown_scaffold", message: "Cannot prove the repository matches a known repo-guard v2 scaffold." });
+        return { provider: input.provider, actionRef: input.actionRef, readyToApply: false, files: [], blockers, external: externalSteps(input.provider) };
+    }
+    const path = providerPath(input.provider);
+    const files = [
+        planProviderFile(path, input.files[path], known.target[path], blockers),
+        planKnownFile(TRANSACTION, input.files[TRANSACTION], known.legacy[TRANSACTION], known.target[TRANSACTION], blockers),
+        planKnownFile(POLICY, input.files[POLICY], known.legacy[POLICY], known.target[POLICY], blockers),
+    ];
+    return {
+        provider: input.provider,
+        actionRef: input.actionRef,
+        readyToApply: blockers.length === 0,
+        files,
+        blockers,
+        external: externalSteps(input.provider),
+    };
+}

--- a/src/init.mts
+++ b/src/init.mts
@@ -12,10 +12,11 @@ const PRESETS = {
   documentation: ["documentation", [], ["README.md"], { max_new_docs: 10, max_new_files: 20 }, []],
 } as const;
 
-type PresetName = keyof typeof PRESETS;
+export type PresetName = keyof typeof PRESETS;
 type EnforcementInput = Parameters<typeof normalizeEnforcementMode>[0];
-type ParallelProvider = "portable" | "github_merge_queue";
+export type ParallelProvider = "portable" | "github_merge_queue";
 interface InitRoots { packageRoot: string; repoRoot: string; enforcementMode?: EnforcementInput; }
+export interface RenderInitScaffoldInput { preset: PresetName; mode: string; actionRef: string; parallel?: ParallelProvider | null; }
 
 function parallelIntegration(provider: ParallelProvider, mode: string, ref: string) {
   const ref_pinning = FULL_SHA.test(ref) ? "sha" : "tag";
@@ -226,6 +227,19 @@ body:
         \`\`\`
     validations: { required: false }
 `;
+
+export function renderInitScaffold({ preset, mode, actionRef, parallel = null }: RenderInitScaffoldInput): Record<string, string> {
+  const rendered: Record<string, string> = {
+    "repo-policy.json": `${JSON.stringify(buildPolicy(preset, mode, parallel, actionRef), null, 2)}\n`,
+    ".github/workflows/repo-guard.yml": parallel ? parallelTransactionWorkflow(mode, actionRef) : workflow(mode, actionRef),
+  };
+  if (parallel === "portable") rendered[".github/workflows/repo-guard-portable-coordinator.yml"] = portableCoordinatorWorkflow(actionRef);
+  if (parallel === "github_merge_queue") rendered[".github/workflows/repo-guard-merge-group.yml"] = nativeMergeGroupWorkflow(actionRef);
+  rendered[".github/PULL_REQUEST_TEMPLATE.md"] = prTemplate();
+  rendered[".github/ISSUE_TEMPLATE/change-intent.yml"] = issueTemplate();
+  return rendered;
+}
+
 function writeIfAbsent(path: string, content: string, created: string[], skipped: string[]) {
   if (existsSync(path)) return skipped.push(path);
   mkdirSync(dirname(path), { recursive: true }); writeFileSync(path, content, "utf-8"); created.push(path);
@@ -255,12 +269,8 @@ export function runInit(roots: InitRoots, args: string[] = []) {
   if (!refCheck.ok) { console.error(refCheck.message); return 1; }
 
   const created: string[] = [], skipped: string[] = [], root = roots.repoRoot, ref = refCheck.ref as string;
-  writeIfAbsent(resolve(root, "repo-policy.json"), `${JSON.stringify(buildPolicy(preset as PresetName, enforcement.mode, parallel, ref), null, 2)}\n`, created, skipped);
-  writeIfAbsent(resolve(root, ".github/workflows/repo-guard.yml"), parallel ? parallelTransactionWorkflow(enforcement.mode, ref) : workflow(enforcement.mode, ref), created, skipped);
-  if (parallel === "portable") writeIfAbsent(resolve(root, ".github/workflows/repo-guard-portable-coordinator.yml"), portableCoordinatorWorkflow(ref), created, skipped);
-  if (parallel === "github_merge_queue") writeIfAbsent(resolve(root, ".github/workflows/repo-guard-merge-group.yml"), nativeMergeGroupWorkflow(ref), created, skipped);
-  writeIfAbsent(resolve(root, ".github/PULL_REQUEST_TEMPLATE.md"), prTemplate(), created, skipped);
-  writeIfAbsent(resolve(root, ".github/ISSUE_TEMPLATE/change-intent.yml"), issueTemplate(), created, skipped);
+  const rendered = renderInitScaffold({ preset: preset as PresetName, mode: enforcement.mode, actionRef: ref, parallel });
+  for (const [path, content] of Object.entries(rendered)) writeIfAbsent(resolve(root, path), content, created, skipped);
 
   console.log(`repo-guard init (preset: ${preset}, enforcement: ${enforcement.mode}, action-ref: ${ref}${parallel ? `, parallel: ${parallel}` : ""})`);
   if (created.length) console.log(`Created:\n${created.map((path) => `  ${relative(root, path)}`).join("\n")}`);

--- a/src/migration-plan.mts
+++ b/src/migration-plan.mts
@@ -1,0 +1,146 @@
+import { renderInitScaffold } from "./init.mjs";
+
+export type ParallelMigrationProvider = "portable" | "github_merge_queue";
+type CanonicalMode = "blocking" | "advisory";
+type PresetName = "application" | "library" | "tooling" | "documentation";
+type FileContent = string | null | undefined;
+
+export interface ParallelMigrationInput {
+  provider: ParallelMigrationProvider;
+  actionRef: string;
+  files: Record<string, FileContent>;
+}
+
+export interface ParallelMigrationFilePlan {
+  path: string;
+  action: "create" | "replace" | "unchanged" | "blocked";
+  before: FileContent;
+  after: string;
+}
+
+export interface ParallelMigrationBlocker {
+  id: "custom_file" | "unknown_scaffold" | "invalid_action_ref";
+  path?: string;
+  message: string;
+}
+
+export interface ParallelMigrationExternalStep {
+  id: "branch_protection" | "ready_label" | "merge_queue";
+  message: string;
+}
+
+export interface ParallelMigrationPlan {
+  provider: ParallelMigrationProvider;
+  actionRef: string;
+  readyToApply: boolean;
+  files: ParallelMigrationFilePlan[];
+  blockers: ParallelMigrationBlocker[];
+  external: ParallelMigrationExternalStep[];
+}
+
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const PRESETS: PresetName[] = ["application", "library", "tooling", "documentation"];
+const MODES: CanonicalMode[] = ["blocking", "advisory"];
+const IMMUTABLE_REF = /^(?:[0-9a-f]{40}|v\d+\.\d+\.\d+)$/i;
+
+function providerPath(provider: ParallelMigrationProvider) {
+  return provider === "portable" ? PORTABLE : NATIVE;
+}
+
+function externalSteps(provider: ParallelMigrationProvider): ParallelMigrationExternalStep[] {
+  return provider === "portable"
+    ? [
+        { id: "branch_protection", message: "Configure required PR/state checks before enabling portable integration." },
+        { id: "ready_label", message: "Create and operationally reserve the repo-guard:ready label." },
+      ]
+    : [
+        { id: "merge_queue", message: "Enable GitHub Merge Queue only after repository readiness is green." },
+      ];
+}
+
+function scaffold(preset: PresetName, mode: CanonicalMode, actionRef: string, parallel: ParallelMigrationProvider | null) {
+  return renderInitScaffold({ preset, mode, actionRef, parallel });
+}
+
+function matches(content: FileContent, ...known: string[]) {
+  return typeof content === "string" && known.includes(content);
+}
+
+function resolveKnownScaffold(input: ParallelMigrationInput) {
+  const currentPolicy = input.files[POLICY];
+  const currentTransaction = input.files[TRANSACTION];
+  const candidates = PRESETS.flatMap((preset) => MODES.map((mode) => {
+    const legacy = scaffold(preset, mode, input.actionRef, null);
+    const target = scaffold(preset, mode, input.actionRef, input.provider);
+    const policyKnown = matches(currentPolicy, legacy[POLICY], target[POLICY]);
+    const transactionKnown = matches(currentTransaction, legacy[TRANSACTION], target[TRANSACTION]);
+    return { preset, mode, legacy, target, policyKnown, transactionKnown };
+  }));
+
+  const exact = candidates.filter(({ policyKnown, transactionKnown }) => policyKnown && transactionKnown);
+  if (exact.length === 1) return exact[0];
+
+  const policyIdentified = candidates.filter(({ policyKnown }) => policyKnown);
+  if (policyIdentified.length === 1) return policyIdentified[0];
+
+  const transactionIdentified = candidates.filter(({ transactionKnown }) => transactionKnown);
+  return transactionIdentified.length === 1 ? transactionIdentified[0] : null;
+}
+
+function planKnownFile(
+  path: string,
+  before: FileContent,
+  legacy: string,
+  target: string,
+  blockers: ParallelMigrationBlocker[],
+): ParallelMigrationFilePlan {
+  if (before === target) return { path, action: "unchanged", before, after: target };
+  if (before === legacy) return { path, action: "replace", before, after: target };
+  blockers.push({ id: "custom_file", path, message: `${path} is not an exact repo-guard generated template; refusing to rewrite it.` });
+  return { path, action: "blocked", before, after: target };
+}
+
+function planProviderFile(
+  path: string,
+  before: FileContent,
+  target: string,
+  blockers: ParallelMigrationBlocker[],
+): ParallelMigrationFilePlan {
+  if (before === target) return { path, action: "unchanged", before, after: target };
+  if (before === null || before === undefined) return { path, action: "create", before, after: target };
+  blockers.push({ id: "custom_file", path, message: `${path} already exists but is not the exact repo-guard generated template; refusing to rewrite it.` });
+  return { path, action: "blocked", before, after: target };
+}
+
+export function planParallelMigration(input: ParallelMigrationInput): ParallelMigrationPlan {
+  const blockers: ParallelMigrationBlocker[] = [];
+  if (!IMMUTABLE_REF.test(input.actionRef)) {
+    blockers.push({ id: "invalid_action_ref", message: `Action ref ${input.actionRef} is mutable or ambiguous; use a full commit SHA or exact vX.Y.Z tag.` });
+    return { provider: input.provider, actionRef: input.actionRef, readyToApply: false, files: [], blockers, external: externalSteps(input.provider) };
+  }
+
+  const known = resolveKnownScaffold(input);
+  if (!known) {
+    blockers.push({ id: "unknown_scaffold", message: "Cannot prove the repository matches a known repo-guard v2 scaffold." });
+    return { provider: input.provider, actionRef: input.actionRef, readyToApply: false, files: [], blockers, external: externalSteps(input.provider) };
+  }
+
+  const path = providerPath(input.provider);
+  const files = [
+    planProviderFile(path, input.files[path], known.target[path], blockers),
+    planKnownFile(TRANSACTION, input.files[TRANSACTION], known.legacy[TRANSACTION], known.target[TRANSACTION], blockers),
+    planKnownFile(POLICY, input.files[POLICY], known.legacy[POLICY], known.target[POLICY], blockers),
+  ];
+
+  return {
+    provider: input.provider,
+    actionRef: input.actionRef,
+    readyToApply: blockers.length === 0,
+    files,
+    blockers,
+    external: externalSteps(input.provider),
+  };
+}

--- a/tests/test-migration-plan.mjs
+++ b/tests/test-migration-plan.mjs
@@ -1,0 +1,193 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+
+const OLD_SHA = "1111111111111111111111111111111111111111";
+const TARGET_SHA = "2222222222222222222222222222222222222222";
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const PR_TEMPLATE = ".github/PULL_REQUEST_TEMPLATE.md";
+const ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/change-intent.yml";
+
+const V2_POLICY = `${JSON.stringify({
+  policy_format_version: "0.3.0",
+  repository_kind: "application",
+  enforcement: { mode: "blocking" },
+  paths: {
+    forbidden: ["*.bak", "*.log"],
+    canonical_docs: ["README.md"],
+    governance_paths: ["repo-policy.json"],
+  },
+  diff_rules: { max_new_docs: 3, max_new_files: 20, max_net_added_lines: 1500 },
+  content_rules: [],
+  cochange_rules: [],
+}, null, 2)}\n`;
+
+const legacyWorkflow = (ref) => `name: Проверка политики repo-guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Проверить политику репозитория
+        uses: netkeep80/repo-guard@${ref}
+        with: { mode: check-pr, enforcement: blocking }
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`;
+
+const portableCoordinator = (ref) => `name: Portable coordinator repo-guard
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+jobs:
+  integrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Интегрировать один READY-кандидат
+        uses: netkeep80/repo-guard@${ref}
+        with:
+          mode: portable-coordinator
+          enforcement: blocking
+          repository: \${{ github.repository }}
+          ready-label: repo-guard:ready
+          merge-method: squash
+          transaction-checks: |
+            policy-check
+          state-checks: |
+            policy-check
+          format: json
+        env:
+          GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
+`;
+
+const V2_PR_TEMPLATE = `## Краткое описание
+
+## Намерение изменения
+
+\`\`\`repo-guard-yaml
+change_type: feature
+scope:
+  - src/**
+budgets: {}
+anchors:
+  affects: []
+  implements: []
+  verifies: []
+must_touch: []
+must_not_touch: []
+expected_effects:
+  - Опишите ожидаемый эффект
+\`\`\`
+`;
+
+function legacyMigrationFiles(ref) {
+  return {
+    [POLICY]: V2_POLICY,
+    [TRANSACTION]: legacyWorkflow(ref),
+    [PORTABLE]: null,
+    [NATIVE]: null,
+  };
+}
+
+function actionSummary(plan) {
+  return plan.files.map(({ path, action }) => ({ path, action }));
+}
+
+describe("P5a compatibility corpus and pure migration plan", () => {
+  it("locks the v2 legacy scaffold and exposes the same pure init renderer", async () => {
+    const { renderInitScaffold } = await import("../dist/init.mjs");
+    assert.equal(typeof renderInitScaffold, "function");
+
+    const rendered = renderInitScaffold({
+      preset: "application",
+      mode: "blocking",
+      actionRef: OLD_SHA,
+      parallel: null,
+    });
+
+    assert.deepEqual(Object.keys(rendered).sort(), [POLICY, TRANSACTION, PR_TEMPLATE, ISSUE_TEMPLATE].sort());
+    assert.equal(rendered[POLICY], V2_POLICY);
+    assert.equal(rendered[TRANSACTION], legacyWorkflow(OLD_SHA));
+    assert.equal(rendered[PR_TEMPLATE], V2_PR_TEMPLATE);
+    assert.match(rendered[PR_TEMPLATE], /repo-guard-yaml/);
+    assert.match(rendered[PR_TEMPLATE], /change_type: feature/);
+    assert.match(rendered[TRANSACTION], new RegExp(`repo-guard@${OLD_SHA}`));
+  });
+
+  it("plans portable preparation from an exact repinned v2 scaffold without writes", async () => {
+    const { planParallelMigration } = await import("../dist/migration-plan.mjs");
+    const before = legacyMigrationFiles(TARGET_SHA);
+    const frozen = structuredClone(before);
+
+    const plan = planParallelMigration({ provider: "portable", actionRef: TARGET_SHA, files: before });
+
+    assert.equal(plan.readyToApply, true, JSON.stringify(plan.blockers));
+    assert.deepEqual(plan.blockers, []);
+    assert.deepEqual(actionSummary(plan), [
+      { path: PORTABLE, action: "create" },
+      { path: TRANSACTION, action: "replace" },
+      { path: POLICY, action: "replace" },
+    ]);
+    assert.deepEqual(plan.external.map(({ id }) => id), ["branch_protection", "ready_label"]);
+    assert.deepEqual(before, frozen, "pure planner must not mutate repository facts");
+    assert.match(plan.files.find(({ path }) => path === PORTABLE).after, /mode: portable-coordinator/);
+  });
+
+  it("resumes a known partial portable preparation idempotently", async () => {
+    const { planParallelMigration } = await import("../dist/migration-plan.mjs");
+    const files = { ...legacyMigrationFiles(TARGET_SHA), [PORTABLE]: portableCoordinator(TARGET_SHA) };
+    const plan = planParallelMigration({ provider: "portable", actionRef: TARGET_SHA, files });
+
+    assert.equal(plan.readyToApply, true, JSON.stringify(plan.blockers));
+    assert.deepEqual(actionSummary(plan), [
+      { path: PORTABLE, action: "unchanged" },
+      { path: TRANSACTION, action: "replace" },
+      { path: POLICY, action: "replace" },
+    ]);
+  });
+
+  it("fails closed when a repository-owned workflow is not an exact known template", async () => {
+    const { planParallelMigration } = await import("../dist/migration-plan.mjs");
+    const files = legacyMigrationFiles(TARGET_SHA);
+    files[TRANSACTION] += "# custom repository step\n";
+
+    const plan = planParallelMigration({ provider: "portable", actionRef: TARGET_SHA, files });
+
+    assert.equal(plan.readyToApply, false);
+    assert.deepEqual(plan.blockers.map(({ id, path }) => ({ id, path })), [
+      { id: "custom_file", path: TRANSACTION },
+    ]);
+    assert.equal(plan.files.find(({ path }) => path === TRANSACTION).action, "blocked");
+  });
+
+  it("plans the same migration protocol for github_merge_queue", async () => {
+    const { planParallelMigration } = await import("../dist/migration-plan.mjs");
+    const plan = planParallelMigration({
+      provider: "github_merge_queue",
+      actionRef: TARGET_SHA,
+      files: legacyMigrationFiles(TARGET_SHA),
+    });
+
+    assert.equal(plan.readyToApply, true, JSON.stringify(plan.blockers));
+    assert.deepEqual(actionSummary(plan), [
+      { path: NATIVE, action: "create" },
+      { path: TRANSACTION, action: "replace" },
+      { path: POLICY, action: "replace" },
+    ]);
+    assert.deepEqual(plan.external.map(({ id }) => id), ["merge_queue"]);
+    const native = plan.files.find(({ path }) => path === NATIVE).after;
+    assert.match(native, /^\s*merge_group:$/m);
+    assert.match(native, /mode: check-merge-group/);
+    assert.doesNotMatch(native, /workflow_dispatch/);
+  });
+});


### PR DESCRIPTION
## Краткое описание

P5a из #310: зафиксировать v2 compatibility corpus и добавить чистый deterministic planner подготовки existing repository к `portable` или `github_merge_queue`. Первый commit test-only и должен дать RED; production implementation добавляется только после подтверждения этого RED.

Part of #310.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/init.mts
  - dist/init.mjs
  - src/migration-plan.mts
  - dist/migration-plan.mjs
  - tests/test-migration-plan.mjs
budgets: {}
anchors:
  affects:
    - "#310"
  implements:
    - "#310"
  verifies:
    - "#310"
must_touch:
  - src/init.mts
  - src/migration-plan.mts
  - tests/test-migration-plan.mjs
must_not_touch:
  - repo-policy.json
  - .github/workflows/**
  - schemas/**
  - action.yml
  - src/parallel-readiness.mts
  - src/github-control-plane.mts
expected_effects:
  - "Current v2 legacy scaffold остаётся byte-locked compatibility baseline с immutable Action pin и ChangeIntent."
  - "`init` и migration planner используют один deterministic pure scaffold renderer, без второго YAML parser или validator semantics."
  - "Planner не пишет в filesystem, принимает только exact known templates и fail-closed возвращает blocker для custom/unknown repository files."
  - "Portable и `github_merge_queue` получают один provider-neutral plan shape с deterministic file actions и external-setting evidence."
```
