### PR TITLE
[Parallel P6b3] Prove real portable readiness in self CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run P6b3 wiring contract test
+        run: node --test tests/test-self-host-portable-wiring.mjs
+
       - name: Probe branch protection GraphQL visibility
         run: >-
           gh api graphql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Run portable readiness diagnostics on self
+        run: npx repo-guard doctor --parallel portable
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run discovered test suite
         run: npm test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,22 +43,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run P6b3 wiring contract test
-        run: node --test tests/test-self-host-portable-wiring.mjs
-
-      - name: Probe branch protection GraphQL visibility
-        run: >-
-          gh api graphql
-          -f 'query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){branchProtectionRules(first:20){nodes{pattern allowsDeletions allowsForcePushes isAdminEnforced requiresApprovingReviews requiredApprovingReviewCount requiresStatusChecks requiresStrictStatusChecks requiredStatusChecks{context app{databaseId slug}} bypassPullRequestAllowances(first:20){totalCount}}}}}'
-          -F owner=netkeep80
-          -F name=repo-guard
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run portable readiness diagnostics on self
         run: npx repo-guard doctor --parallel portable
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_GUARD_CONTROL_PLANE_TOKEN }}
 
       - name: Run discovered test suite
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Probe branch protection GraphQL visibility
+        run: >-
+          gh api graphql
+          -f 'query=query($owner:String!,$name:String!){repository(owner:$owner,name:$name){branchProtectionRules(first:20){nodes{pattern allowsDeletions allowsForcePushes isAdminEnforced requiresApprovingReviews requiredApprovingReviewCount requiresStatusChecks requiresStrictStatusChecks requiredStatusChecks{context app{databaseId slug}} bypassPullRequestAllowances(first:20){totalCount}}}}}'
+          -F owner=netkeep80
+          -F name=repo-guard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run portable readiness diagnostics on self
         run: npx repo-guard doctor --parallel portable
         env:

--- a/tests/test-self-host-portable-wiring.mjs
+++ b/tests/test-self-host-portable-wiring.mjs
@@ -74,7 +74,7 @@ describe("P6a portable self-host repository wiring", () => {
     const step = workflow.jobs?.validate?.steps?.find((item) => item.run === "npx repo-guard doctor --parallel portable");
 
     assert.ok(step, "self CI must execute doctor --parallel portable");
-    assert.equal(step.env?.GH_TOKEN, "${{ secrets.GITHUB_TOKEN }}");
+    assert.equal(step.env?.GH_TOKEN, "${{ secrets.REPO_GUARD_CONTROL_PLANE_TOKEN }}");
   });
 
   it("is repository-ready when the separate portable control-plane facts are green", () => {

--- a/tests/test-self-host-portable-wiring.mjs
+++ b/tests/test-self-host-portable-wiring.mjs
@@ -8,6 +8,7 @@ import { evaluateParallelReadiness } from "../dist/parallel-readiness.mjs";
 
 const projectRoot = resolve(new URL("..", import.meta.url).pathname);
 const coordinatorPath = ".github/workflows/repo-guard-portable-coordinator.yml";
+const selfCiPath = ".github/workflows/ci.yml";
 const acceptedSelfPin = "f9aae6f6de54b434f7645494637e10f64d4e7577";
 const read = (path) => readFileSync(resolve(projectRoot, path), "utf8");
 const policy = JSON.parse(read("repo-policy.json"));
@@ -27,7 +28,7 @@ describe("P6a portable self-host repository wiring", () => {
     const coordinator = policy.integration.workflows.find((item) => item.role === "repo_guard_portable_coordinator");
 
     assert.ok(transaction, "existing self PR gate must remain declared");
-    assert.equal(transaction.path, ".github/workflows/ci.yml");
+    assert.equal(transaction.path, selfCiPath);
     assert.ok(coordinator, "portable self-host coordinator must be declared");
     assert.equal(coordinator.path, coordinatorPath);
     assert.deepEqual(coordinator.expect, {
@@ -68,6 +69,14 @@ describe("P6a portable self-host repository wiring", () => {
     assert.equal(workflow.jobs.integrate.steps.some((item) => typeof item.run === "string"), false);
   });
 
+  it("executes canonical portable readiness against real GitHub facts in self CI", () => {
+    const workflow = parseYaml(read(selfCiPath));
+    const step = workflow.jobs?.validate?.steps?.find((item) => item.run === "npx repo-guard doctor --parallel portable");
+
+    assert.ok(step, "self CI must execute doctor --parallel portable");
+    assert.equal(step.env?.GH_TOKEN, "${{ secrets.GITHUB_TOKEN }}");
+  });
+
   it("is repository-ready when the separate portable control-plane facts are green", () => {
     assert.equal(existsSync(resolve(projectRoot, coordinatorPath)), true, "portable coordinator workflow must exist before readiness evaluation");
     const integrationFacts = extractIntegration(policy, {
@@ -90,7 +99,7 @@ describe("P6a portable self-host repository wiring", () => {
 
     assert.equal(report.ready, true, JSON.stringify(report.blockers));
     assert.deepEqual(report.blockers, []);
-    assert.equal(report.evidence.repository.transactionWorkflow, ".github/workflows/ci.yml");
+    assert.equal(report.evidence.repository.transactionWorkflow, selfCiPath);
     assert.equal(report.evidence.repository.providerWorkflow, coordinatorPath);
   });
 });


### PR DESCRIPTION
Fixes #343
Refs #342, #311, #304.

TDD slice для реального `doctor --parallel portable` после включения protection на `main`.

```repo-guard-yaml
change_type: feature
scope:
  - tests/test-self-host-portable-wiring.mjs
  - .github/workflows/ci.yml
budgets:
  max_new_files: 0
  max_new_docs: 0
  max_net_added_lines: 30
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - tests/test-self-host-portable-wiring.mjs
  - .github/workflows/ci.yml
must_not_touch:
  - repo-policy.json
  - .github/workflows/repo-guard-portable-coordinator.yml
  - package.json
  - package-lock.json
  - schemas/**
  - action.yml
  - src/**
  - dist/**
expected_effects:
  - self CI executes canonical portable readiness against live GitHub control-plane facts
  - readiness command receives GH_TOKEN and fails the validate job unless provider readiness is green
  - existing validate and smoke-pack required check names remain unchanged
  - no provider trigger, coordinator permission, protection, package or release semantics change
```