### PR TITLE
[Parallel P5b] Add read-only migrate dry-run CLI

### DIFF
--- a/dist/migrate.mjs
+++ b/dist/migrate.mjs
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { validateExplicitActionRef } from "./init.mjs";
+import { planParallelMigration } from "./migration-plan.mjs";
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const PROVIDERS = new Set(["portable", "github_merge_queue"]);
+const FORMATS = new Set(["summary", "json"]);
+const usage = "Usage: repo-guard migrate --parallel <portable|github_merge_queue> --action-ref <40-char-sha|vX.Y.Z> --dry-run [--format <summary|json>]";
+function packageVersion(packageRoot) {
+    const parsed = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
+    if (typeof parsed.version !== "string" || !parsed.version)
+        throw new Error("Cannot determine repo-guard package version");
+    return parsed.version;
+}
+function readOptional(repoRoot, path) {
+    const target = resolve(repoRoot, path);
+    return existsSync(target) ? readFileSync(target, "utf8") : null;
+}
+function renderSummary(payload) {
+    const lines = [
+        `repo-guard migrate (${payload.mode})`,
+        `provider: ${payload.provider}`,
+        `action-ref: ${payload.actionRef}`,
+        `ready-to-apply: ${payload.readyToApply ? "yes" : "no"}`,
+        "files:",
+        ...payload.files.map(({ action, path }) => `  ${action}: ${path}`),
+    ];
+    if (payload.blockers.length) {
+        lines.push("blockers:", ...payload.blockers.map(({ id, path, message }) => `  ${id}${path ? ` (${path})` : ""}: ${message}`));
+    }
+    if (payload.external.length) {
+        lines.push("external:", ...payload.external.map(({ id, message }) => `  ${id}: ${message}`));
+    }
+    return lines.join("\n");
+}
+function migrationPayload(plan) {
+    return { command: "migrate", mode: "dry-run", ...plan };
+}
+export function runMigrate(roots, args = []) {
+    let provider = null;
+    let actionRef = null;
+    let format = "summary";
+    let dryRun = false;
+    for (let i = 0; i < args.length; i++) {
+        const option = args[i];
+        if (option === "--dry-run") {
+            dryRun = true;
+            continue;
+        }
+        if (["--parallel", "--action-ref", "--format"].includes(option)) {
+            const value = args[++i];
+            if (!value) {
+                console.error(`Missing value for ${option}\n${usage}`);
+                return 1;
+            }
+            if (option === "--parallel") {
+                if (!PROVIDERS.has(value)) {
+                    console.error(`Unknown parallel provider: ${value}\n${usage}`);
+                    return 1;
+                }
+                provider = value;
+            }
+            else if (option === "--action-ref") {
+                actionRef = value;
+            }
+            else {
+                if (!FORMATS.has(value)) {
+                    console.error(`Unknown migrate format: ${value}\n${usage}`);
+                    return 1;
+                }
+                format = value;
+            }
+            continue;
+        }
+        if (option === "--help") {
+            console.log(usage);
+            return 0;
+        }
+        console.error(`Unknown option for migrate: ${option}\n${usage}`);
+        return 1;
+    }
+    if (!dryRun) {
+        console.error(`migrate is read-only in this release slice; pass --dry-run\n${usage}`);
+        return 1;
+    }
+    if (!provider) {
+        console.error(`Missing required --parallel provider\n${usage}`);
+        return 1;
+    }
+    if (!actionRef) {
+        console.error(`Missing required --action-ref\n${usage}`);
+        return 1;
+    }
+    let refCheck;
+    try {
+        refCheck = validateExplicitActionRef(actionRef, packageVersion(roots.packageRoot));
+    }
+    catch (error) {
+        console.error(error.message);
+        return 1;
+    }
+    if (!refCheck.ok) {
+        console.error(refCheck.message);
+        return 1;
+    }
+    const providerPath = provider === "portable" ? PORTABLE : NATIVE;
+    const plan = planParallelMigration({
+        provider,
+        actionRef: refCheck.ref,
+        files: {
+            [POLICY]: readOptional(roots.repoRoot, POLICY),
+            [TRANSACTION]: readOptional(roots.repoRoot, TRANSACTION),
+            [providerPath]: readOptional(roots.repoRoot, providerPath),
+        },
+    });
+    const payload = migrationPayload(plan);
+    console.log(format === "json" ? JSON.stringify(payload, null, 2) : renderSummary(payload));
+    return plan.readyToApply ? 0 : 1;
+}

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -32,6 +32,10 @@ const COMMAND_SPECS = {
         options: { ...valueOptions("--preset", "--mode", "--action-ref", "--parallel"), "--help": false }, positionals: 0,
         run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
     },
+    migrate: {
+        options: { ...valueOptions("--parallel", "--action-ref", "--format"), "--dry-run": false, "--help": false }, positionals: 0,
+        run: async (roots, args) => (await import("./migrate.mjs")).runMigrate(roots, args),
+    },
     doctor: {
         options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
         run: async (roots, args) => args.includes("--integration")

--- a/src/migrate.mts
+++ b/src/migrate.mts
@@ -1,0 +1,135 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { validateExplicitActionRef } from "./init.mjs";
+import { planParallelMigration, type ParallelMigrationProvider } from "./migration-plan.mjs";
+
+interface MigrateRoots {
+  packageRoot: string;
+  repoRoot: string;
+}
+
+type OutputFormat = "summary" | "json";
+
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const PROVIDERS = new Set<ParallelMigrationProvider>(["portable", "github_merge_queue"]);
+const FORMATS = new Set<OutputFormat>(["summary", "json"]);
+const usage = "Usage: repo-guard migrate --parallel <portable|github_merge_queue> --action-ref <40-char-sha|vX.Y.Z> --dry-run [--format <summary|json>]";
+
+function packageVersion(packageRoot: string) {
+  const parsed = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8")) as { version?: unknown };
+  if (typeof parsed.version !== "string" || !parsed.version) throw new Error("Cannot determine repo-guard package version");
+  return parsed.version;
+}
+
+function readOptional(repoRoot: string, path: string) {
+  const target = resolve(repoRoot, path);
+  return existsSync(target) ? readFileSync(target, "utf8") : null;
+}
+
+function renderSummary(payload: ReturnType<typeof migrationPayload>) {
+  const lines = [
+    `repo-guard migrate (${payload.mode})`,
+    `provider: ${payload.provider}`,
+    `action-ref: ${payload.actionRef}`,
+    `ready-to-apply: ${payload.readyToApply ? "yes" : "no"}`,
+    "files:",
+    ...payload.files.map(({ action, path }) => `  ${action}: ${path}`),
+  ];
+  if (payload.blockers.length) {
+    lines.push("blockers:", ...payload.blockers.map(({ id, path, message }) => `  ${id}${path ? ` (${path})` : ""}: ${message}`));
+  }
+  if (payload.external.length) {
+    lines.push("external:", ...payload.external.map(({ id, message }) => `  ${id}: ${message}`));
+  }
+  return lines.join("\n");
+}
+
+function migrationPayload(plan: ReturnType<typeof planParallelMigration>) {
+  return { command: "migrate" as const, mode: "dry-run" as const, ...plan };
+}
+
+export function runMigrate(roots: MigrateRoots, args: string[] = []) {
+  let provider: ParallelMigrationProvider | null = null;
+  let actionRef: string | null = null;
+  let format: OutputFormat = "summary";
+  let dryRun = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const option = args[i];
+    if (option === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (["--parallel", "--action-ref", "--format"].includes(option)) {
+      const value = args[++i];
+      if (!value) {
+        console.error(`Missing value for ${option}\n${usage}`);
+        return 1;
+      }
+      if (option === "--parallel") {
+        if (!PROVIDERS.has(value as ParallelMigrationProvider)) {
+          console.error(`Unknown parallel provider: ${value}\n${usage}`);
+          return 1;
+        }
+        provider = value as ParallelMigrationProvider;
+      } else if (option === "--action-ref") {
+        actionRef = value;
+      } else {
+        if (!FORMATS.has(value as OutputFormat)) {
+          console.error(`Unknown migrate format: ${value}\n${usage}`);
+          return 1;
+        }
+        format = value as OutputFormat;
+      }
+      continue;
+    }
+    if (option === "--help") {
+      console.log(usage);
+      return 0;
+    }
+    console.error(`Unknown option for migrate: ${option}\n${usage}`);
+    return 1;
+  }
+
+  if (!dryRun) {
+    console.error(`migrate is read-only in this release slice; pass --dry-run\n${usage}`);
+    return 1;
+  }
+  if (!provider) {
+    console.error(`Missing required --parallel provider\n${usage}`);
+    return 1;
+  }
+  if (!actionRef) {
+    console.error(`Missing required --action-ref\n${usage}`);
+    return 1;
+  }
+
+  let refCheck: ReturnType<typeof validateExplicitActionRef>;
+  try {
+    refCheck = validateExplicitActionRef(actionRef, packageVersion(roots.packageRoot));
+  } catch (error: unknown) {
+    console.error((error as Error).message);
+    return 1;
+  }
+  if (!refCheck.ok) {
+    console.error(refCheck.message);
+    return 1;
+  }
+
+  const providerPath = provider === "portable" ? PORTABLE : NATIVE;
+  const plan = planParallelMigration({
+    provider,
+    actionRef: refCheck.ref as string,
+    files: {
+      [POLICY]: readOptional(roots.repoRoot, POLICY),
+      [TRANSACTION]: readOptional(roots.repoRoot, TRANSACTION),
+      [providerPath]: readOptional(roots.repoRoot, providerPath),
+    },
+  });
+  const payload = migrationPayload(plan);
+  console.log(format === "json" ? JSON.stringify(payload, null, 2) : renderSummary(payload));
+  return plan.readyToApply ? 0 : 1;
+}

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -48,6 +48,10 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
     options: { ...valueOptions("--preset", "--mode", "--action-ref", "--parallel"), "--help": false }, positionals: 0,
     run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
   },
+  migrate: {
+    options: { ...valueOptions("--parallel", "--action-ref", "--format"), "--dry-run": false, "--help": false }, positionals: 0,
+    run: async (roots, args) => (await import("./migrate.mjs")).runMigrate(roots, args),
+  },
   doctor: {
     options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
     run: async (roots, args) => args.includes("--integration")

--- a/tests/test-migrate.mjs
+++ b/tests/test-migrate.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import test from "node:test";
+
+import { renderInitScaffold } from "../dist/init.mjs";
+import { COMMANDS, runCli } from "../dist/repo-guard.mjs";
+
+const ACTION_REF = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+
+function write(repo, path, content) {
+  const target = join(repo, path);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, "utf8");
+}
+
+function legacyRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "repo-guard-migrate-"));
+  const scaffold = renderInitScaffold({ preset: "application", mode: "blocking", actionRef: ACTION_REF });
+  for (const [path, content] of Object.entries(scaffold)) write(repo, path, content);
+  return repo;
+}
+
+function snapshot(root) {
+  const out = {};
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else out[relative(root, path)] = readFileSync(path, "utf8");
+    }
+  }
+  walk(root);
+  return out;
+}
+
+async function capture(args) {
+  const logs = [], errors = [];
+  const oldLog = console.log, oldError = console.error;
+  console.log = (...parts) => logs.push(parts.join(" "));
+  console.error = (...parts) => errors.push(parts.join(" "));
+  try {
+    const exit = await runCli(args);
+    return { exit, stdout: logs.join("\n"), stderr: errors.join("\n") };
+  } finally {
+    console.log = oldLog;
+    console.error = oldError;
+  }
+}
+
+test("P5b migrate dry-run public surface", async (t) => {
+  await t.test("is an additive declarative CLI command", () => {
+    assert.equal(COMMANDS.includes("migrate"), true);
+  });
+
+  await t.test("emits a deterministic portable JSON plan without writing", async () => {
+    const repo = legacyRepo(), before = snapshot(repo);
+    const first = await capture(["--repo-root", repo, "migrate", "--parallel", "portable", "--action-ref", ACTION_REF, "--dry-run", "--format", "json"]);
+    const after = snapshot(repo);
+    assert.equal(first.exit, 0, first.stderr);
+    assert.deepEqual(after, before, "dry-run never changes repository files");
+    const payload = JSON.parse(first.stdout);
+    assert.equal(payload.command, "migrate");
+    assert.equal(payload.mode, "dry-run");
+    assert.equal(payload.provider, "portable");
+    assert.equal(payload.actionRef, ACTION_REF);
+    assert.equal(payload.readyToApply, true);
+    assert.deepEqual(payload.files.map(({ path, action }) => [path, action]), [
+      [PORTABLE, "create"],
+      [TRANSACTION, "replace"],
+      [POLICY, "replace"],
+    ]);
+    assert.deepEqual(payload.external.map(({ id }) => id), ["branch_protection", "ready_label"]);
+
+    const second = await capture(["--repo-root", repo, "migrate", "--parallel", "portable", "--action-ref", ACTION_REF, "--dry-run", "--format", "json"]);
+    assert.equal(second.exit, 0);
+    assert.equal(second.stdout, first.stdout, "same repository snapshot yields byte-stable JSON output");
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("fails closed on a custom workflow and preserves it byte-for-byte", async () => {
+    const repo = legacyRepo();
+    write(repo, TRANSACTION, `${readFileSync(join(repo, TRANSACTION), "utf8")}\n# custom repository step\n`);
+    const before = snapshot(repo);
+    const result = await capture(["--repo-root", repo, "migrate", "--parallel", "portable", "--action-ref", ACTION_REF, "--dry-run", "--format", "json"]);
+    assert.equal(result.exit, 1);
+    assert.deepEqual(snapshot(repo), before);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.readyToApply, false);
+    assert.equal(payload.blockers.some(({ id, path }) => id === "custom_file" && path === TRANSACTION), true);
+  });
+
+  await t.test("requires explicit dry-run before any future apply surface", async () => {
+    const repo = legacyRepo(), before = snapshot(repo);
+    const result = await capture(["--repo-root", repo, "migrate", "--parallel", "portable", "--action-ref", ACTION_REF, "--format", "json"]);
+    assert.equal(result.exit, 1);
+    assert.match(result.stderr, /dry-run/i);
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("rejects mutable Action refs before planning or writing", async () => {
+    const repo = legacyRepo(), before = snapshot(repo);
+    const result = await capture(["--repo-root", repo, "migrate", "--parallel", "portable", "--action-ref", "main", "--dry-run", "--format", "json"]);
+    assert.equal(result.exit, 1);
+    assert.match(result.stderr, /mutable|ambiguous|Action ref/i);
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("uses the same machine protocol for github_merge_queue", async () => {
+    const repo = legacyRepo(), before = snapshot(repo);
+    const result = await capture(["--repo-root", repo, "migrate", "--parallel", "github_merge_queue", "--action-ref", ACTION_REF, "--dry-run", "--format", "json"]);
+    assert.equal(result.exit, 0, result.stderr);
+    assert.deepEqual(snapshot(repo), before);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.provider, "github_merge_queue");
+    assert.deepEqual(payload.files.map(({ path, action }) => [path, action]), [
+      [NATIVE, "create"],
+      [TRANSACTION, "replace"],
+      [POLICY, "replace"],
+    ]);
+    assert.deepEqual(payload.external.map(({ id }) => id), ["merge_queue"]);
+  });
+});

--- a/tests/test-typescript-source-cutover.mjs
+++ b/tests/test-typescript-source-cutover.mjs
@@ -33,7 +33,7 @@ describe("strict TypeScript source cutover", () => {
   });
 
   it("keeps the built CLI command inventory explicit", () => {
-    assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "check-merge-group", "status", "init", "doctor", "portable-coordinator", "validate-integration"]);
+    assert.deepEqual(COMMANDS, ["validate", "check-diff", "check-pr", "check-merge-group", "status", "init", "migrate", "doctor", "portable-coordinator", "validate-integration"]);
   });
 
   it("keeps the privileged portable coordinator on the trusted execFile control-plane boundary", () => {


### PR DESCRIPTION
## Краткое описание

P5b из #310: добавить только read-only migration preview поверх принятого P5a planner. Первый commit test-only и должен подтвердить RED публичного `migrate` surface. Apply/mutation намеренно не входит в этот PR.

Part of #310.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/migrate.mts
  - dist/migrate.mjs
  - src/repo-guard.mts
  - dist/repo-guard.mjs
  - tests/test-migrate.mjs
  - tests/test-typescript-source-cutover.mjs
budgets: {}
anchors:
  affects:
    - "#310"
  implements:
    - "#310"
  verifies:
    - "#310"
must_touch:
  - src/migrate.mts
  - src/repo-guard.mts
  - tests/test-migrate.mjs
must_not_touch:
  - repo-policy.json
  - .github/workflows/**
  - schemas/**
  - action.yml
  - src/migration-plan.mts
  - src/parallel-readiness.mts
  - src/github-control-plane.mts
expected_effects:
  - "`migrate --parallel <portable|github_merge_queue> --action-ref <immutable-ref> --dry-run` становится additive declarative CLI surface."
  - "P5b никогда не пишет repository files и не выполняет GitHub mutations; отсутствие `--dry-run` fail-closed до будущего P5c apply surface."
  - "JSON output детерминирован и повторно использует accepted P5a planner для exact file actions, blockers и external settings evidence."
  - "Custom/unknown workflow остаётся byte-for-byte неизменным и возвращает fail-closed blocker вместо heuristic YAML rewrite."
  - "Existing explicit CLI inventory test признаёт additive `migrate` command и сохраняет mts-only source-cutover boundary."
```
