### PR TITLE
[Parallel P6a] Prepare portable self-host repository wiring

### DIFF
--- a/.github/workflows/repo-guard-portable-coordinator.yml
+++ b/.github/workflows/repo-guard-portable-coordinator.yml
@@ -1,0 +1,31 @@
+name: Portable coordinator repo-guard
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  integrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Интегрировать один READY-кандидат
+        uses: netkeep80/repo-guard@f9aae6f6de54b434f7645494637e10f64d4e7577
+        with:
+          mode: portable-coordinator
+          enforcement: blocking
+          repository: ${{ github.repository }}
+          ready-label: repo-guard:ready
+          merge-method: squash
+          transaction-checks: |
+            validate
+            smoke-pack
+          state-checks: |
+            validate
+            smoke-pack
+          format: json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/repo-policy.json
+++ b/repo-policy.json
@@ -29,6 +29,27 @@
           "summary": true,
           "disallow": ["continue_on_error", "manual_clone", "direct_temp_cli_execution"]
         }
+      },
+      {
+        "id": "repo-guard-portable-coordinator",
+        "kind": "github_actions",
+        "path": ".github/workflows/repo-guard-portable-coordinator.yml",
+        "role": "repo_guard_portable_coordinator",
+        "expect": {
+          "events": ["workflow_dispatch"],
+          "action": {
+            "uses": "netkeep80/repo-guard",
+            "ref_pinning": "sha"
+          },
+          "mode": "portable-coordinator",
+          "enforcement": "blocking",
+          "permissions": {
+            "contents": "write",
+            "pull-requests": "write",
+            "checks": "read"
+          },
+          "token_env": ["GH_TOKEN"]
+        }
       }
     ],
     "templates": [

--- a/tests/test-self-host-portable-wiring.mjs
+++ b/tests/test-self-host-portable-wiring.mjs
@@ -1,0 +1,96 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseYaml } from "../dist/document-facts.mjs";
+import { extractIntegration } from "../dist/extractors/integration.mjs";
+import { evaluateParallelReadiness } from "../dist/parallel-readiness.mjs";
+
+const projectRoot = resolve(new URL("..", import.meta.url).pathname);
+const coordinatorPath = ".github/workflows/repo-guard-portable-coordinator.yml";
+const acceptedSelfPin = "f9aae6f6de54b434f7645494637e10f64d4e7577";
+const read = (path) => readFileSync(resolve(projectRoot, path), "utf8");
+const policy = JSON.parse(read("repo-policy.json"));
+
+function integrationTrackedFiles() {
+  return [...new Set([
+    ...(policy.integration?.workflows || []).map((item) => item.path),
+    ...(policy.integration?.templates || []).map((item) => item.path),
+    ...(policy.integration?.docs || []).map((item) => item.path),
+    ...(policy.integration?.profiles || []).map((item) => item.doc_path),
+  ])];
+}
+
+describe("P6a portable self-host repository wiring", () => {
+  it("declares the portable coordinator alongside the existing self PR gate", () => {
+    const transaction = policy.integration.workflows.find((item) => item.role === "repo_guard_pr_gate");
+    const coordinator = policy.integration.workflows.find((item) => item.role === "repo_guard_portable_coordinator");
+
+    assert.ok(transaction, "existing self PR gate must remain declared");
+    assert.equal(transaction.path, ".github/workflows/ci.yml");
+    assert.ok(coordinator, "portable self-host coordinator must be declared");
+    assert.equal(coordinator.path, coordinatorPath);
+    assert.deepEqual(coordinator.expect, {
+      events: ["workflow_dispatch"],
+      action: { uses: "netkeep80/repo-guard", ref_pinning: "sha" },
+      mode: "portable-coordinator",
+      enforcement: "blocking",
+      permissions: {
+        contents: "write",
+        "pull-requests": "write",
+        checks: "read",
+      },
+      token_env: ["GH_TOKEN"],
+    });
+  });
+
+  it("pins a privileged-safe coordinator to the accepted exact self SHA and real CI checks", () => {
+    assert.equal(existsSync(resolve(projectRoot, coordinatorPath)), true, "portable coordinator workflow must exist");
+    const text = read(coordinatorPath);
+    const workflow = parseYaml(text);
+    const step = workflow.jobs?.integrate?.steps?.find((item) => item.uses?.startsWith("netkeep80/repo-guard@"));
+
+    assert.deepEqual(workflow.permissions, {
+      contents: "write",
+      "pull-requests": "write",
+      checks: "read",
+    });
+    assert.ok(step, "portable coordinator Action step must exist");
+    assert.equal(step.uses, `netkeep80/repo-guard@${acceptedSelfPin}`);
+    assert.equal(step.with.mode, "portable-coordinator");
+    assert.equal(step.with.enforcement, "blocking");
+    assert.equal(step.with["ready-label"], "repo-guard:ready");
+    assert.equal(step.with["merge-method"], "squash");
+    assert.equal(step.with["transaction-checks"], "validate\nsmoke-pack\n");
+    assert.equal(step.with["state-checks"], "validate\nsmoke-pack\n");
+    assert.equal(step.env.GH_TOKEN, "${{ secrets.GITHUB_TOKEN }}");
+    assert.equal(workflow.jobs.integrate.steps.some((item) => item.uses?.startsWith("actions/checkout@")), false);
+    assert.equal(workflow.jobs.integrate.steps.some((item) => typeof item.run === "string"), false);
+  });
+
+  it("is repository-ready when the separate portable control-plane facts are green", () => {
+    assert.equal(existsSync(resolve(projectRoot, coordinatorPath)), true, "portable coordinator workflow must exist before readiness evaluation");
+    const integrationFacts = extractIntegration(policy, {
+      repoRoot: projectRoot,
+      trackedFiles: integrationTrackedFiles(),
+      readFile: read,
+    });
+    const report = evaluateParallelReadiness({
+      provider: "portable",
+      integrationFacts,
+      controlPlaneFacts: {
+        targetBranch: "main",
+        requiredChecks: ["validate", "smoke-pack"],
+        pullRequestRequired: true,
+        requiredChecksEnforced: true,
+        noBypass: true,
+        upToDateRequired: true,
+      },
+    });
+
+    assert.equal(report.ready, true, JSON.stringify(report.blockers));
+    assert.deepEqual(report.blockers, []);
+    assert.equal(report.evidence.repository.transactionWorkflow, ".github/workflows/ci.yml");
+    assert.equal(report.evidence.repository.providerWorkflow, coordinatorPath);
+  });
+});


### PR DESCRIPTION
## Краткое описание

P6a из #340: подготовить repository-side wiring для portable self-hosting без включения branch protection/ruleset и без release/version mutation. Первый commit test-only и должен подтвердить RED до любых governance изменений.

Fixes #340.

## Намерение изменения

```repo-guard-yaml
change_type: feature
scope:
  - tests/test-self-host-portable-wiring.mjs
  - repo-policy.json
  - .github/workflows/repo-guard-portable-coordinator.yml
budgets: {}
anchors:
  affects:
    - "#340"
  implements:
    - "#340"
  verifies:
    - "#340"
must_touch:
  - tests/test-self-host-portable-wiring.mjs
  - repo-policy.json
  - .github/workflows/repo-guard-portable-coordinator.yml
must_not_touch:
  - .github/workflows/ci.yml
  - src/**
  - dist/**
  - schemas/**
  - action.yml
  - package.json
  - package-lock.json
expected_effects:
  - "Existing self CI remains authoritative and unchanged."
  - "A separate privileged portable coordinator is pinned to the exact accepted SHA."
  - "repo-policy declares the portable coordinator without replacing the transaction gate."
  - "Repository readiness becomes valid independently of the still-disabled control plane."
  - "No branch protection, ruleset, package, version, tag or release mutation occurs in P6a."
```

Governance authorization is recorded in #340 and is limited to `repo-policy.json` plus `.github/workflows/repo-guard-portable-coordinator.yml` with no policy relaxation.