### PR TITLE
[Parallel P5c] Apply exact-known migration plans safely

### DIFF
--- a/dist/migrate.mjs
+++ b/dist/migrate.mjs
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { validateExplicitActionRef } from "./init.mjs";
+import { applyParallelMigration } from "./migration-apply.mjs";
 import { planParallelMigration } from "./migration-plan.mjs";
 const POLICY = "repo-policy.json";
 const TRANSACTION = ".github/workflows/repo-guard.yml";
@@ -8,7 +9,7 @@ const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
 const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
 const PROVIDERS = new Set(["portable", "github_merge_queue"]);
 const FORMATS = new Set(["summary", "json"]);
-const usage = "Usage: repo-guard migrate --parallel <portable|github_merge_queue> --action-ref <40-char-sha|vX.Y.Z> --dry-run [--format <summary|json>]";
+const usage = "Usage: repo-guard migrate --parallel <portable|github_merge_queue> --action-ref <40-char-sha|vX.Y.Z> (--dry-run|--apply) [--format <summary|json>]";
 function packageVersion(packageRoot) {
     const parsed = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8"));
     if (typeof parsed.version !== "string" || !parsed.version)
@@ -19,6 +20,33 @@ function readOptional(repoRoot, path) {
     const target = resolve(repoRoot, path);
     return existsSync(target) ? readFileSync(target, "utf8") : null;
 }
+function migrationSnapshot(repoRoot) {
+    return {
+        [POLICY]: readOptional(repoRoot, POLICY),
+        [TRANSACTION]: readOptional(repoRoot, TRANSACTION),
+        [PORTABLE]: readOptional(repoRoot, PORTABLE),
+        [NATIVE]: readOptional(repoRoot, NATIVE),
+    };
+}
+function filesystemAdapter(repoRoot) {
+    return {
+        read: (path) => readOptional(repoRoot, path),
+        create(path, content) {
+            const target = resolve(repoRoot, path);
+            if (existsSync(target))
+                throw new Error(`${path} changed after migration preflight; refusing to overwrite it.`);
+            mkdirSync(dirname(target), { recursive: true });
+            writeFileSync(target, content, { encoding: "utf8", flag: "wx" });
+        },
+        replace(path, expectedBefore, content) {
+            const target = resolve(repoRoot, path);
+            const current = readOptional(repoRoot, path);
+            if (current !== expectedBefore)
+                throw new Error(`${path} changed after migration preflight; refusing to overwrite it.`);
+            writeFileSync(target, content, "utf8");
+        },
+    };
+}
 function renderSummary(payload) {
     const lines = [
         `repo-guard migrate (${payload.mode})`,
@@ -28,6 +56,10 @@ function renderSummary(payload) {
         "files:",
         ...payload.files.map(({ action, path }) => `  ${action}: ${path}`),
     ];
+    if (payload.applied !== undefined)
+        lines.push(`applied: ${payload.applied ? "yes" : "no"}`);
+    if (payload.writes?.length)
+        lines.push("writes:", ...payload.writes.map((path) => `  ${path}`));
     if (payload.blockers.length) {
         lines.push("blockers:", ...payload.blockers.map(({ id, path, message }) => `  ${id}${path ? ` (${path})` : ""}: ${message}`));
     }
@@ -36,18 +68,22 @@ function renderSummary(payload) {
     }
     return lines.join("\n");
 }
-function migrationPayload(plan) {
-    return { command: "migrate", mode: "dry-run", ...plan };
+function printPayload(payload, format) {
+    console.log(format === "json" ? JSON.stringify(payload, null, 2) : renderSummary(payload));
 }
 export function runMigrate(roots, args = []) {
     let provider = null;
     let actionRef = null;
     let format = "summary";
     let dryRun = false;
+    let apply = false;
     for (let i = 0; i < args.length; i++) {
         const option = args[i];
-        if (option === "--dry-run") {
-            dryRun = true;
+        if (option === "--dry-run" || option === "--apply") {
+            if (option === "--dry-run")
+                dryRun = true;
+            else
+                apply = true;
             continue;
         }
         if (["--parallel", "--action-ref", "--format"].includes(option)) {
@@ -82,8 +118,8 @@ export function runMigrate(roots, args = []) {
         console.error(`Unknown option for migrate: ${option}\n${usage}`);
         return 1;
     }
-    if (!dryRun) {
-        console.error(`migrate is read-only in this release slice; pass --dry-run\n${usage}`);
+    if (dryRun === apply) {
+        console.error(`migrate requires exactly one of --dry-run or --apply\n${usage}`);
         return 1;
     }
     if (!provider) {
@@ -106,17 +142,23 @@ export function runMigrate(roots, args = []) {
         console.error(refCheck.message);
         return 1;
     }
-    const providerPath = provider === "portable" ? PORTABLE : NATIVE;
-    const plan = planParallelMigration({
+    const immutableRef = refCheck.ref;
+    if (dryRun) {
+        const plan = planParallelMigration({
+            provider,
+            actionRef: immutableRef,
+            files: migrationSnapshot(roots.repoRoot),
+        });
+        const payload = { command: "migrate", mode: "dry-run", ...plan };
+        printPayload(payload, format);
+        return plan.readyToApply ? 0 : 1;
+    }
+    const result = applyParallelMigration({
         provider,
-        actionRef: refCheck.ref,
-        files: {
-            [POLICY]: readOptional(roots.repoRoot, POLICY),
-            [TRANSACTION]: readOptional(roots.repoRoot, TRANSACTION),
-            [providerPath]: readOptional(roots.repoRoot, providerPath),
-        },
+        actionRef: immutableRef,
+        io: filesystemAdapter(roots.repoRoot),
     });
-    const payload = migrationPayload(plan);
-    console.log(format === "json" ? JSON.stringify(payload, null, 2) : renderSummary(payload));
-    return plan.readyToApply ? 0 : 1;
+    const payload = { command: "migrate", mode: "apply", ...result };
+    printPayload(payload, format);
+    return result.applied && result.readyToApply ? 0 : 1;
 }

--- a/dist/migration-apply.mjs
+++ b/dist/migration-apply.mjs
@@ -1,0 +1,53 @@
+import { planParallelMigration, } from "./migration-plan.mjs";
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const MIGRATION_PATHS = [PORTABLE, NATIVE, TRANSACTION, POLICY];
+function snapshot(io) {
+    return Object.fromEntries(MIGRATION_PATHS.map((path) => [path, io.read(path)]));
+}
+export function applyParallelMigration(input) {
+    const before = snapshot(input.io);
+    const plan = planParallelMigration({
+        provider: input.provider,
+        actionRef: input.actionRef,
+        files: before,
+    });
+    if (!plan.readyToApply) {
+        return { ...plan, applied: false, writes: [] };
+    }
+    const current = snapshot(input.io);
+    const driftPath = MIGRATION_PATHS.find((path) => current[path] !== before[path]);
+    if (driftPath) {
+        const blocker = {
+            id: "stale_snapshot",
+            path: driftPath,
+            message: `${driftPath} changed after migration planning; refusing to apply any writes.`,
+        };
+        return {
+            ...plan,
+            readyToApply: false,
+            blockers: [...plan.blockers, blocker],
+            applied: false,
+            writes: [],
+        };
+    }
+    const writes = [];
+    for (const file of plan.files) {
+        if (file.action === "unchanged")
+            continue;
+        if (file.action === "create") {
+            input.io.create(file.path, file.after);
+            writes.push(file.path);
+            continue;
+        }
+        if (file.action === "replace") {
+            input.io.replace(file.path, file.before, file.after);
+            writes.push(file.path);
+            continue;
+        }
+        throw new Error(`Invariant violation: blocked migration action reached apply for ${file.path}`);
+    }
+    return { ...plan, applied: true, writes };
+}

--- a/dist/migration-plan.mjs
+++ b/dist/migration-plan.mjs
@@ -9,6 +9,9 @@ const IMMUTABLE_REF = /^(?:[0-9a-f]{40}|v\d+\.\d+\.\d+)$/i;
 function providerPath(provider) {
     return provider === "portable" ? PORTABLE : NATIVE;
 }
+function oppositeProviderPath(provider) {
+    return provider === "portable" ? NATIVE : PORTABLE;
+}
 function externalSteps(provider) {
     return provider === "portable"
         ? [
@@ -72,6 +75,14 @@ export function planParallelMigration(input) {
         return { provider: input.provider, actionRef: input.actionRef, readyToApply: false, files: [], blockers, external: externalSteps(input.provider) };
     }
     const path = providerPath(input.provider);
+    const oppositePath = oppositeProviderPath(input.provider);
+    if (input.files[oppositePath] !== null && input.files[oppositePath] !== undefined) {
+        blockers.push({
+            id: "provider_conflict",
+            path: oppositePath,
+            message: `${oppositePath} already exists; refusing to switch or combine parallel providers automatically.`,
+        });
+    }
     const files = [
         planProviderFile(path, input.files[path], known.target[path], blockers),
         planKnownFile(TRANSACTION, input.files[TRANSACTION], known.legacy[TRANSACTION], known.target[TRANSACTION], blockers),

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -33,7 +33,7 @@ const COMMAND_SPECS = {
         run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
     },
     migrate: {
-        options: { ...valueOptions("--parallel", "--action-ref", "--format"), "--dry-run": false, "--help": false }, positionals: 0,
+        options: { ...valueOptions("--parallel", "--action-ref", "--format"), "--dry-run": false, "--apply": false, "--help": false }, positionals: 0,
         run: async (roots, args) => (await import("./migrate.mjs")).runMigrate(roots, args),
     },
     doctor: {

--- a/src/migrate.mts
+++ b/src/migrate.mts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { validateExplicitActionRef } from "./init.mjs";
+import { applyParallelMigration, type MigrationFileAdapter } from "./migration-apply.mjs";
 import { planParallelMigration, type ParallelMigrationProvider } from "./migration-plan.mjs";
 
 interface MigrateRoots {
@@ -9,6 +10,20 @@ interface MigrateRoots {
 }
 
 type OutputFormat = "summary" | "json";
+type MigrateMode = "dry-run" | "apply";
+
+interface MigrationOutput {
+  command: "migrate";
+  mode: MigrateMode;
+  provider: ParallelMigrationProvider;
+  actionRef: string;
+  readyToApply: boolean;
+  files: Array<{ path: string; action: string }>;
+  blockers: Array<{ id: string; path?: string; message: string }>;
+  external: Array<{ id: string; message: string }>;
+  applied?: boolean;
+  writes?: string[];
+}
 
 const POLICY = "repo-policy.json";
 const TRANSACTION = ".github/workflows/repo-guard.yml";
@@ -16,7 +31,7 @@ const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
 const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
 const PROVIDERS = new Set<ParallelMigrationProvider>(["portable", "github_merge_queue"]);
 const FORMATS = new Set<OutputFormat>(["summary", "json"]);
-const usage = "Usage: repo-guard migrate --parallel <portable|github_merge_queue> --action-ref <40-char-sha|vX.Y.Z> --dry-run [--format <summary|json>]";
+const usage = "Usage: repo-guard migrate --parallel <portable|github_merge_queue> --action-ref <40-char-sha|vX.Y.Z> (--dry-run|--apply) [--format <summary|json>]";
 
 function packageVersion(packageRoot: string) {
   const parsed = JSON.parse(readFileSync(resolve(packageRoot, "package.json"), "utf8")) as { version?: unknown };
@@ -29,7 +44,34 @@ function readOptional(repoRoot: string, path: string) {
   return existsSync(target) ? readFileSync(target, "utf8") : null;
 }
 
-function renderSummary(payload: ReturnType<typeof migrationPayload>) {
+function migrationSnapshot(repoRoot: string) {
+  return {
+    [POLICY]: readOptional(repoRoot, POLICY),
+    [TRANSACTION]: readOptional(repoRoot, TRANSACTION),
+    [PORTABLE]: readOptional(repoRoot, PORTABLE),
+    [NATIVE]: readOptional(repoRoot, NATIVE),
+  };
+}
+
+function filesystemAdapter(repoRoot: string): MigrationFileAdapter {
+  return {
+    read: (path) => readOptional(repoRoot, path),
+    create(path, content) {
+      const target = resolve(repoRoot, path);
+      if (existsSync(target)) throw new Error(`${path} changed after migration preflight; refusing to overwrite it.`);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, content, { encoding: "utf8", flag: "wx" });
+    },
+    replace(path, expectedBefore, content) {
+      const target = resolve(repoRoot, path);
+      const current = readOptional(repoRoot, path);
+      if (current !== expectedBefore) throw new Error(`${path} changed after migration preflight; refusing to overwrite it.`);
+      writeFileSync(target, content, "utf8");
+    },
+  };
+}
+
+function renderSummary(payload: MigrationOutput) {
   const lines = [
     `repo-guard migrate (${payload.mode})`,
     `provider: ${payload.provider}`,
@@ -38,6 +80,8 @@ function renderSummary(payload: ReturnType<typeof migrationPayload>) {
     "files:",
     ...payload.files.map(({ action, path }) => `  ${action}: ${path}`),
   ];
+  if (payload.applied !== undefined) lines.push(`applied: ${payload.applied ? "yes" : "no"}`);
+  if (payload.writes?.length) lines.push("writes:", ...payload.writes.map((path) => `  ${path}`));
   if (payload.blockers.length) {
     lines.push("blockers:", ...payload.blockers.map(({ id, path, message }) => `  ${id}${path ? ` (${path})` : ""}: ${message}`));
   }
@@ -47,8 +91,8 @@ function renderSummary(payload: ReturnType<typeof migrationPayload>) {
   return lines.join("\n");
 }
 
-function migrationPayload(plan: ReturnType<typeof planParallelMigration>) {
-  return { command: "migrate" as const, mode: "dry-run" as const, ...plan };
+function printPayload(payload: MigrationOutput, format: OutputFormat) {
+  console.log(format === "json" ? JSON.stringify(payload, null, 2) : renderSummary(payload));
 }
 
 export function runMigrate(roots: MigrateRoots, args: string[] = []) {
@@ -56,11 +100,13 @@ export function runMigrate(roots: MigrateRoots, args: string[] = []) {
   let actionRef: string | null = null;
   let format: OutputFormat = "summary";
   let dryRun = false;
+  let apply = false;
 
   for (let i = 0; i < args.length; i++) {
     const option = args[i];
-    if (option === "--dry-run") {
-      dryRun = true;
+    if (option === "--dry-run" || option === "--apply") {
+      if (option === "--dry-run") dryRun = true;
+      else apply = true;
       continue;
     }
     if (["--parallel", "--action-ref", "--format"].includes(option)) {
@@ -94,8 +140,8 @@ export function runMigrate(roots: MigrateRoots, args: string[] = []) {
     return 1;
   }
 
-  if (!dryRun) {
-    console.error(`migrate is read-only in this release slice; pass --dry-run\n${usage}`);
+  if (dryRun === apply) {
+    console.error(`migrate requires exactly one of --dry-run or --apply\n${usage}`);
     return 1;
   }
   if (!provider) {
@@ -118,18 +164,25 @@ export function runMigrate(roots: MigrateRoots, args: string[] = []) {
     console.error(refCheck.message);
     return 1;
   }
+  const immutableRef = refCheck.ref as string;
 
-  const providerPath = provider === "portable" ? PORTABLE : NATIVE;
-  const plan = planParallelMigration({
+  if (dryRun) {
+    const plan = planParallelMigration({
+      provider,
+      actionRef: immutableRef,
+      files: migrationSnapshot(roots.repoRoot),
+    });
+    const payload: MigrationOutput = { command: "migrate", mode: "dry-run", ...plan };
+    printPayload(payload, format);
+    return plan.readyToApply ? 0 : 1;
+  }
+
+  const result = applyParallelMigration({
     provider,
-    actionRef: refCheck.ref as string,
-    files: {
-      [POLICY]: readOptional(roots.repoRoot, POLICY),
-      [TRANSACTION]: readOptional(roots.repoRoot, TRANSACTION),
-      [providerPath]: readOptional(roots.repoRoot, providerPath),
-    },
+    actionRef: immutableRef,
+    io: filesystemAdapter(roots.repoRoot),
   });
-  const payload = migrationPayload(plan);
-  console.log(format === "json" ? JSON.stringify(payload, null, 2) : renderSummary(payload));
-  return plan.readyToApply ? 0 : 1;
+  const payload: MigrationOutput = { command: "migrate", mode: "apply", ...result };
+  printPayload(payload, format);
+  return result.applied && result.readyToApply ? 0 : 1;
 }

--- a/src/migration-apply.mts
+++ b/src/migration-apply.mts
@@ -1,0 +1,81 @@
+import {
+  planParallelMigration,
+  type ParallelMigrationBlocker,
+  type ParallelMigrationProvider,
+} from "./migration-plan.mjs";
+
+export interface MigrationFileAdapter {
+  read(path: string): string | null | undefined;
+  create(path: string, content: string): void;
+  replace(path: string, expectedBefore: string, content: string): void;
+}
+
+export interface ApplyParallelMigrationInput {
+  provider: ParallelMigrationProvider;
+  actionRef: string;
+  io: MigrationFileAdapter;
+}
+
+export interface MigrationApplyBlocker {
+  id: "stale_snapshot";
+  path: string;
+  message: string;
+}
+
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+const MIGRATION_PATHS = [PORTABLE, NATIVE, TRANSACTION, POLICY] as const;
+
+function snapshot(io: MigrationFileAdapter) {
+  return Object.fromEntries(MIGRATION_PATHS.map((path) => [path, io.read(path)]));
+}
+
+export function applyParallelMigration(input: ApplyParallelMigrationInput) {
+  const before = snapshot(input.io);
+  const plan = planParallelMigration({
+    provider: input.provider,
+    actionRef: input.actionRef,
+    files: before,
+  });
+
+  if (!plan.readyToApply) {
+    return { ...plan, applied: false as const, writes: [] as string[] };
+  }
+
+  const current = snapshot(input.io);
+  const driftPath = MIGRATION_PATHS.find((path) => current[path] !== before[path]);
+  if (driftPath) {
+    const blocker: MigrationApplyBlocker = {
+      id: "stale_snapshot",
+      path: driftPath,
+      message: `${driftPath} changed after migration planning; refusing to apply any writes.`,
+    };
+    return {
+      ...plan,
+      readyToApply: false,
+      blockers: [...plan.blockers, blocker] as Array<ParallelMigrationBlocker | MigrationApplyBlocker>,
+      applied: false as const,
+      writes: [] as string[],
+    };
+  }
+
+  const writes: string[] = [];
+  for (const file of plan.files) {
+    if (file.action === "unchanged") continue;
+    if (file.action === "create") {
+      input.io.create(file.path, file.after);
+      writes.push(file.path);
+      continue;
+    }
+    if (file.action === "replace") {
+      input.io.replace(file.path, file.before as string, file.after);
+      writes.push(file.path);
+      continue;
+    }
+    throw new Error(`Invariant violation: blocked migration action reached apply for ${file.path}`);
+  }
+
+  return { ...plan, applied: true as const, writes };
+}

--- a/src/migration-plan.mts
+++ b/src/migration-plan.mts
@@ -19,7 +19,7 @@ export interface ParallelMigrationFilePlan {
 }
 
 export interface ParallelMigrationBlocker {
-  id: "custom_file" | "unknown_scaffold" | "invalid_action_ref";
+  id: "custom_file" | "unknown_scaffold" | "invalid_action_ref" | "provider_conflict";
   path?: string;
   message: string;
 }
@@ -48,6 +48,10 @@ const IMMUTABLE_REF = /^(?:[0-9a-f]{40}|v\d+\.\d+\.\d+)$/i;
 
 function providerPath(provider: ParallelMigrationProvider) {
   return provider === "portable" ? PORTABLE : NATIVE;
+}
+
+function oppositeProviderPath(provider: ParallelMigrationProvider) {
+  return provider === "portable" ? NATIVE : PORTABLE;
 }
 
 function externalSteps(provider: ParallelMigrationProvider): ParallelMigrationExternalStep[] {
@@ -129,6 +133,15 @@ export function planParallelMigration(input: ParallelMigrationInput): ParallelMi
   }
 
   const path = providerPath(input.provider);
+  const oppositePath = oppositeProviderPath(input.provider);
+  if (input.files[oppositePath] !== null && input.files[oppositePath] !== undefined) {
+    blockers.push({
+      id: "provider_conflict",
+      path: oppositePath,
+      message: `${oppositePath} already exists; refusing to switch or combine parallel providers automatically.`,
+    });
+  }
+
   const files = [
     planProviderFile(path, input.files[path], known.target[path], blockers),
     planKnownFile(TRANSACTION, input.files[TRANSACTION], known.legacy[TRANSACTION], known.target[TRANSACTION], blockers),

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -49,7 +49,7 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
     run: async (roots, args) => (await import("./init.mjs")).runInit(roots, args),
   },
   migrate: {
-    options: { ...valueOptions("--parallel", "--action-ref", "--format"), "--dry-run": false, "--help": false }, positionals: 0,
+    options: { ...valueOptions("--parallel", "--action-ref", "--format"), "--dry-run": false, "--apply": false, "--help": false }, positionals: 0,
     run: async (roots, args) => (await import("./migrate.mjs")).runMigrate(roots, args),
   },
   doctor: {

--- a/tests/test-migrate-apply.mjs
+++ b/tests/test-migrate-apply.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import test from "node:test";
+
+import { renderInitScaffold } from "../dist/init.mjs";
+import { runCli } from "../dist/repo-guard.mjs";
+
+const ACTION_REF = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const POLICY = "repo-policy.json";
+const TRANSACTION = ".github/workflows/repo-guard.yml";
+const PORTABLE = ".github/workflows/repo-guard-portable-coordinator.yml";
+const NATIVE = ".github/workflows/repo-guard-merge-group.yml";
+
+function write(repo, path, content) {
+  const target = join(repo, path);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, "utf8");
+}
+
+function legacyRepo() {
+  const repo = mkdtempSync(join(tmpdir(), "repo-guard-migrate-apply-"));
+  const scaffold = renderInitScaffold({ preset: "application", mode: "blocking", actionRef: ACTION_REF });
+  for (const [path, content] of Object.entries(scaffold)) write(repo, path, content);
+  return repo;
+}
+
+function snapshot(root) {
+  const out = {};
+  function walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else out[relative(root, path)] = readFileSync(path, "utf8");
+    }
+  }
+  walk(root);
+  return out;
+}
+
+async function capture(args) {
+  const logs = [], errors = [];
+  const oldLog = console.log, oldError = console.error;
+  console.log = (...parts) => logs.push(parts.join(" "));
+  console.error = (...parts) => errors.push(parts.join(" "));
+  try {
+    const exit = await runCli(args);
+    return { exit, stdout: logs.join("\n"), stderr: errors.join("\n") };
+  } finally {
+    console.log = oldLog;
+    console.error = oldError;
+  }
+}
+
+function applyArgs(repo, provider = "portable") {
+  return ["--repo-root", repo, "migrate", "--parallel", provider, "--action-ref", ACTION_REF, "--apply", "--format", "json"];
+}
+
+test("P5c known-template migration apply", async (t) => {
+  await t.test("applies only the exact known portable scaffold", async () => {
+    const repo = legacyRepo();
+    const expected = renderInitScaffold({ preset: "application", mode: "blocking", actionRef: ACTION_REF, parallel: "portable" });
+
+    const result = await capture(applyArgs(repo));
+    assert.equal(result.exit, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.command, "migrate");
+    assert.equal(payload.mode, "apply");
+    assert.equal(payload.provider, "portable");
+    assert.equal(payload.applied, true);
+    assert.deepEqual(payload.writes, [PORTABLE, TRANSACTION, POLICY]);
+    assert.deepEqual(snapshot(repo), expected);
+  });
+
+  await t.test("is idempotent after the target scaffold is already exact", async () => {
+    const repo = legacyRepo();
+    const first = await capture(applyArgs(repo));
+    assert.equal(first.exit, 0, first.stderr);
+    const before = snapshot(repo);
+
+    const second = await capture(applyArgs(repo));
+    assert.equal(second.exit, 0, second.stderr);
+    const payload = JSON.parse(second.stdout);
+    assert.equal(payload.applied, true);
+    assert.deepEqual(payload.writes, []);
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("refuses a custom repository workflow with zero writes", async () => {
+    const repo = legacyRepo();
+    write(repo, TRANSACTION, `${readFileSync(join(repo, TRANSACTION), "utf8")}\n# repository-owned customization\n`);
+    const before = snapshot(repo);
+
+    const result = await capture(applyArgs(repo));
+    assert.equal(result.exit, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.applied, false);
+    assert.deepEqual(payload.writes, []);
+    assert.equal(payload.blockers.some(({ id, path }) => id === "custom_file" && path === TRANSACTION), true);
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("requires exactly one of dry-run or apply", async () => {
+    const repo = legacyRepo(), before = snapshot(repo);
+    const result = await capture([...applyArgs(repo), "--dry-run"]);
+    assert.equal(result.exit, 1);
+    assert.match(result.stderr, /dry-run|apply|exactly one|mutually exclusive/i);
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("refuses an opposite-provider scaffold instead of switching providers", async () => {
+    const repo = legacyRepo();
+    const native = renderInitScaffold({ preset: "application", mode: "blocking", actionRef: ACTION_REF, parallel: "github_merge_queue" });
+    write(repo, NATIVE, native[NATIVE]);
+    const before = snapshot(repo);
+
+    const result = await capture(applyArgs(repo, "portable"));
+    assert.equal(result.exit, 1);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.applied, false);
+    assert.deepEqual(payload.writes, []);
+    assert.equal(payload.blockers.some(({ id, path }) => id === "provider_conflict" && path === NATIVE), true);
+    assert.deepEqual(snapshot(repo), before);
+  });
+
+  await t.test("revalidates the complete snapshot before the first write", async () => {
+    const { applyParallelMigration } = await import("../dist/migration-apply.mjs");
+    const legacy = renderInitScaffold({ preset: "application", mode: "blocking", actionRef: ACTION_REF });
+    const files = {
+      [POLICY]: legacy[POLICY],
+      [TRANSACTION]: legacy[TRANSACTION],
+      [PORTABLE]: null,
+      [NATIVE]: null,
+    };
+    const reads = new Map(), writes = [];
+    const io = {
+      read(path) {
+        const count = (reads.get(path) ?? 0) + 1;
+        reads.set(path, count);
+        if (path === TRANSACTION && count === 2) return `${files[path]}\n# concurrent drift\n`;
+        return files[path] ?? null;
+      },
+      create(path, content) {
+        writes.push(["create", path]);
+        files[path] = content;
+      },
+      replace(path, expectedBefore, content) {
+        writes.push(["replace", path, expectedBefore]);
+        files[path] = content;
+      },
+    };
+
+    const result = await applyParallelMigration({ provider: "portable", actionRef: ACTION_REF, io });
+    assert.equal(result.applied, false);
+    assert.deepEqual(result.writes, []);
+    assert.deepEqual(writes, []);
+    assert.equal(result.blockers.some(({ id, path }) => id === "stale_snapshot" && path === TRANSACTION), true);
+    assert.equal([...reads.values()].every((count) => count >= 2), true, "every migration precondition is re-read before mutation");
+  });
+});


### PR DESCRIPTION
## Краткое описание

P5c из #310: добавить opt-in `migrate --apply` поверх принятого P5a planner/P5b dry-run. Первый commit test-only и обязан подтвердить RED. Apply разрешён только для exact-known repo-guard scaffold после полного preflight; custom/unknown/provider-conflict/drift до первой записи должны завершаться с `writes=0`.

Part of #310.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - src/migration-apply.mts
  - dist/migration-apply.mjs
  - src/migration-plan.mts
  - dist/migration-plan.mjs
  - src/migrate.mts
  - dist/migrate.mjs
  - src/repo-guard.mts
  - dist/repo-guard.mjs
  - tests/test-migrate-apply.mjs
budgets: {}
anchors:
  affects:
    - "#310"
  implements:
    - "#310"
  verifies:
    - "#310"
must_touch:
  - src/migration-apply.mts
  - src/migration-plan.mts
  - src/migrate.mts
  - src/repo-guard.mts
  - tests/test-migrate-apply.mjs
must_not_touch:
  - repo-policy.json
  - .github/workflows/**
  - schemas/**
  - action.yml
  - src/parallel-readiness.mts
  - src/github-control-plane.mts
expected_effects:
  - "`migrate --apply` применяет только exact-known create/replace actions из canonical P5a planner; `--dry-run` сохраняет прежнюю read-only семантику."
  - "Перед первой mutation полный repository migration snapshot перечитывается byte-for-byte; любой drift завершает apply с `writes=0`."
  - "Custom/unknown scaffold и существующий opposite-provider workflow fail-closed и не переписываются heuristic YAML editing."
  - "Apply идемпотентен: exact target scaffold повторно даёт успешный result без writes."
  - "`--dry-run` и `--apply` взаимоисключающие explicit modes; immutable Action ref остаётся обязательным."
```
