### PR TITLE
[Branch hygiene] Add fail-closed branch lifecycle facts

### DIFF
--- a/dist/branch-hygiene.mjs
+++ b/dist/branch-hygiene.mjs
@@ -1,0 +1,151 @@
+const SHA = /^[0-9a-f]{40}$/i;
+const OWNERSHIP_STATES = new Set(["live", "handoff", "stale_candidate"]);
+function fail(error, message) {
+    return { ok: false, error, message };
+}
+function isRecord(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+function isNonEmptyString(value) {
+    return typeof value === "string" && value.length > 0;
+}
+function isSha(value) {
+    return typeof value === "string" && SHA.test(value);
+}
+function isPositiveInteger(value) {
+    return Number.isInteger(value) && value > 0;
+}
+function normalizeBranchEnvelope(value) {
+    if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items))
+        return null;
+    const names = new Set();
+    const items = [];
+    for (const item of value.items) {
+        if (!isRecord(item) || !isNonEmptyString(item.name) || !isSha(item.sha) || typeof item.protected !== "boolean" || names.has(item.name))
+            return null;
+        names.add(item.name);
+        items.push({ name: item.name, sha: item.sha, protected: item.protected });
+    }
+    return { complete: true, items };
+}
+function normalizePullRequestHeadEnvelope(value) {
+    if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items))
+        return null;
+    const names = new Set();
+    const items = [];
+    for (const item of value.items) {
+        if (!isRecord(item) || !isPositiveInteger(item.number) || !isNonEmptyString(item.name) || !isSha(item.sha) || names.has(item.name))
+            return null;
+        names.add(item.name);
+        items.push({ number: item.number, name: item.name, sha: item.sha });
+    }
+    return { complete: true, items };
+}
+function normalizeOwnershipEnvelope(value) {
+    if (value === undefined || value === null)
+        return { complete: true, items: [] };
+    if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items))
+        return null;
+    const names = new Set();
+    const items = [];
+    for (const item of value.items) {
+        if (!isRecord(item) || !isNonEmptyString(item.name) || typeof item.state !== "string"
+            || !OWNERSHIP_STATES.has(item.state) || names.has(item.name))
+            return null;
+        names.add(item.name);
+        items.push({ name: item.name, state: item.state });
+    }
+    return { complete: true, items };
+}
+function normalizePersistentBranches(value) {
+    if (value === undefined || value === null)
+        return [];
+    if (!Array.isArray(value))
+        return null;
+    const names = new Set();
+    for (const item of value) {
+        if (!isNonEmptyString(item))
+            return null;
+        names.add(item);
+    }
+    return [...names];
+}
+function byName(left, right) {
+    return left.name.localeCompare(right.name);
+}
+function deleteBranchOnMergeDrift(setting, residualCount) {
+    if (setting === null)
+        return { state: "unknown", residualMergedBranchCount: residualCount };
+    if (setting === false)
+        return { state: "disabled", residualMergedBranchCount: residualCount };
+    if (residualCount > 0)
+        return { state: "residual", residualMergedBranchCount: residualCount };
+    return { state: "clean", residualMergedBranchCount: 0 };
+}
+export function analyzeBranchHygiene(input) {
+    if (!isRecord(input) || !isNonEmptyString(input.defaultBranch)
+        || !(typeof input.deleteBranchOnMerge === "boolean" || input.deleteBranchOnMerge === null)) {
+        return fail("invalid_branch_hygiene_facts", "branch hygiene input must contain defaultBranch and boolean/null deleteBranchOnMerge");
+    }
+    const branches = normalizeBranchEnvelope(input.branchInventory);
+    const openHeads = normalizePullRequestHeadEnvelope(input.openSameRepositoryPullRequestHeads);
+    const mergedHeads = normalizePullRequestHeadEnvelope(input.mergedSameRepositoryPullRequestHeads);
+    const ownership = normalizeOwnershipEnvelope(input.durableOwnership);
+    const persistentNames = normalizePersistentBranches(input.persistentBranches);
+    if (branches === null || openHeads === null || mergedHeads === null || ownership === null || persistentNames === null) {
+        return fail("incomplete_branch_hygiene_facts", "branch inventory, PR heads, merged heads, persistent exemptions and supplied ownership must be complete and valid");
+    }
+    const branchItems = branches.items;
+    const branchByName = new Map(branchItems.map((item) => [item.name, item]));
+    if (!branchByName.has(input.defaultBranch)) {
+        return fail("default_branch_missing", `default branch ${input.defaultBranch} is absent from branch inventory`);
+    }
+    const openItems = openHeads.items;
+    for (const head of openItems) {
+        const current = branchByName.get(head.name);
+        if (current === undefined || current.sha !== head.sha) {
+            return fail("branch_fact_race", `open PR head ${head.name} does not match current branch inventory`);
+        }
+    }
+    const persistent = new Set([input.defaultBranch, ...persistentNames]);
+    const openByName = new Map(openItems.map((item) => [item.name, item]));
+    const ownershipItems = ownership.items;
+    const ownershipByName = new Map(ownershipItems.map((item) => [item.name, item]));
+    const mergedItems = mergedHeads.items;
+    const persistentBranches = [];
+    const ownedPrePullRequestBranches = [];
+    const staleOwnershipBranches = [];
+    const orphanCandidates = [];
+    for (const branch of branchItems) {
+        if (persistent.has(branch.name)) {
+            persistentBranches.push(branch);
+            continue;
+        }
+        if (openByName.has(branch.name))
+            continue;
+        const owner = ownershipByName.get(branch.name);
+        if (owner?.state === "live" || owner?.state === "handoff") {
+            ownedPrePullRequestBranches.push({ name: branch.name, sha: branch.sha, state: owner.state });
+            continue;
+        }
+        if (owner?.state === "stale_candidate") {
+            staleOwnershipBranches.push({ name: branch.name, sha: branch.sha, state: "stale_candidate" });
+            continue;
+        }
+        orphanCandidates.push(branch);
+    }
+    const orphanByName = new Map(orphanCandidates.map((item) => [item.name, item]));
+    const mergedPullRequestHeadsStillPresent = mergedItems
+        .filter((head) => orphanByName.get(head.name)?.sha === head.sha)
+        .sort(byName);
+    return {
+        ok: true,
+        persistentBranches: persistentBranches.sort(byName),
+        activePullRequestHeads: [...openItems].sort(byName),
+        ownedPrePullRequestBranches: ownedPrePullRequestBranches.sort(byName),
+        staleOwnershipBranches: staleOwnershipBranches.sort(byName),
+        orphanCandidates: orphanCandidates.sort(byName),
+        mergedPullRequestHeadsStillPresent,
+        deleteBranchOnMergeDrift: deleteBranchOnMergeDrift(input.deleteBranchOnMerge, mergedPullRequestHeadsStillPresent.length),
+    };
+}

--- a/dist/branch-hygiene.mjs
+++ b/dist/branch-hygiene.mjs
@@ -149,3 +149,27 @@ export function analyzeBranchHygiene(input) {
         deleteBranchOnMergeDrift: deleteBranchOnMergeDrift(input.deleteBranchOnMerge, mergedPullRequestHeadsStillPresent.length),
     };
 }
+export function planMergedBranchDeletion(input) {
+    if (!isRecord(input) || !isNonEmptyString(input.branchName) || !isPositiveInteger(input.prNumber)
+        || !isSha(input.expectedHeadSha) || !isRecord(input.rereadBranch)
+        || !isNonEmptyString(input.rereadBranch.name) || !isSha(input.rereadBranch.sha)) {
+        return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread");
+    }
+    const analysis = analyzeBranchHygiene(input.facts);
+    if (!analysis.ok)
+        return analysis;
+    const merged = analysis.mergedPullRequestHeadsStillPresent.find((head) => head.number === input.prNumber && head.name === input.branchName && head.sha === input.expectedHeadSha);
+    if (merged === undefined) {
+        return fail("deletion_not_authorized", "branch is not an exact merged same-repository residue in the current hygiene snapshot");
+    }
+    if (input.rereadBranch.name !== input.branchName || input.rereadBranch.sha !== input.expectedHeadSha) {
+        return fail("stale_head", "fresh branch reread no longer matches the expected merged head");
+    }
+    return {
+        ok: true,
+        kind: "delete_merged_branch",
+        branchName: input.branchName,
+        prNumber: input.prNumber,
+        expectedHeadSha: input.expectedHeadSha,
+    };
+}

--- a/dist/branch-hygiene.mjs
+++ b/dist/branch-hygiene.mjs
@@ -150,10 +150,11 @@ export function analyzeBranchHygiene(input) {
     };
 }
 export function planMergedBranchDeletion(input) {
+    const rereadValid = isRecord(input) && (input.rereadBranch === null
+        || (isRecord(input.rereadBranch) && isNonEmptyString(input.rereadBranch.name) && isSha(input.rereadBranch.sha)));
     if (!isRecord(input) || !isNonEmptyString(input.branchName) || !isPositiveInteger(input.prNumber)
-        || !isSha(input.expectedHeadSha) || !isRecord(input.rereadBranch)
-        || !isNonEmptyString(input.rereadBranch.name) || !isSha(input.rereadBranch.sha)) {
-        return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread");
+        || !isSha(input.expectedHeadSha) || !rereadValid) {
+        return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread or confirmed absence");
     }
     const analysis = analyzeBranchHygiene(input.facts);
     if (!analysis.ok)
@@ -161,6 +162,15 @@ export function planMergedBranchDeletion(input) {
     const merged = analysis.mergedPullRequestHeadsStillPresent.find((head) => head.number === input.prNumber && head.name === input.branchName && head.sha === input.expectedHeadSha);
     if (merged === undefined) {
         return fail("deletion_not_authorized", "branch is not an exact merged same-repository residue in the current hygiene snapshot");
+    }
+    if (input.rereadBranch === null) {
+        return {
+            ok: true,
+            kind: "already_absent",
+            branchName: input.branchName,
+            prNumber: input.prNumber,
+            expectedHeadSha: input.expectedHeadSha,
+        };
     }
     if (input.rereadBranch.name !== input.branchName || input.rereadBranch.sha !== input.expectedHeadSha) {
         return fail("stale_head", "fresh branch reread no longer matches the expected merged head");

--- a/dist/branch-hygiene.mjs
+++ b/dist/branch-hygiene.mjs
@@ -15,6 +15,13 @@ function isSha(value) {
 function isPositiveInteger(value) {
     return Number.isInteger(value) && value > 0;
 }
+function normalizeRereadBranch(value) {
+    if (value === null)
+        return null;
+    if (!isRecord(value) || !isNonEmptyString(value.name) || !isSha(value.sha))
+        return undefined;
+    return { name: value.name, sha: value.sha };
+}
 function normalizeBranchEnvelope(value) {
     if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items))
         return null;
@@ -150,10 +157,12 @@ export function analyzeBranchHygiene(input) {
     };
 }
 export function planMergedBranchDeletion(input) {
-    const rereadValid = isRecord(input) && (input.rereadBranch === null
-        || (isRecord(input.rereadBranch) && isNonEmptyString(input.rereadBranch.name) && isSha(input.rereadBranch.sha)));
     if (!isRecord(input) || !isNonEmptyString(input.branchName) || !isPositiveInteger(input.prNumber)
-        || !isSha(input.expectedHeadSha) || !rereadValid) {
+        || !isSha(input.expectedHeadSha)) {
+        return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread or confirmed absence");
+    }
+    const rereadBranch = normalizeRereadBranch(input.rereadBranch);
+    if (rereadBranch === undefined) {
         return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread or confirmed absence");
     }
     const analysis = analyzeBranchHygiene(input.facts);
@@ -163,7 +172,7 @@ export function planMergedBranchDeletion(input) {
     if (merged === undefined) {
         return fail("deletion_not_authorized", "branch is not an exact merged same-repository residue in the current hygiene snapshot");
     }
-    if (input.rereadBranch === null) {
+    if (rereadBranch === null) {
         return {
             ok: true,
             kind: "already_absent",
@@ -172,7 +181,7 @@ export function planMergedBranchDeletion(input) {
             expectedHeadSha: input.expectedHeadSha,
         };
     }
-    if (input.rereadBranch.name !== input.branchName || input.rereadBranch.sha !== input.expectedHeadSha) {
+    if (rereadBranch.name !== input.branchName || rereadBranch.sha !== input.expectedHeadSha) {
         return fail("stale_head", "fresh branch reread no longer matches the expected merged head");
     }
     return {

--- a/dist/github-control-plane.mjs
+++ b/dist/github-control-plane.mjs
@@ -134,6 +134,9 @@ function repositoryOwnerType(metadata) {
         return null;
     return owner.type === "User" || owner.type === "Organization" ? owner.type : null;
 }
+function deleteBranchOnMerge(metadata) {
+    return typeof metadata.delete_branch_on_merge === "boolean" ? metadata.delete_branch_on_merge : null;
+}
 export function readGitHubControlPlane(input) {
     if (input.provider !== "portable" && input.provider !== "github_merge_queue") {
         return fail("invalid_provider", "provider must be portable or github_merge_queue");
@@ -153,6 +156,7 @@ export function readGitHubControlPlane(input) {
     }
     const defaultBranch = metadata.value.default_branch;
     const ownerType = repositoryOwnerType(metadata.value);
+    const deleteOnMerge = deleteBranchOnMerge(metadata.value);
     const errors = [];
     const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
     const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
@@ -163,6 +167,7 @@ export function readGitHubControlPlane(input) {
         repository,
         repositoryOwnerType: ownerType,
         defaultBranch,
+        deleteBranchOnMerge: deleteOnMerge,
         branchProtection,
         activeBranchRules,
         rulesets,

--- a/dist/github-control-plane.mjs
+++ b/dist/github-control-plane.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SHA = /^[0-9a-f]{40}$/i;
 const PARALLEL_RULE_TYPES = new Set(["pull_request", "required_status_checks", "merge_queue"]);
 function fail(error, message) {
     return { ok: false, error, message };
@@ -128,6 +129,28 @@ function readRulesets(run, repoRoot, repository, activeRules, errors) {
     }
     return { complete, items: complete ? items : items };
 }
+function readBranchInventory(run, repoRoot, repository, errors) {
+    const endpoint = `repos/${repository}/branches?per_page=100`;
+    const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+    if (!response.ok) {
+        errors.push({ id: "branch_inventory_api_error", message: response.message });
+        return { complete: false, items: null };
+    }
+    if (!Array.isArray(response.value) || !response.value.every(Array.isArray)) {
+        errors.push({ id: "branch_inventory_api_error", message: "branch inventory must be a complete paginated array" });
+        return { complete: false, items: null };
+    }
+    const items = [];
+    for (const value of response.value.flat()) {
+        if (!isRecord(value) || typeof value.name !== "string" || value.name.length === 0 || !isRecord(value.commit)
+            || typeof value.commit.sha !== "string" || !SHA.test(value.commit.sha) || typeof value.protected !== "boolean") {
+            errors.push({ id: "branch_inventory_api_error", message: "branch inventory contains a malformed branch fact" });
+            return { complete: false, items: null };
+        }
+        items.push({ name: value.name, sha: value.commit.sha, protected: value.protected });
+    }
+    return { complete: true, items };
+}
 function repositoryOwnerType(metadata) {
     const owner = metadata.owner;
     if (!isRecord(owner))
@@ -158,6 +181,7 @@ export function readGitHubControlPlane(input) {
     const ownerType = repositoryOwnerType(metadata.value);
     const deleteOnMerge = deleteBranchOnMerge(metadata.value);
     const errors = [];
+    const branchInventory = input.includeBranchHygiene === true ? readBranchInventory(run, input.repoRoot, repository, errors) : null;
     const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
     const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
     const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
@@ -168,6 +192,7 @@ export function readGitHubControlPlane(input) {
         repositoryOwnerType: ownerType,
         defaultBranch,
         deleteBranchOnMerge: deleteOnMerge,
+        branchInventory,
         branchProtection,
         activeBranchRules,
         rulesets,

--- a/dist/github-control-plane.mjs
+++ b/dist/github-control-plane.mjs
@@ -176,6 +176,46 @@ function readOpenSameRepositoryPullRequestHeads(run, repoRoot, repository, error
     }
     return { complete: true, items };
 }
+function readMergedSameRepositoryPullRequestHeads(run, repoRoot, repository, errors) {
+    const endpoint = `repos/${repository}/pulls?state=closed&per_page=100`;
+    const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+    if (!response.ok) {
+        errors.push({ id: "merged_pr_head_inventory_api_error", message: response.message });
+        return { complete: false, items: null };
+    }
+    if (!Array.isArray(response.value) || !response.value.every(Array.isArray)) {
+        errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory must be a complete paginated array" });
+        return { complete: false, items: null };
+    }
+    const items = [];
+    for (const value of response.value.flat()) {
+        if (!isRecord(value) || !Number.isInteger(value.number) || value.number <= 0
+            || !(value.merged_at === null || (typeof value.merged_at === "string" && value.merged_at.length > 0))) {
+            errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory contains a malformed PR state" });
+            return { complete: false, items: null };
+        }
+        if (value.merged_at === null)
+            continue;
+        if (!isRecord(value.head)) {
+            errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory contains a malformed merged PR head" });
+            return { complete: false, items: null };
+        }
+        if (value.head.repo === null)
+            continue;
+        if (!isRecord(value.head.repo) || typeof value.head.repo.full_name !== "string") {
+            errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory contains a malformed head repository" });
+            return { complete: false, items: null };
+        }
+        if (value.head.repo.full_name !== repository)
+            continue;
+        if (typeof value.head.ref !== "string" || value.head.ref.length === 0 || typeof value.head.sha !== "string" || !SHA.test(value.head.sha)) {
+            errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged same-repository PR head must contain an exact branch and SHA" });
+            return { complete: false, items: null };
+        }
+        items.push({ number: value.number, name: value.head.ref, sha: value.head.sha });
+    }
+    return { complete: true, items };
+}
 function repositoryOwnerType(metadata) {
     const owner = metadata.owner;
     if (!isRecord(owner))
@@ -210,6 +250,9 @@ export function readGitHubControlPlane(input) {
     const openSameRepositoryPullRequestHeads = input.includeBranchHygiene === true
         ? readOpenSameRepositoryPullRequestHeads(run, input.repoRoot, repository, errors)
         : null;
+    const mergedSameRepositoryPullRequestHeads = input.includeBranchHygiene === true
+        ? readMergedSameRepositoryPullRequestHeads(run, input.repoRoot, repository, errors)
+        : null;
     const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
     const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
     const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
@@ -222,6 +265,7 @@ export function readGitHubControlPlane(input) {
         deleteBranchOnMerge: deleteOnMerge,
         branchInventory,
         openSameRepositoryPullRequestHeads,
+        mergedSameRepositoryPullRequestHeads,
         branchProtection,
         activeBranchRules,
         rulesets,

--- a/dist/github-control-plane.mjs
+++ b/dist/github-control-plane.mjs
@@ -151,6 +151,31 @@ function readBranchInventory(run, repoRoot, repository, errors) {
     }
     return { complete: true, items };
 }
+function readOpenSameRepositoryPullRequestHeads(run, repoRoot, repository, errors) {
+    const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
+    const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+    if (!response.ok) {
+        errors.push({ id: "open_pr_head_inventory_api_error", message: response.message });
+        return { complete: false, items: null };
+    }
+    if (!Array.isArray(response.value) || !response.value.every(Array.isArray)) {
+        errors.push({ id: "open_pr_head_inventory_api_error", message: "open PR head inventory must be a complete paginated array" });
+        return { complete: false, items: null };
+    }
+    const items = [];
+    for (const value of response.value.flat()) {
+        if (!isRecord(value) || !Number.isInteger(value.number) || value.number <= 0 || !isRecord(value.head)
+            || typeof value.head.ref !== "string" || value.head.ref.length === 0 || typeof value.head.sha !== "string"
+            || !SHA.test(value.head.sha) || !isRecord(value.head.repo) || typeof value.head.repo.full_name !== "string") {
+            errors.push({ id: "open_pr_head_inventory_api_error", message: "open PR head inventory contains a malformed PR fact" });
+            return { complete: false, items: null };
+        }
+        if (value.head.repo.full_name !== repository)
+            continue;
+        items.push({ number: value.number, name: value.head.ref, sha: value.head.sha });
+    }
+    return { complete: true, items };
+}
 function repositoryOwnerType(metadata) {
     const owner = metadata.owner;
     if (!isRecord(owner))
@@ -182,6 +207,9 @@ export function readGitHubControlPlane(input) {
     const deleteOnMerge = deleteBranchOnMerge(metadata.value);
     const errors = [];
     const branchInventory = input.includeBranchHygiene === true ? readBranchInventory(run, input.repoRoot, repository, errors) : null;
+    const openSameRepositoryPullRequestHeads = input.includeBranchHygiene === true
+        ? readOpenSameRepositoryPullRequestHeads(run, input.repoRoot, repository, errors)
+        : null;
     const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
     const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
     const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
@@ -193,6 +221,7 @@ export function readGitHubControlPlane(input) {
         defaultBranch,
         deleteBranchOnMerge: deleteOnMerge,
         branchInventory,
+        openSameRepositoryPullRequestHeads,
         branchProtection,
         activeBranchRules,
         rulesets,

--- a/dist/parallel-doctor.mjs
+++ b/dist/parallel-doctor.mjs
@@ -1,4 +1,5 @@
 import { readGitHubControlPlane } from "./github-control-plane.mjs";
+import { analyzeBranchHygiene } from "./branch-hygiene.mjs";
 import { createIntegrationAnalysisReport } from "./integration-validator.mjs";
 import { normalizeGitHubControlPlane } from "./parallel-control-plane.mjs";
 import { evaluateParallelReadiness } from "./parallel-readiness.mjs";
@@ -7,6 +8,14 @@ const PARALLEL_FORMATS = new Set(["text", "json"]);
 function option(args, name, fallback) {
     const index = args.indexOf(name);
     return index < 0 ? fallback : args[index + 1] ?? fallback;
+}
+function options(args, name) {
+    const values = [];
+    for (let index = 0; index < args.length; index++) {
+        if (args[index] === name && args[index + 1] !== undefined)
+            values.push(args[index + 1]);
+    }
+    return values;
 }
 function addBlocker(blockers, blocker) {
     if (!blockers.some((item) => item.id === blocker.id))
@@ -56,6 +65,21 @@ function controlPlaneProjection(provider, controlPlaneRead) {
             },
         };
 }
+function branchHygieneProjection(input) {
+    const read = input.controlPlaneRead;
+    if (!read.ok || read.branchInventory == null || read.openSameRepositoryPullRequestHeads == null
+        || read.mergedSameRepositoryPullRequestHeads == null)
+        return null;
+    return analyzeBranchHygiene({
+        defaultBranch: read.defaultBranch,
+        deleteBranchOnMerge: read.deleteBranchOnMerge,
+        branchInventory: read.branchInventory,
+        openSameRepositoryPullRequestHeads: read.openSameRepositoryPullRequestHeads,
+        mergedSameRepositoryPullRequestHeads: read.mergedSameRepositoryPullRequestHeads,
+        persistentBranches: input.persistentBranches ?? [],
+        durableOwnership: input.durableOwnership,
+    });
+}
 export function parseParallelProvider(args) {
     const index = args.indexOf("--parallel");
     if (index < 0)
@@ -92,6 +116,7 @@ export function createParallelDoctorReport(input) {
             integrationValid: input.integrationValid,
             integrationMessage: input.integrationMessage ?? null,
             controlPlane: controlPlane.diagnostic,
+            branchHygiene: branchHygieneProjection(input),
         },
     };
 }
@@ -118,6 +143,19 @@ export function renderParallelDoctorReport(report, format) {
         for (const blocker of report.blockers)
             lines.push(`  - ${blocker.source}/${blocker.id}: ${blocker.message}`);
     }
+    const branchHygiene = report.diagnostics.branchHygiene;
+    if (branchHygiene) {
+        if (branchHygiene.ok) {
+            lines.push("branch hygiene: advisory");
+            lines.push(`persistent branches: ${branchHygiene.persistentBranches.map((branch) => branch.name).join(", ") || "none"}`);
+            lines.push(`merged PR heads still present: ${branchHygiene.mergedPullRequestHeadsStillPresent.map((head) => head.name).join(", ") || "none"}`);
+            lines.push(`orphan candidates: ${branchHygiene.orphanCandidates.map((branch) => branch.name).join(", ") || "none"}`);
+            lines.push(`delete_branch_on_merge: ${branchHygiene.deleteBranchOnMergeDrift.state}`);
+        }
+        else {
+            lines.push(`branch hygiene: unavailable (${branchHygiene.error}: ${branchHygiene.message})`);
+        }
+    }
     const diagnosticErrors = report.diagnostics.controlPlane.adapterErrors;
     if (diagnosticErrors.length > 0) {
         lines.push("control-plane adapter errors:");
@@ -141,13 +179,14 @@ export async function runParallelDoctor(roots, args) {
     const integrationValid = integrationReport.fatal !== true && integrationReport.exitCode === 0;
     const integrationFacts = integrationReport.integration ?? {};
     const integrationMessage = integrationReport.fatal ? integrationReport.message ?? "integration analysis failed" : null;
-    const controlPlaneRead = readGitHubControlPlane({ repoRoot: roots.repoRoot, provider });
+    const controlPlaneRead = readGitHubControlPlane({ repoRoot: roots.repoRoot, provider, includeBranchHygiene: true });
     const report = createParallelDoctorReport({
         provider,
         integrationFacts,
         integrationValid,
         integrationMessage,
         controlPlaneRead,
+        persistentBranches: options(args, "--persistent-branch"),
     });
     console.log(renderParallelDoctorReport(report, format));
     return report.ready ? 0 : 1;

--- a/dist/portable-integration/github-write.mjs
+++ b/dist/portable-integration/github-write.mjs
@@ -19,6 +19,9 @@ function isPositiveInteger(value) {
 function isMergeMethod(value) {
     return typeof value === "string" && MERGE_METHODS.has(value);
 }
+function encodeBranchPath(value) {
+    return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+}
 function normalizeTransport(input) {
     if (!isRecord(input) || typeof input.request !== "function")
         return null;
@@ -151,6 +154,61 @@ export function createGitHubWriteAdapter(transportInput) {
                 expectedHeadSha: valid.expectedHeadSha,
                 mergeSha: response.body.sha,
                 mergeMethod: input.mergeMethod,
+            };
+        },
+        async deleteMergedBranchExact(input) {
+            const common = validateCommonInput(input);
+            if (!common.ok)
+                return common;
+            const valid = common.value;
+            if (!isRecord(input) || input.kind !== "delete_merged_branch" || typeof input.branchName !== "string" || input.branchName.length === 0)
+                return fail("invalid_input", "branch deletion requires planner kind delete_merged_branch and a branch name");
+            if (transport === null)
+                return fail("invalid_transport", "write transport must expose an async request function");
+            const branchName = input.branchName;
+            const encodedBranch = encodeBranchPath(branchName);
+            let rawRead;
+            try {
+                rawRead = await transport.request({
+                    method: "GET",
+                    path: `/repos/${valid.repository}/git/ref/heads/${encodedBranch}`,
+                });
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return fail("transport_error", `branch reread transport failed: ${message}`);
+            }
+            const read = normalizeResponse(rawRead);
+            if (read === null)
+                return fail("malformed_response", "branch reread transport returned a malformed response");
+            if (read.status !== 200)
+                return fail("unexpected_response", `branch reread returned unexpected HTTP ${read.status}${responseMessage(read.body)}`);
+            if (!isRecord(read.body) || read.body.ref !== `refs/heads/${branchName}` || !isRecord(read.body.object) || !isSha(read.body.object.sha))
+                return fail("malformed_response", "branch reread must contain the exact ref and commit SHA");
+            if (read.body.object.sha !== valid.expectedHeadSha)
+                return fail("stale_head", "branch moved after merged-head evidence was collected");
+            let rawDelete;
+            try {
+                rawDelete = await transport.request({
+                    method: "DELETE",
+                    path: `/repos/${valid.repository}/git/refs/heads/${encodedBranch}`,
+                });
+            }
+            catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return fail("transport_error", `branch delete transport failed: ${message}`);
+            }
+            const deletion = normalizeResponse(rawDelete);
+            if (deletion === null)
+                return fail("malformed_response", "branch delete transport returned a malformed response");
+            if (deletion.status !== 204)
+                return fail("unexpected_response", `branch delete returned unexpected HTTP ${deletion.status}${responseMessage(deletion.body)}`);
+            return {
+                ok: true,
+                kind: "deleted",
+                branchName,
+                prNumber: valid.prNumber,
+                expectedHeadSha: valid.expectedHeadSha,
             };
         },
     };

--- a/dist/portable-integration/github-write.mjs
+++ b/dist/portable-integration/github-write.mjs
@@ -19,6 +19,23 @@ function isPositiveInteger(value) {
 function isMergeMethod(value) {
     return typeof value === "string" && MERGE_METHODS.has(value);
 }
+function isBranchRefName(value) {
+    if (typeof value !== "string" || value.length === 0)
+        return false;
+    if (value === "@" || value.startsWith("-") || value.startsWith("/") || value.endsWith("/")
+        || value.includes("//") || value.includes("..") || value.includes("@{") || value.endsWith("."))
+        return false;
+    for (const component of value.split("/")) {
+        if (component.length === 0 || component.startsWith(".") || component.endsWith(".lock"))
+            return false;
+    }
+    for (const character of value) {
+        const code = character.charCodeAt(0);
+        if (code <= 0x20 || code === 0x7f || "~^:?*[\\".includes(character))
+            return false;
+    }
+    return true;
+}
 function encodeBranchPath(value) {
     return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
 }
@@ -161,8 +178,8 @@ export function createGitHubWriteAdapter(transportInput) {
             if (!common.ok)
                 return common;
             const valid = common.value;
-            if (!isRecord(input) || input.kind !== "delete_merged_branch" || typeof input.branchName !== "string" || input.branchName.length === 0)
-                return fail("invalid_input", "branch deletion requires planner kind delete_merged_branch and a branch name");
+            if (!isRecord(input) || input.kind !== "delete_merged_branch" || !isBranchRefName(input.branchName))
+                return fail("invalid_input", "branch deletion requires planner kind delete_merged_branch and a valid branch name");
             if (transport === null)
                 return fail("invalid_transport", "write transport must expose an async request function");
             const branchName = input.branchName;

--- a/dist/portable-integration/github-write.mjs
+++ b/dist/portable-integration/github-write.mjs
@@ -181,6 +181,15 @@ export function createGitHubWriteAdapter(transportInput) {
             const read = normalizeResponse(rawRead);
             if (read === null)
                 return fail("malformed_response", "branch reread transport returned a malformed response");
+            if (read.status === 404) {
+                return {
+                    ok: true,
+                    kind: "already_absent",
+                    branchName,
+                    prNumber: valid.prNumber,
+                    expectedHeadSha: valid.expectedHeadSha,
+                };
+            }
             if (read.status !== 200)
                 return fail("unexpected_response", `branch reread returned unexpected HTTP ${read.status}${responseMessage(read.body)}`);
             if (!isRecord(read.body) || read.body.ref !== `refs/heads/${branchName}` || !isRecord(read.body.object) || !isSha(read.body.object.sha))

--- a/dist/repo-guard.mjs
+++ b/dist/repo-guard.mjs
@@ -37,7 +37,7 @@ const COMMAND_SPECS = {
         run: async (roots, args) => (await import("./migrate.mjs")).runMigrate(roots, args),
     },
     doctor: {
-        options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
+        options: { "--integration": false, ...valueOptions("--format", "--parallel", "--persistent-branch") }, positionals: 0,
         run: async (roots, args) => args.includes("--integration")
             ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
             : args.includes("--parallel")

--- a/src/branch-hygiene.mts
+++ b/src/branch-hygiene.mts
@@ -210,3 +210,31 @@ export function analyzeBranchHygiene(input: unknown): Failure | Success {
     deleteBranchOnMergeDrift: deleteBranchOnMergeDrift(input.deleteBranchOnMerge, mergedPullRequestHeadsStillPresent.length),
   };
 }
+
+export function planMergedBranchDeletion(input: unknown) {
+  if (!isRecord(input) || !isNonEmptyString(input.branchName) || !isPositiveInteger(input.prNumber)
+    || !isSha(input.expectedHeadSha) || !isRecord(input.rereadBranch)
+    || !isNonEmptyString(input.rereadBranch.name) || !isSha(input.rereadBranch.sha)) {
+    return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread");
+  }
+
+  const analysis = analyzeBranchHygiene(input.facts);
+  if (!analysis.ok) return analysis;
+
+  const merged = analysis.mergedPullRequestHeadsStillPresent.find((head) =>
+    head.number === input.prNumber && head.name === input.branchName && head.sha === input.expectedHeadSha);
+  if (merged === undefined) {
+    return fail("deletion_not_authorized", "branch is not an exact merged same-repository residue in the current hygiene snapshot");
+  }
+  if (input.rereadBranch.name !== input.branchName || input.rereadBranch.sha !== input.expectedHeadSha) {
+    return fail("stale_head", "fresh branch reread no longer matches the expected merged head");
+  }
+
+  return {
+    ok: true as const,
+    kind: "delete_merged_branch" as const,
+    branchName: input.branchName,
+    prNumber: input.prNumber,
+    expectedHeadSha: input.expectedHeadSha,
+  };
+}

--- a/src/branch-hygiene.mts
+++ b/src/branch-hygiene.mts
@@ -52,6 +52,8 @@ type Success = {
   deleteBranchOnMergeDrift: DeleteBranchOnMergeDrift;
 };
 
+type RereadBranchFact = { name: string; sha: string };
+
 const SHA = /^[0-9a-f]{40}$/i;
 const OWNERSHIP_STATES = new Set<OwnershipState>(["live", "handoff", "stale_candidate"]);
 
@@ -73,6 +75,12 @@ function isSha(value: unknown): value is string {
 
 function isPositiveInteger(value: unknown): value is number {
   return Number.isInteger(value) && (value as number) > 0;
+}
+
+function normalizeRereadBranch(value: unknown): RereadBranchFact | null | undefined {
+  if (value === null) return null;
+  if (!isRecord(value) || !isNonEmptyString(value.name) || !isSha(value.sha)) return undefined;
+  return { name: value.name, sha: value.sha };
 }
 
 function normalizeBranchEnvelope(value: unknown): Envelope<BranchFact> | null {
@@ -212,10 +220,12 @@ export function analyzeBranchHygiene(input: unknown): Failure | Success {
 }
 
 export function planMergedBranchDeletion(input: unknown) {
-  const rereadValid = isRecord(input) && (input.rereadBranch === null
-    || (isRecord(input.rereadBranch) && isNonEmptyString(input.rereadBranch.name) && isSha(input.rereadBranch.sha)));
   if (!isRecord(input) || !isNonEmptyString(input.branchName) || !isPositiveInteger(input.prNumber)
-    || !isSha(input.expectedHeadSha) || !rereadValid) {
+    || !isSha(input.expectedHeadSha)) {
+    return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread or confirmed absence");
+  }
+  const rereadBranch = normalizeRereadBranch(input.rereadBranch);
+  if (rereadBranch === undefined) {
     return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread or confirmed absence");
   }
 
@@ -227,7 +237,7 @@ export function planMergedBranchDeletion(input: unknown) {
   if (merged === undefined) {
     return fail("deletion_not_authorized", "branch is not an exact merged same-repository residue in the current hygiene snapshot");
   }
-  if (input.rereadBranch === null) {
+  if (rereadBranch === null) {
     return {
       ok: true as const,
       kind: "already_absent" as const,
@@ -236,7 +246,7 @@ export function planMergedBranchDeletion(input: unknown) {
       expectedHeadSha: input.expectedHeadSha,
     };
   }
-  if (input.rereadBranch.name !== input.branchName || input.rereadBranch.sha !== input.expectedHeadSha) {
+  if (rereadBranch.name !== input.branchName || rereadBranch.sha !== input.expectedHeadSha) {
     return fail("stale_head", "fresh branch reread no longer matches the expected merged head");
   }
 

--- a/src/branch-hygiene.mts
+++ b/src/branch-hygiene.mts
@@ -212,10 +212,11 @@ export function analyzeBranchHygiene(input: unknown): Failure | Success {
 }
 
 export function planMergedBranchDeletion(input: unknown) {
+  const rereadValid = isRecord(input) && (input.rereadBranch === null
+    || (isRecord(input.rereadBranch) && isNonEmptyString(input.rereadBranch.name) && isSha(input.rereadBranch.sha)));
   if (!isRecord(input) || !isNonEmptyString(input.branchName) || !isPositiveInteger(input.prNumber)
-    || !isSha(input.expectedHeadSha) || !isRecord(input.rereadBranch)
-    || !isNonEmptyString(input.rereadBranch.name) || !isSha(input.rereadBranch.sha)) {
-    return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread");
+    || !isSha(input.expectedHeadSha) || !rereadValid) {
+    return fail("invalid_deletion_evidence", "deletion planning requires branch, PR, expected head SHA and a fresh branch reread or confirmed absence");
   }
 
   const analysis = analyzeBranchHygiene(input.facts);
@@ -225,6 +226,15 @@ export function planMergedBranchDeletion(input: unknown) {
     head.number === input.prNumber && head.name === input.branchName && head.sha === input.expectedHeadSha);
   if (merged === undefined) {
     return fail("deletion_not_authorized", "branch is not an exact merged same-repository residue in the current hygiene snapshot");
+  }
+  if (input.rereadBranch === null) {
+    return {
+      ok: true as const,
+      kind: "already_absent" as const,
+      branchName: input.branchName,
+      prNumber: input.prNumber,
+      expectedHeadSha: input.expectedHeadSha,
+    };
   }
   if (input.rereadBranch.name !== input.branchName || input.rereadBranch.sha !== input.expectedHeadSha) {
     return fail("stale_head", "fresh branch reread no longer matches the expected merged head");

--- a/src/branch-hygiene.mts
+++ b/src/branch-hygiene.mts
@@ -1,0 +1,212 @@
+type Failure = { ok: false; error: string; message: string };
+
+type BranchFact = {
+  name: string;
+  sha: string;
+  protected: boolean;
+};
+
+type PullRequestHeadFact = {
+  number: number;
+  name: string;
+  sha: string;
+};
+
+type OwnershipState = "live" | "handoff" | "stale_candidate";
+
+type OwnershipFact = {
+  name: string;
+  state: OwnershipState;
+};
+
+type Envelope<T> = {
+  complete: boolean;
+  items: T[] | null;
+};
+
+type OwnedBranchProjection = {
+  name: string;
+  sha: string;
+  state: "live" | "handoff";
+};
+
+type StaleOwnershipProjection = {
+  name: string;
+  sha: string;
+  state: "stale_candidate";
+};
+
+type DeleteBranchOnMergeDrift = {
+  state: "disabled" | "residual" | "clean" | "unknown";
+  residualMergedBranchCount: number;
+};
+
+type Success = {
+  ok: true;
+  persistentBranches: BranchFact[];
+  activePullRequestHeads: PullRequestHeadFact[];
+  ownedPrePullRequestBranches: OwnedBranchProjection[];
+  staleOwnershipBranches: StaleOwnershipProjection[];
+  orphanCandidates: BranchFact[];
+  mergedPullRequestHeadsStillPresent: PullRequestHeadFact[];
+  deleteBranchOnMergeDrift: DeleteBranchOnMergeDrift;
+};
+
+const SHA = /^[0-9a-f]{40}$/i;
+const OWNERSHIP_STATES = new Set<OwnershipState>(["live", "handoff", "stale_candidate"]);
+
+function fail(error: string, message: string): Failure {
+  return { ok: false, error, message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isSha(value: unknown): value is string {
+  return typeof value === "string" && SHA.test(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}
+
+function normalizeBranchEnvelope(value: unknown): Envelope<BranchFact> | null {
+  if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items)) return null;
+  const names = new Set<string>();
+  const items: BranchFact[] = [];
+  for (const item of value.items) {
+    if (!isRecord(item) || !isNonEmptyString(item.name) || !isSha(item.sha) || typeof item.protected !== "boolean" || names.has(item.name)) return null;
+    names.add(item.name);
+    items.push({ name: item.name, sha: item.sha, protected: item.protected });
+  }
+  return { complete: true, items };
+}
+
+function normalizePullRequestHeadEnvelope(value: unknown): Envelope<PullRequestHeadFact> | null {
+  if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items)) return null;
+  const names = new Set<string>();
+  const items: PullRequestHeadFact[] = [];
+  for (const item of value.items) {
+    if (!isRecord(item) || !isPositiveInteger(item.number) || !isNonEmptyString(item.name) || !isSha(item.sha) || names.has(item.name)) return null;
+    names.add(item.name);
+    items.push({ number: item.number, name: item.name, sha: item.sha });
+  }
+  return { complete: true, items };
+}
+
+function normalizeOwnershipEnvelope(value: unknown): Envelope<OwnershipFact> | null {
+  if (value === undefined || value === null) return { complete: true, items: [] };
+  if (!isRecord(value) || value.complete !== true || !Array.isArray(value.items)) return null;
+  const names = new Set<string>();
+  const items: OwnershipFact[] = [];
+  for (const item of value.items) {
+    if (!isRecord(item) || !isNonEmptyString(item.name) || typeof item.state !== "string"
+      || !OWNERSHIP_STATES.has(item.state as OwnershipState) || names.has(item.name)) return null;
+    names.add(item.name);
+    items.push({ name: item.name, state: item.state as OwnershipState });
+  }
+  return { complete: true, items };
+}
+
+function normalizePersistentBranches(value: unknown): string[] | null {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) return null;
+  const names = new Set<string>();
+  for (const item of value) {
+    if (!isNonEmptyString(item)) return null;
+    names.add(item);
+  }
+  return [...names];
+}
+
+function byName<T extends { name: string }>(left: T, right: T): number {
+  return left.name.localeCompare(right.name);
+}
+
+function deleteBranchOnMergeDrift(setting: boolean | null, residualCount: number): DeleteBranchOnMergeDrift {
+  if (setting === null) return { state: "unknown", residualMergedBranchCount: residualCount };
+  if (setting === false) return { state: "disabled", residualMergedBranchCount: residualCount };
+  if (residualCount > 0) return { state: "residual", residualMergedBranchCount: residualCount };
+  return { state: "clean", residualMergedBranchCount: 0 };
+}
+
+export function analyzeBranchHygiene(input: unknown): Failure | Success {
+  if (!isRecord(input) || !isNonEmptyString(input.defaultBranch)
+    || !(typeof input.deleteBranchOnMerge === "boolean" || input.deleteBranchOnMerge === null)) {
+    return fail("invalid_branch_hygiene_facts", "branch hygiene input must contain defaultBranch and boolean/null deleteBranchOnMerge");
+  }
+
+  const branches = normalizeBranchEnvelope(input.branchInventory);
+  const openHeads = normalizePullRequestHeadEnvelope(input.openSameRepositoryPullRequestHeads);
+  const mergedHeads = normalizePullRequestHeadEnvelope(input.mergedSameRepositoryPullRequestHeads);
+  const ownership = normalizeOwnershipEnvelope(input.durableOwnership);
+  const persistentNames = normalizePersistentBranches(input.persistentBranches);
+  if (branches === null || openHeads === null || mergedHeads === null || ownership === null || persistentNames === null) {
+    return fail("incomplete_branch_hygiene_facts", "branch inventory, PR heads, merged heads, persistent exemptions and supplied ownership must be complete and valid");
+  }
+
+  const branchItems = branches.items as BranchFact[];
+  const branchByName = new Map(branchItems.map((item) => [item.name, item]));
+  if (!branchByName.has(input.defaultBranch)) {
+    return fail("default_branch_missing", `default branch ${input.defaultBranch} is absent from branch inventory`);
+  }
+
+  const openItems = openHeads.items as PullRequestHeadFact[];
+  for (const head of openItems) {
+    const current = branchByName.get(head.name);
+    if (current === undefined || current.sha !== head.sha) {
+      return fail("branch_fact_race", `open PR head ${head.name} does not match current branch inventory`);
+    }
+  }
+
+  const persistent = new Set<string>([input.defaultBranch, ...persistentNames]);
+  const openByName = new Map(openItems.map((item) => [item.name, item]));
+  const ownershipItems = ownership.items as OwnershipFact[];
+  const ownershipByName = new Map(ownershipItems.map((item) => [item.name, item]));
+  const mergedItems = mergedHeads.items as PullRequestHeadFact[];
+
+  const persistentBranches: BranchFact[] = [];
+  const ownedPrePullRequestBranches: OwnedBranchProjection[] = [];
+  const staleOwnershipBranches: StaleOwnershipProjection[] = [];
+  const orphanCandidates: BranchFact[] = [];
+
+  for (const branch of branchItems) {
+    if (persistent.has(branch.name)) {
+      persistentBranches.push(branch);
+      continue;
+    }
+    if (openByName.has(branch.name)) continue;
+
+    const owner = ownershipByName.get(branch.name);
+    if (owner?.state === "live" || owner?.state === "handoff") {
+      ownedPrePullRequestBranches.push({ name: branch.name, sha: branch.sha, state: owner.state });
+      continue;
+    }
+    if (owner?.state === "stale_candidate") {
+      staleOwnershipBranches.push({ name: branch.name, sha: branch.sha, state: "stale_candidate" });
+      continue;
+    }
+    orphanCandidates.push(branch);
+  }
+
+  const orphanByName = new Map(orphanCandidates.map((item) => [item.name, item]));
+  const mergedPullRequestHeadsStillPresent = mergedItems
+    .filter((head) => orphanByName.get(head.name)?.sha === head.sha)
+    .sort(byName);
+
+  return {
+    ok: true,
+    persistentBranches: persistentBranches.sort(byName),
+    activePullRequestHeads: [...openItems].sort(byName),
+    ownedPrePullRequestBranches: ownedPrePullRequestBranches.sort(byName),
+    staleOwnershipBranches: staleOwnershipBranches.sort(byName),
+    orphanCandidates: orphanCandidates.sort(byName),
+    mergedPullRequestHeadsStillPresent,
+    deleteBranchOnMergeDrift: deleteBranchOnMergeDrift(input.deleteBranchOnMerge, mergedPullRequestHeadsStillPresent.length),
+  };
+}

--- a/src/github-control-plane.mts
+++ b/src/github-control-plane.mts
@@ -33,6 +33,17 @@ type BranchInventoryEnvelope = {
   items: BranchFact[] | null;
 };
 
+type OpenSameRepositoryPullRequestHeadFact = {
+  number: number;
+  name: string;
+  sha: string;
+};
+
+type OpenSameRepositoryPullRequestHeadsEnvelope = {
+  complete: boolean;
+  items: OpenSameRepositoryPullRequestHeadFact[] | null;
+};
+
 export type GitHubControlPlaneReadResult = Failure | {
   ok: true;
   provider: ParallelReadinessProvider;
@@ -41,6 +52,7 @@ export type GitHubControlPlaneReadResult = Failure | {
   defaultBranch: string;
   deleteBranchOnMerge: boolean | null;
   branchInventory: BranchInventoryEnvelope | null;
+  openSameRepositoryPullRequestHeads: OpenSameRepositoryPullRequestHeadsEnvelope | null;
   branchProtection: BranchProtectionEnvelope;
   activeBranchRules: ActiveBranchRulesEnvelope;
   rulesets: RulesetsEnvelope;
@@ -207,6 +219,37 @@ function readBranchInventory(run: RunCommand, repoRoot: string, repository: stri
   return { complete: true, items };
 }
 
+function readOpenSameRepositoryPullRequestHeads(
+  run: RunCommand,
+  repoRoot: string,
+  repository: string,
+  errors: AdapterError[],
+): OpenSameRepositoryPullRequestHeadsEnvelope {
+  const endpoint = `repos/${repository}/pulls?state=open&per_page=100`;
+  const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+  if (!response.ok) {
+    errors.push({ id: "open_pr_head_inventory_api_error", message: response.message });
+    return { complete: false, items: null };
+  }
+  if (!Array.isArray(response.value) || !response.value.every(Array.isArray)) {
+    errors.push({ id: "open_pr_head_inventory_api_error", message: "open PR head inventory must be a complete paginated array" });
+    return { complete: false, items: null };
+  }
+
+  const items: OpenSameRepositoryPullRequestHeadFact[] = [];
+  for (const value of (response.value as unknown[][]).flat()) {
+    if (!isRecord(value) || !Number.isInteger(value.number) || (value.number as number) <= 0 || !isRecord(value.head)
+      || typeof value.head.ref !== "string" || value.head.ref.length === 0 || typeof value.head.sha !== "string"
+      || !SHA.test(value.head.sha) || !isRecord(value.head.repo) || typeof value.head.repo.full_name !== "string") {
+      errors.push({ id: "open_pr_head_inventory_api_error", message: "open PR head inventory contains a malformed PR fact" });
+      return { complete: false, items: null };
+    }
+    if (value.head.repo.full_name !== repository) continue;
+    items.push({ number: value.number as number, name: value.head.ref, sha: value.head.sha });
+  }
+  return { complete: true, items };
+}
+
 function repositoryOwnerType(metadata: Record<string, unknown>): RepositoryOwnerType | null {
   const owner = metadata.owner;
   if (!isRecord(owner)) return null;
@@ -237,6 +280,9 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
   const deleteOnMerge = deleteBranchOnMerge(metadata.value);
   const errors: AdapterError[] = [];
   const branchInventory = input.includeBranchHygiene === true ? readBranchInventory(run, input.repoRoot, repository, errors) : null;
+  const openSameRepositoryPullRequestHeads = input.includeBranchHygiene === true
+    ? readOpenSameRepositoryPullRequestHeads(run, input.repoRoot, repository, errors)
+    : null;
   const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
   const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
   const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
@@ -249,6 +295,7 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
     defaultBranch,
     deleteBranchOnMerge: deleteOnMerge,
     branchInventory,
+    openSameRepositoryPullRequestHeads,
     branchProtection,
     activeBranchRules,
     rulesets,

--- a/src/github-control-plane.mts
+++ b/src/github-control-plane.mts
@@ -44,6 +44,11 @@ type OpenSameRepositoryPullRequestHeadsEnvelope = {
   items: OpenSameRepositoryPullRequestHeadFact[] | null;
 };
 
+type MergedSameRepositoryPullRequestHeadsEnvelope = {
+  complete: boolean;
+  items: OpenSameRepositoryPullRequestHeadFact[] | null;
+};
+
 export type GitHubControlPlaneReadResult = Failure | {
   ok: true;
   provider: ParallelReadinessProvider;
@@ -53,6 +58,7 @@ export type GitHubControlPlaneReadResult = Failure | {
   deleteBranchOnMerge: boolean | null;
   branchInventory: BranchInventoryEnvelope | null;
   openSameRepositoryPullRequestHeads: OpenSameRepositoryPullRequestHeadsEnvelope | null;
+  mergedSameRepositoryPullRequestHeads: MergedSameRepositoryPullRequestHeadsEnvelope | null;
   branchProtection: BranchProtectionEnvelope;
   activeBranchRules: ActiveBranchRulesEnvelope;
   rulesets: RulesetsEnvelope;
@@ -250,6 +256,50 @@ function readOpenSameRepositoryPullRequestHeads(
   return { complete: true, items };
 }
 
+function readMergedSameRepositoryPullRequestHeads(
+  run: RunCommand,
+  repoRoot: string,
+  repository: string,
+  errors: AdapterError[],
+): MergedSameRepositoryPullRequestHeadsEnvelope {
+  const endpoint = `repos/${repository}/pulls?state=closed&per_page=100`;
+  const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+  if (!response.ok) {
+    errors.push({ id: "merged_pr_head_inventory_api_error", message: response.message });
+    return { complete: false, items: null };
+  }
+  if (!Array.isArray(response.value) || !response.value.every(Array.isArray)) {
+    errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory must be a complete paginated array" });
+    return { complete: false, items: null };
+  }
+
+  const items: OpenSameRepositoryPullRequestHeadFact[] = [];
+  for (const value of (response.value as unknown[][]).flat()) {
+    if (!isRecord(value) || !Number.isInteger(value.number) || (value.number as number) <= 0
+      || !(value.merged_at === null || (typeof value.merged_at === "string" && value.merged_at.length > 0))) {
+      errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory contains a malformed PR state" });
+      return { complete: false, items: null };
+    }
+    if (value.merged_at === null) continue;
+    if (!isRecord(value.head)) {
+      errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory contains a malformed merged PR head" });
+      return { complete: false, items: null };
+    }
+    if (value.head.repo === null) continue;
+    if (!isRecord(value.head.repo) || typeof value.head.repo.full_name !== "string") {
+      errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged PR head inventory contains a malformed head repository" });
+      return { complete: false, items: null };
+    }
+    if (value.head.repo.full_name !== repository) continue;
+    if (typeof value.head.ref !== "string" || value.head.ref.length === 0 || typeof value.head.sha !== "string" || !SHA.test(value.head.sha)) {
+      errors.push({ id: "merged_pr_head_inventory_api_error", message: "merged same-repository PR head must contain an exact branch and SHA" });
+      return { complete: false, items: null };
+    }
+    items.push({ number: value.number as number, name: value.head.ref, sha: value.head.sha });
+  }
+  return { complete: true, items };
+}
+
 function repositoryOwnerType(metadata: Record<string, unknown>): RepositoryOwnerType | null {
   const owner = metadata.owner;
   if (!isRecord(owner)) return null;
@@ -283,6 +333,9 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
   const openSameRepositoryPullRequestHeads = input.includeBranchHygiene === true
     ? readOpenSameRepositoryPullRequestHeads(run, input.repoRoot, repository, errors)
     : null;
+  const mergedSameRepositoryPullRequestHeads = input.includeBranchHygiene === true
+    ? readMergedSameRepositoryPullRequestHeads(run, input.repoRoot, repository, errors)
+    : null;
   const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
   const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
   const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
@@ -296,6 +349,7 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
     deleteBranchOnMerge: deleteOnMerge,
     branchInventory,
     openSameRepositoryPullRequestHeads,
+    mergedSameRepositoryPullRequestHeads,
     branchProtection,
     activeBranchRules,
     rulesets,

--- a/src/github-control-plane.mts
+++ b/src/github-control-plane.mts
@@ -28,6 +28,7 @@ export type GitHubControlPlaneReadResult = Failure | {
   repository: string;
   repositoryOwnerType: RepositoryOwnerType | null;
   defaultBranch: string;
+  deleteBranchOnMerge: boolean | null;
   branchProtection: BranchProtectionEnvelope;
   activeBranchRules: ActiveBranchRulesEnvelope;
   rulesets: RulesetsEnvelope;
@@ -174,6 +175,10 @@ function repositoryOwnerType(metadata: Record<string, unknown>): RepositoryOwner
   return owner.type === "User" || owner.type === "Organization" ? owner.type : null;
 }
 
+function deleteBranchOnMerge(metadata: Record<string, unknown>): boolean | null {
+  return typeof metadata.delete_branch_on_merge === "boolean" ? metadata.delete_branch_on_merge : null;
+}
+
 export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneReadResult {
   if (input.provider !== "portable" && input.provider !== "github_merge_queue") {
     return fail("invalid_provider", "provider must be portable or github_merge_queue");
@@ -191,6 +196,7 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
   }
   const defaultBranch = metadata.value.default_branch;
   const ownerType = repositoryOwnerType(metadata.value);
+  const deleteOnMerge = deleteBranchOnMerge(metadata.value);
   const errors: AdapterError[] = [];
   const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
   const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
@@ -202,6 +208,7 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
     repository,
     repositoryOwnerType: ownerType,
     defaultBranch,
+    deleteBranchOnMerge: deleteOnMerge,
     branchProtection,
     activeBranchRules,
     rulesets,

--- a/src/github-control-plane.mts
+++ b/src/github-control-plane.mts
@@ -22,6 +22,17 @@ type RulesetsEnvelope = {
   items: unknown[] | null;
 };
 
+type BranchFact = {
+  name: string;
+  sha: string;
+  protected: boolean;
+};
+
+type BranchInventoryEnvelope = {
+  complete: boolean;
+  items: BranchFact[] | null;
+};
+
 export type GitHubControlPlaneReadResult = Failure | {
   ok: true;
   provider: ParallelReadinessProvider;
@@ -29,6 +40,7 @@ export type GitHubControlPlaneReadResult = Failure | {
   repositoryOwnerType: RepositoryOwnerType | null;
   defaultBranch: string;
   deleteBranchOnMerge: boolean | null;
+  branchInventory: BranchInventoryEnvelope | null;
   branchProtection: BranchProtectionEnvelope;
   activeBranchRules: ActiveBranchRulesEnvelope;
   rulesets: RulesetsEnvelope;
@@ -40,9 +52,11 @@ interface ReadInput {
   provider: ParallelReadinessProvider;
   env?: Record<string, string | undefined>;
   run?: RunCommand;
+  includeBranchHygiene?: boolean;
 }
 
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const SHA = /^[0-9a-f]{40}$/i;
 const PARALLEL_RULE_TYPES = new Set(["pull_request", "required_status_checks", "merge_queue"]);
 
 function fail(error: string, message: string): Failure {
@@ -169,6 +183,30 @@ function readRulesets(run: RunCommand, repoRoot: string, repository: string, act
   return { complete, items: complete ? items : items };
 }
 
+function readBranchInventory(run: RunCommand, repoRoot: string, repository: string, errors: AdapterError[]): BranchInventoryEnvelope {
+  const endpoint = `repos/${repository}/branches?per_page=100`;
+  const response = apiJson(run, repoRoot, endpoint, ["--paginate", "--slurp"]);
+  if (!response.ok) {
+    errors.push({ id: "branch_inventory_api_error", message: response.message });
+    return { complete: false, items: null };
+  }
+  if (!Array.isArray(response.value) || !response.value.every(Array.isArray)) {
+    errors.push({ id: "branch_inventory_api_error", message: "branch inventory must be a complete paginated array" });
+    return { complete: false, items: null };
+  }
+
+  const items: BranchFact[] = [];
+  for (const value of (response.value as unknown[][]).flat()) {
+    if (!isRecord(value) || typeof value.name !== "string" || value.name.length === 0 || !isRecord(value.commit)
+      || typeof value.commit.sha !== "string" || !SHA.test(value.commit.sha) || typeof value.protected !== "boolean") {
+      errors.push({ id: "branch_inventory_api_error", message: "branch inventory contains a malformed branch fact" });
+      return { complete: false, items: null };
+    }
+    items.push({ name: value.name, sha: value.commit.sha, protected: value.protected });
+  }
+  return { complete: true, items };
+}
+
 function repositoryOwnerType(metadata: Record<string, unknown>): RepositoryOwnerType | null {
   const owner = metadata.owner;
   if (!isRecord(owner)) return null;
@@ -198,6 +236,7 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
   const ownerType = repositoryOwnerType(metadata.value);
   const deleteOnMerge = deleteBranchOnMerge(metadata.value);
   const errors: AdapterError[] = [];
+  const branchInventory = input.includeBranchHygiene === true ? readBranchInventory(run, input.repoRoot, repository, errors) : null;
   const branchProtection = readBranchProtection(run, input.repoRoot, repository, defaultBranch, errors);
   const activeBranchRules = readActiveRules(run, input.repoRoot, repository, defaultBranch, errors);
   const rulesets = readRulesets(run, input.repoRoot, repository, activeBranchRules, errors);
@@ -209,6 +248,7 @@ export function readGitHubControlPlane(input: ReadInput): GitHubControlPlaneRead
     repositoryOwnerType: ownerType,
     defaultBranch,
     deleteBranchOnMerge: deleteOnMerge,
+    branchInventory,
     branchProtection,
     activeBranchRules,
     rulesets,

--- a/src/parallel-doctor.mts
+++ b/src/parallel-doctor.mts
@@ -1,5 +1,6 @@
 import type { GitHubControlPlaneReadResult } from "./github-control-plane.mjs";
 import { readGitHubControlPlane } from "./github-control-plane.mjs";
+import { analyzeBranchHygiene } from "./branch-hygiene.mjs";
 import { createIntegrationAnalysisReport } from "./integration-validator.mjs";
 import type { ParallelControlPlaneNormalizationResult } from "./parallel-control-plane.mjs";
 import { normalizeGitHubControlPlane } from "./parallel-control-plane.mjs";
@@ -15,6 +16,7 @@ const PARALLEL_FORMATS = new Set(["text", "json"]);
 
 type ParallelDoctorRoots = Parameters<typeof createIntegrationAnalysisReport>[0];
 type ParallelDoctorFormat = "text" | "json";
+type BranchHygieneDiagnostic = ReturnType<typeof analyzeBranchHygiene> | null;
 
 type ControlPlaneDiagnostic = {
   repository: string | null;
@@ -30,6 +32,7 @@ export interface ParallelDoctorReport extends ParallelReadinessReport {
     integrationValid: boolean;
     integrationMessage: string | null;
     controlPlane: ControlPlaneDiagnostic;
+    branchHygiene: BranchHygieneDiagnostic;
   };
 }
 
@@ -39,6 +42,8 @@ interface CreateParallelDoctorReportInput {
   integrationValid: boolean;
   integrationMessage?: string | null;
   controlPlaneRead: GitHubControlPlaneReadResult;
+  persistentBranches?: string[];
+  durableOwnership?: unknown;
 }
 
 interface IntegrationReportProjection {
@@ -51,6 +56,14 @@ interface IntegrationReportProjection {
 function option(args: readonly string[], name: string, fallback: string): string {
   const index = args.indexOf(name);
   return index < 0 ? fallback : args[index + 1] ?? fallback;
+}
+
+function options(args: readonly string[], name: string): string[] {
+  const values: string[] = [];
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] === name && args[index + 1] !== undefined) values.push(args[index + 1]);
+  }
+  return values;
 }
 
 function addBlocker(blockers: ParallelReadinessBlocker[], blocker: ParallelReadinessBlocker): void {
@@ -110,6 +123,21 @@ function controlPlaneProjection(
       };
 }
 
+function branchHygieneProjection(input: CreateParallelDoctorReportInput): BranchHygieneDiagnostic {
+  const read = input.controlPlaneRead;
+  if (!read.ok || read.branchInventory == null || read.openSameRepositoryPullRequestHeads == null
+    || read.mergedSameRepositoryPullRequestHeads == null) return null;
+  return analyzeBranchHygiene({
+    defaultBranch: read.defaultBranch,
+    deleteBranchOnMerge: read.deleteBranchOnMerge,
+    branchInventory: read.branchInventory,
+    openSameRepositoryPullRequestHeads: read.openSameRepositoryPullRequestHeads,
+    mergedSameRepositoryPullRequestHeads: read.mergedSameRepositoryPullRequestHeads,
+    persistentBranches: input.persistentBranches ?? [],
+    durableOwnership: input.durableOwnership,
+  });
+}
+
 export function parseParallelProvider(args: string[]): ParallelReadinessProvider {
   const index = args.indexOf("--parallel");
   if (index < 0) throw new Error("--parallel requires a value");
@@ -147,6 +175,7 @@ export function createParallelDoctorReport(input: CreateParallelDoctorReportInpu
       integrationValid: input.integrationValid,
       integrationMessage: input.integrationMessage ?? null,
       controlPlane: controlPlane.diagnostic,
+      branchHygiene: branchHygieneProjection(input),
     },
   };
 }
@@ -172,6 +201,18 @@ export function renderParallelDoctorReport(report: ParallelDoctorReport, format:
     lines.push("blockers:");
     for (const blocker of report.blockers) lines.push(`  - ${blocker.source}/${blocker.id}: ${blocker.message}`);
   }
+  const branchHygiene = report.diagnostics.branchHygiene;
+  if (branchHygiene) {
+    if (branchHygiene.ok) {
+      lines.push("branch hygiene: advisory");
+      lines.push(`persistent branches: ${branchHygiene.persistentBranches.map((branch) => branch.name).join(", ") || "none"}`);
+      lines.push(`merged PR heads still present: ${branchHygiene.mergedPullRequestHeadsStillPresent.map((head) => head.name).join(", ") || "none"}`);
+      lines.push(`orphan candidates: ${branchHygiene.orphanCandidates.map((branch) => branch.name).join(", ") || "none"}`);
+      lines.push(`delete_branch_on_merge: ${branchHygiene.deleteBranchOnMergeDrift.state}`);
+    } else {
+      lines.push(`branch hygiene: unavailable (${branchHygiene.error}: ${branchHygiene.message})`);
+    }
+  }
   const diagnosticErrors = report.diagnostics.controlPlane.adapterErrors;
   if (diagnosticErrors.length > 0) {
     lines.push("control-plane adapter errors:");
@@ -194,13 +235,14 @@ export async function runParallelDoctor(roots: ParallelDoctorRoots, args: string
   const integrationValid = integrationReport.fatal !== true && integrationReport.exitCode === 0;
   const integrationFacts = integrationReport.integration ?? {};
   const integrationMessage = integrationReport.fatal ? integrationReport.message ?? "integration analysis failed" : null;
-  const controlPlaneRead = readGitHubControlPlane({ repoRoot: roots.repoRoot, provider });
+  const controlPlaneRead = readGitHubControlPlane({ repoRoot: roots.repoRoot, provider, includeBranchHygiene: true });
   const report = createParallelDoctorReport({
     provider,
     integrationFacts,
     integrationValid,
     integrationMessage,
     controlPlaneRead,
+    persistentBranches: options(args, "--persistent-branch"),
   });
   console.log(renderParallelDoctorReport(report, format as ParallelDoctorFormat));
   return report.ready ? 0 : 1;

--- a/src/portable-integration/github-write.mts
+++ b/src/portable-integration/github-write.mts
@@ -49,9 +49,17 @@ type DeleteSuccess = {
   expectedHeadSha: string;
 };
 
+type AlreadyAbsentSuccess = {
+  ok: true;
+  kind: "already_absent";
+  branchName: string;
+  prNumber: number;
+  expectedHeadSha: string;
+};
+
 export type GitHubUpdateBranchResult = Failure | UpdateSuccess;
 export type GitHubMergeExactHeadResult = Failure | MergeSuccess;
-export type GitHubDeleteMergedBranchResult = Failure | DeleteSuccess;
+export type GitHubDeleteMergedBranchResult = Failure | DeleteSuccess | AlreadyAbsentSuccess;
 
 const SHA = /^[0-9a-f]{40}$/i;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -237,6 +245,15 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
 
       const read = normalizeResponse(rawRead);
       if (read === null) return fail("malformed_response", "branch reread transport returned a malformed response");
+      if (read.status === 404) {
+        return {
+          ok: true,
+          kind: "already_absent",
+          branchName,
+          prNumber: valid.prNumber,
+          expectedHeadSha: valid.expectedHeadSha,
+        };
+      }
       if (read.status !== 200) return fail("unexpected_response", `branch reread returned unexpected HTTP ${read.status}${responseMessage(read.body)}`);
       if (!isRecord(read.body) || read.body.ref !== `refs/heads/${branchName}` || !isRecord(read.body.object) || !isSha(read.body.object.sha))
         return fail("malformed_response", "branch reread must contain the exact ref and commit SHA");

--- a/src/portable-integration/github-write.mts
+++ b/src/portable-integration/github-write.mts
@@ -1,8 +1,13 @@
-type GitHubMutationRequest = {
-  method: "PUT";
-  path: string;
-  body: Record<string, string>;
-};
+type GitHubMutationRequest =
+  | {
+    method: "PUT";
+    path: string;
+    body: Record<string, string>;
+  }
+  | {
+    method: "GET" | "DELETE";
+    path: string;
+  };
 
 type GitHubMutationResponse = {
   status: number;
@@ -36,8 +41,17 @@ type MergeSuccess = {
   mergeMethod: MergeMethod;
 };
 
+type DeleteSuccess = {
+  ok: true;
+  kind: "deleted";
+  branchName: string;
+  prNumber: number;
+  expectedHeadSha: string;
+};
+
 export type GitHubUpdateBranchResult = Failure | UpdateSuccess;
 export type GitHubMergeExactHeadResult = Failure | MergeSuccess;
+export type GitHubDeleteMergedBranchResult = Failure | DeleteSuccess;
 
 const SHA = /^[0-9a-f]{40}$/i;
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
@@ -65,6 +79,10 @@ function isPositiveInteger(value: unknown): value is number {
 
 function isMergeMethod(value: unknown): value is MergeMethod {
   return typeof value === "string" && MERGE_METHODS.has(value as MergeMethod);
+}
+
+function encodeBranchPath(value: string): string {
+  return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
 }
 
 function normalizeTransport(input: unknown): GitHubMutationTransport | null {
@@ -193,6 +211,59 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
         expectedHeadSha: valid.expectedHeadSha,
         mergeSha: response.body.sha,
         mergeMethod: input.mergeMethod,
+      };
+    },
+
+    async deleteMergedBranchExact(input: unknown): Promise<GitHubDeleteMergedBranchResult> {
+      const common = validateCommonInput(input);
+      if (!common.ok) return common;
+      const valid = common.value;
+      if (!isRecord(input) || input.kind !== "delete_merged_branch" || typeof input.branchName !== "string" || input.branchName.length === 0)
+        return fail("invalid_input", "branch deletion requires planner kind delete_merged_branch and a branch name");
+      if (transport === null) return fail("invalid_transport", "write transport must expose an async request function");
+
+      const branchName = input.branchName;
+      const encodedBranch = encodeBranchPath(branchName);
+      let rawRead: unknown;
+      try {
+        rawRead = await transport.request({
+          method: "GET",
+          path: `/repos/${valid.repository}/git/ref/heads/${encodedBranch}`,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return fail("transport_error", `branch reread transport failed: ${message}`);
+      }
+
+      const read = normalizeResponse(rawRead);
+      if (read === null) return fail("malformed_response", "branch reread transport returned a malformed response");
+      if (read.status !== 200) return fail("unexpected_response", `branch reread returned unexpected HTTP ${read.status}${responseMessage(read.body)}`);
+      if (!isRecord(read.body) || read.body.ref !== `refs/heads/${branchName}` || !isRecord(read.body.object) || !isSha(read.body.object.sha))
+        return fail("malformed_response", "branch reread must contain the exact ref and commit SHA");
+      if (read.body.object.sha !== valid.expectedHeadSha)
+        return fail("stale_head", "branch moved after merged-head evidence was collected");
+
+      let rawDelete: unknown;
+      try {
+        rawDelete = await transport.request({
+          method: "DELETE",
+          path: `/repos/${valid.repository}/git/refs/heads/${encodedBranch}`,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return fail("transport_error", `branch delete transport failed: ${message}`);
+      }
+
+      const deletion = normalizeResponse(rawDelete);
+      if (deletion === null) return fail("malformed_response", "branch delete transport returned a malformed response");
+      if (deletion.status !== 204) return fail("unexpected_response", `branch delete returned unexpected HTTP ${deletion.status}${responseMessage(deletion.body)}`);
+
+      return {
+        ok: true,
+        kind: "deleted",
+        branchName,
+        prNumber: valid.prNumber,
+        expectedHeadSha: valid.expectedHeadSha,
       };
     },
   };

--- a/src/portable-integration/github-write.mts
+++ b/src/portable-integration/github-write.mts
@@ -89,6 +89,23 @@ function isMergeMethod(value: unknown): value is MergeMethod {
   return typeof value === "string" && MERGE_METHODS.has(value as MergeMethod);
 }
 
+function isBranchRefName(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0) return false;
+  if (value === "@" || value.startsWith("-") || value.startsWith("/") || value.endsWith("/")
+    || value.includes("//") || value.includes("..") || value.includes("@{") || value.endsWith(".")) return false;
+
+  for (const component of value.split("/")) {
+    if (component.length === 0 || component.startsWith(".") || component.endsWith(".lock")) return false;
+  }
+
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code <= 0x20 || code === 0x7f || "~^:?*[\\".includes(character)) return false;
+  }
+
+  return true;
+}
+
 function encodeBranchPath(value: string): string {
   return value.split("/").map((segment) => encodeURIComponent(segment)).join("/");
 }
@@ -226,8 +243,8 @@ export function createGitHubWriteAdapter(transportInput: unknown) {
       const common = validateCommonInput(input);
       if (!common.ok) return common;
       const valid = common.value;
-      if (!isRecord(input) || input.kind !== "delete_merged_branch" || typeof input.branchName !== "string" || input.branchName.length === 0)
-        return fail("invalid_input", "branch deletion requires planner kind delete_merged_branch and a branch name");
+      if (!isRecord(input) || input.kind !== "delete_merged_branch" || !isBranchRefName(input.branchName))
+        return fail("invalid_input", "branch deletion requires planner kind delete_merged_branch and a valid branch name");
       if (transport === null) return fail("invalid_transport", "write transport must expose an async request function");
 
       const branchName = input.branchName;

--- a/src/repo-guard.mts
+++ b/src/repo-guard.mts
@@ -53,7 +53,7 @@ const COMMAND_SPECS: Record<string, CommandSpec> = {
     run: async (roots, args) => (await import("./migrate.mjs")).runMigrate(roots, args),
   },
   doctor: {
-    options: { "--integration": false, ...valueOptions("--format", "--parallel") }, positionals: 0,
+    options: { "--integration": false, ...valueOptions("--format", "--parallel", "--persistent-branch") }, positionals: 0,
     run: async (roots, args) => args.includes("--integration")
       ? (await import("./integration-validator.mjs")).runValidateIntegration(roots, args)
       : args.includes("--parallel")

--- a/tests/test-branch-hygiene-analysis.mjs
+++ b/tests/test-branch-hygiene-analysis.mjs
@@ -1,0 +1,89 @@
+import { strict as assert } from "node:assert";
+import { analyzeBranchHygiene } from "../dist/branch-hygiene.mjs";
+
+const sha = (digit) => digit.repeat(40);
+const MAIN = sha("1");
+const PAGES = sha("2");
+const RELEASE = sha("3");
+const OPEN = sha("4");
+const OWNED = sha("5");
+const HANDOFF = sha("6");
+const STALE = sha("7");
+const MERGED = sha("8");
+const ORPHAN = sha("9");
+
+const branch = (name, value, protectedBranch = false) => ({ name, sha: value, protected: protectedBranch });
+
+const input = {
+  defaultBranch: "main",
+  deleteBranchOnMerge: false,
+  branchInventory: {
+    complete: true,
+    items: [
+      branch("main", MAIN, true),
+      branch("gh-pages", PAGES),
+      branch("release/stable", RELEASE),
+      branch("feature/open", OPEN),
+      branch("feature/owned", OWNED),
+      branch("feature/handoff", HANDOFF),
+      branch("feature/stale", STALE),
+      branch("feature/merged", MERGED),
+      branch("feature/orphan", ORPHAN),
+    ],
+  },
+  openSameRepositoryPullRequestHeads: {
+    complete: true,
+    items: [{ number: 11, name: "feature/open", sha: OPEN }],
+  },
+  persistentBranches: ["gh-pages", "release/stable"],
+  durableOwnership: {
+    complete: true,
+    items: [
+      { name: "feature/owned", sha: OWNED, state: "live" },
+      { name: "feature/handoff", sha: HANDOFF, state: "handoff" },
+      { name: "feature/stale", sha: STALE, state: "stale_candidate" },
+    ],
+  },
+  mergedSameRepositoryPullRequestHeads: {
+    complete: true,
+    items: [{ number: 10, name: "feature/merged", sha: MERGED }],
+  },
+};
+
+const result = analyzeBranchHygiene(input);
+assert.equal(result.ok, true);
+assert.deepEqual(result.persistentBranches.map((item) => item.name).sort(), ["gh-pages", "main", "release/stable"]);
+assert.deepEqual(result.activePullRequestHeads.map((item) => item.name), ["feature/open"]);
+assert.deepEqual(result.ownedPrePullRequestBranches.map((item) => [item.name, item.state]).sort(), [
+  ["feature/handoff", "handoff"],
+  ["feature/owned", "live"],
+]);
+assert.deepEqual(result.staleOwnershipBranches.map((item) => item.name), ["feature/stale"]);
+assert.deepEqual(result.orphanCandidates.map((item) => item.name).sort(), ["feature/merged", "feature/orphan"]);
+assert.deepEqual(result.mergedPullRequestHeadsStillPresent, [
+  { number: 10, name: "feature/merged", sha: MERGED },
+]);
+assert.deepEqual(result.deleteBranchOnMergeDrift, {
+  state: "disabled",
+  residualMergedBranchCount: 1,
+});
+assert.equal(Object.hasOwn(result, "deletePlan"), false, "classification must never manufacture deletion authority");
+
+const incompleteOwnership = analyzeBranchHygiene({
+  ...input,
+  durableOwnership: { complete: false, items: null },
+});
+assert.equal(incompleteOwnership.ok, false);
+assert.equal(incompleteOwnership.error, "incomplete_branch_hygiene_facts");
+
+const missingDefault = analyzeBranchHygiene({
+  ...input,
+  branchInventory: {
+    complete: true,
+    items: input.branchInventory.items.filter((item) => item.name !== "main"),
+  },
+});
+assert.equal(missingDefault.ok, false);
+assert.equal(missingDefault.error, "default_branch_missing");
+
+console.log("Branch hygiene analysis tests passed");

--- a/tests/test-branch-hygiene-analysis.mjs
+++ b/tests/test-branch-hygiene-analysis.mjs
@@ -1,6 +1,7 @@
 import { strict as assert } from "node:assert";
-import { analyzeBranchHygiene } from "../dist/branch-hygiene.mjs";
+import * as branchHygiene from "../dist/branch-hygiene.mjs";
 
+const { analyzeBranchHygiene } = branchHygiene;
 const sha = (digit) => digit.repeat(40);
 const MAIN = sha("1");
 const PAGES = sha("2");
@@ -85,5 +86,25 @@ const missingDefault = analyzeBranchHygiene({
 });
 assert.equal(missingDefault.ok, false);
 assert.equal(missingDefault.error, "default_branch_missing");
+
+assert.equal(
+  typeof branchHygiene.planMergedBranchDeletion,
+  "function",
+  "merged branch cleanup requires an explicit planner before any mutation",
+);
+const deletionPlan = branchHygiene.planMergedBranchDeletion?.({
+  facts: input,
+  branchName: "feature/merged",
+  prNumber: 10,
+  expectedHeadSha: MERGED,
+  rereadBranch: { name: "feature/merged", sha: MERGED },
+});
+assert.deepEqual(deletionPlan, {
+  ok: true,
+  kind: "delete_merged_branch",
+  branchName: "feature/merged",
+  prNumber: 10,
+  expectedHeadSha: MERGED,
+});
 
 console.log("Branch hygiene analysis tests passed");

--- a/tests/test-branch-hygiene-analysis.mjs
+++ b/tests/test-branch-hygiene-analysis.mjs
@@ -107,4 +107,19 @@ assert.deepEqual(deletionPlan, {
   expectedHeadSha: MERGED,
 });
 
+const alreadyAbsentPlan = branchHygiene.planMergedBranchDeletion?.({
+  facts: input,
+  branchName: "feature/merged",
+  prNumber: 10,
+  expectedHeadSha: MERGED,
+  rereadBranch: null,
+});
+assert.deepEqual(alreadyAbsentPlan, {
+  ok: true,
+  kind: "already_absent",
+  branchName: "feature/merged",
+  prNumber: 10,
+  expectedHeadSha: MERGED,
+});
+
 console.log("Branch hygiene analysis tests passed");

--- a/tests/test-branch-hygiene-control-plane.mjs
+++ b/tests/test-branch-hygiene-control-plane.mjs
@@ -1,6 +1,9 @@
 import { strict as assert } from "node:assert";
 import { readGitHubControlPlane } from "../dist/github-control-plane.mjs";
 
+const MAIN = "1111111111111111111111111111111111111111";
+const HEAD = "2222222222222222222222222222222222222222";
+
 function commandError(stderr, status = 1) {
   const error = new Error(stderr);
   error.status = status;
@@ -20,7 +23,15 @@ function run(command, args) {
     },
     "repos/netkeep80/example/branches/main/protection": commandError("Branch not protected (HTTP 404)"),
     "repos/netkeep80/example/rules/branches/main": [[]],
+    "repos/netkeep80/example/branches?per_page=100": [
+      [{ name: "main", commit: { sha: MAIN }, protected: true }],
+      [{ name: "feature/work", commit: { sha: HEAD }, protected: false }],
+    ],
   };
+  if (endpoint === "repos/netkeep80/example/branches?per_page=100") {
+    assert.equal(args.includes("--paginate"), true, "branch inventory must request every page");
+    assert.equal(args.includes("--slurp"), true, "branch inventory must preserve pagination completeness");
+  }
   const value = fixtures[endpoint];
   if (value instanceof Error) throw value;
   if (value === undefined) throw new Error(`unexpected gh api endpoint: ${endpoint}`);
@@ -32,6 +43,7 @@ const result = readGitHubControlPlane({
   provider: "portable",
   env: { GITHUB_REPOSITORY: "netkeep80/example" },
   run,
+  includeBranchHygiene: true,
 });
 
 assert.equal(result.ok, true);
@@ -40,5 +52,12 @@ assert.equal(
   false,
   "repository delete_branch_on_merge=false must remain an explicit control-plane fact",
 );
+assert.deepEqual(result.branchInventory, {
+  complete: true,
+  items: [
+    { name: "main", sha: MAIN, protected: true },
+    { name: "feature/work", sha: HEAD, protected: false },
+  ],
+});
 
-console.log("Branch hygiene repository-setting fact test passed");
+console.log("Branch hygiene control-plane fact tests passed");

--- a/tests/test-branch-hygiene-control-plane.mjs
+++ b/tests/test-branch-hygiene-control-plane.mjs
@@ -4,6 +4,7 @@ import { readGitHubControlPlane } from "../dist/github-control-plane.mjs";
 const MAIN = "1111111111111111111111111111111111111111";
 const HEAD = "2222222222222222222222222222222222222222";
 const FORK = "3333333333333333333333333333333333333333";
+const MERGED = "4444444444444444444444444444444444444444";
 
 function commandError(stderr, status = 1) {
   const error = new Error(stderr);
@@ -46,8 +47,38 @@ function run(command, args) {
         },
       }],
     ],
+    "repos/netkeep80/example/pulls?state=closed&per_page=100": [
+      [{
+        number: 6,
+        merged_at: "2026-08-01T00:00:00Z",
+        head: {
+          ref: "feature/merged",
+          sha: MERGED,
+          repo: { full_name: "netkeep80/example" },
+        },
+      }, {
+        number: 9,
+        merged_at: null,
+        head: {
+          ref: "feature/closed-unmerged",
+          sha: HEAD,
+          repo: { full_name: "netkeep80/example" },
+        },
+      }],
+      [{
+        number: 10,
+        merged_at: "2026-08-02T00:00:00Z",
+        head: {
+          ref: "fork-merged",
+          sha: FORK,
+          repo: { full_name: "contributor/example" },
+        },
+      }],
+    ],
   };
-  if (endpoint === "repos/netkeep80/example/branches?per_page=100" || endpoint === "repos/netkeep80/example/pulls?state=open&per_page=100") {
+  if (endpoint === "repos/netkeep80/example/branches?per_page=100"
+    || endpoint === "repos/netkeep80/example/pulls?state=open&per_page=100"
+    || endpoint === "repos/netkeep80/example/pulls?state=closed&per_page=100") {
     assert.equal(args.includes("--paginate"), true, `${endpoint} must request every page`);
     assert.equal(args.includes("--slurp"), true, `${endpoint} must preserve pagination completeness`);
   }
@@ -84,5 +115,11 @@ assert.deepEqual(result.openSameRepositoryPullRequestHeads, {
     { number: 7, name: "feature/work", sha: HEAD },
   ],
 }, "fork PR heads must not become ownership facts for branches in the base repository");
+assert.deepEqual(result.mergedSameRepositoryPullRequestHeads, {
+  complete: true,
+  items: [
+    { number: 6, name: "feature/merged", sha: MERGED },
+  ],
+}, "only merged same-repository PR heads may become merged-residue evidence");
 
 console.log("Branch hygiene control-plane fact tests passed");

--- a/tests/test-branch-hygiene-control-plane.mjs
+++ b/tests/test-branch-hygiene-control-plane.mjs
@@ -3,6 +3,7 @@ import { readGitHubControlPlane } from "../dist/github-control-plane.mjs";
 
 const MAIN = "1111111111111111111111111111111111111111";
 const HEAD = "2222222222222222222222222222222222222222";
+const FORK = "3333333333333333333333333333333333333333";
 
 function commandError(stderr, status = 1) {
   const error = new Error(stderr);
@@ -27,10 +28,28 @@ function run(command, args) {
       [{ name: "main", commit: { sha: MAIN }, protected: true }],
       [{ name: "feature/work", commit: { sha: HEAD }, protected: false }],
     ],
+    "repos/netkeep80/example/pulls?state=open&per_page=100": [
+      [{
+        number: 7,
+        head: {
+          ref: "feature/work",
+          sha: HEAD,
+          repo: { full_name: "netkeep80/example" },
+        },
+      }],
+      [{
+        number: 8,
+        head: {
+          ref: "fork-work",
+          sha: FORK,
+          repo: { full_name: "contributor/example" },
+        },
+      }],
+    ],
   };
-  if (endpoint === "repos/netkeep80/example/branches?per_page=100") {
-    assert.equal(args.includes("--paginate"), true, "branch inventory must request every page");
-    assert.equal(args.includes("--slurp"), true, "branch inventory must preserve pagination completeness");
+  if (endpoint === "repos/netkeep80/example/branches?per_page=100" || endpoint === "repos/netkeep80/example/pulls?state=open&per_page=100") {
+    assert.equal(args.includes("--paginate"), true, `${endpoint} must request every page`);
+    assert.equal(args.includes("--slurp"), true, `${endpoint} must preserve pagination completeness`);
   }
   const value = fixtures[endpoint];
   if (value instanceof Error) throw value;
@@ -59,5 +78,11 @@ assert.deepEqual(result.branchInventory, {
     { name: "feature/work", sha: HEAD, protected: false },
   ],
 });
+assert.deepEqual(result.openSameRepositoryPullRequestHeads, {
+  complete: true,
+  items: [
+    { number: 7, name: "feature/work", sha: HEAD },
+  ],
+}, "fork PR heads must not become ownership facts for branches in the base repository");
 
 console.log("Branch hygiene control-plane fact tests passed");

--- a/tests/test-branch-hygiene-control-plane.mjs
+++ b/tests/test-branch-hygiene-control-plane.mjs
@@ -1,0 +1,44 @@
+import { strict as assert } from "node:assert";
+import { readGitHubControlPlane } from "../dist/github-control-plane.mjs";
+
+function commandError(stderr, status = 1) {
+  const error = new Error(stderr);
+  error.status = status;
+  error.stderr = stderr;
+  return error;
+}
+
+function run(command, args) {
+  assert.equal(command, "gh");
+  assert.equal(args[0], "api");
+  const endpoint = args[1];
+  const fixtures = {
+    "repos/netkeep80/example": {
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      owner: { type: "User" },
+    },
+    "repos/netkeep80/example/branches/main/protection": commandError("Branch not protected (HTTP 404)"),
+    "repos/netkeep80/example/rules/branches/main": [[]],
+  };
+  const value = fixtures[endpoint];
+  if (value instanceof Error) throw value;
+  if (value === undefined) throw new Error(`unexpected gh api endpoint: ${endpoint}`);
+  return JSON.stringify(value);
+}
+
+const result = readGitHubControlPlane({
+  repoRoot: "/repo",
+  provider: "portable",
+  env: { GITHUB_REPOSITORY: "netkeep80/example" },
+  run,
+});
+
+assert.equal(result.ok, true);
+assert.equal(
+  result.deleteBranchOnMerge,
+  false,
+  "repository delete_branch_on_merge=false must remain an explicit control-plane fact",
+);
+
+console.log("Branch hygiene repository-setting fact test passed");

--- a/tests/test-branch-hygiene-write-hardening.mjs
+++ b/tests/test-branch-hygiene-write-hardening.mjs
@@ -1,0 +1,35 @@
+import { strict as assert } from "node:assert";
+import { createGitHubWriteAdapter } from "../dist/portable-integration/github-write.mjs";
+
+const REPO = "netkeep80/repo-guard";
+const HEAD = "1111111111111111111111111111111111111111";
+
+for (const branchName of [
+  "",
+  "../main",
+  "/main",
+  "main/",
+  "feature//work",
+  "feature\\work",
+  "feature\u0000work",
+]) {
+  let calls = 0;
+  const adapter = createGitHubWriteAdapter({
+    request: async () => {
+      calls += 1;
+      return { status: 404, body: { message: "should not be called" } };
+    },
+  });
+  const result = await adapter.deleteMergedBranchExact({
+    repository: REPO,
+    kind: "delete_merged_branch",
+    branchName,
+    prNumber: 42,
+    expectedHeadSha: HEAD,
+  });
+  assert.equal(result.ok, false, `${JSON.stringify(branchName)} must fail before transport`);
+  assert.equal(result.error, "invalid_input", `${JSON.stringify(branchName)} must be typed invalid input`);
+  assert.equal(calls, 0, `${JSON.stringify(branchName)} must not reach transport`);
+}
+
+console.log("Branch hygiene write hardening tests passed");

--- a/tests/test-parallel-doctor.mjs
+++ b/tests/test-parallel-doctor.mjs
@@ -7,6 +7,14 @@ const projectRoot = resolve(new URL("..", import.meta.url).pathname);
 const cli = resolve(projectRoot, "dist/repo-guard.mjs");
 let failures = 0;
 
+const MAIN = "1111111111111111111111111111111111111111";
+const OPEN = "2222222222222222222222222222222222222222";
+const OWNED = "3333333333333333333333333333333333333333";
+const MERGED = "4444444444444444444444444444444444444444";
+const ORPHAN = "5555555555555555555555555555555555555555";
+const PUBLISH = "6666666666666666666666666666666666666666";
+const RELEASE = "7777777777777777777777777777777777777777";
+
 function expect(label, actual, expected) {
   const passed = actual === expected;
   console.log(`${passed ? "PASS" : "FAIL"}: ${label}`);
@@ -92,6 +100,33 @@ function readyControlPlaneRead() {
   };
 }
 
+function branchAwareControlPlaneRead() {
+  return {
+    ...readyControlPlaneRead(),
+    deleteBranchOnMerge: false,
+    branchInventory: {
+      complete: true,
+      items: [
+        { name: "main", sha: MAIN, protected: true },
+        { name: "gh-pages", sha: PUBLISH, protected: false },
+        { name: "release/stable", sha: RELEASE, protected: false },
+        { name: "feature/open", sha: OPEN, protected: false },
+        { name: "agent/owned", sha: OWNED, protected: false },
+        { name: "feature/merged", sha: MERGED, protected: false },
+        { name: "feature/orphan", sha: ORPHAN, protected: false },
+      ],
+    },
+    openSameRepositoryPullRequestHeads: {
+      complete: true,
+      items: [{ number: 7, name: "feature/open", sha: OPEN }],
+    },
+    mergedSameRepositoryPullRequestHeads: {
+      complete: true,
+      items: [{ number: 6, name: "feature/merged", sha: MERGED }],
+    },
+  };
+}
+
 function incompleteClassicControlPlaneRead(repositoryOwnerType) {
   return {
     ok: true,
@@ -129,6 +164,14 @@ console.log("\n--- doctor --parallel rejects unsupported providers ---");
   expectIncludes("unsupported provider is explicit", result.stderr, "Unsupported parallel provider: bogus");
 }
 
+console.log("\n--- doctor --parallel accepts explicit persistent branch refs ---");
+{
+  const result = run(["doctor", "--parallel", "bogus", "--persistent-branch", "gh-pages"]);
+  expect("unsupported provider still exits non-zero", result.code, 1);
+  expectIncludes("provider validation remains authoritative", result.stderr, "Unsupported parallel provider: bogus");
+  expectNotIncludes("persistent branch option is accepted by CLI parser", result.stderr, "Unknown option for doctor: --persistent-branch");
+}
+
 console.log("\n--- parallel doctor composes canonical repository and control-plane readiness ---");
 {
   const report = createParallelDoctorReport({
@@ -159,6 +202,52 @@ console.log("\n--- parallel doctor composes canonical repository and control-pla
   assert.match(text, /provider workflow: \.github\/workflows\/parallel\.yml/);
   assert.match(text, /target branch: main/);
   assert.match(text, /required checks: CI \/ validate/);
+}
+
+console.log("\n--- branch hygiene is a machine-readable advisory diagnostic with explicit exemptions ---");
+{
+  const report = createParallelDoctorReport({
+    provider: "portable",
+    integrationFacts: readyIntegrationFacts(),
+    integrationValid: true,
+    controlPlaneRead: branchAwareControlPlaneRead(),
+    persistentBranches: ["gh-pages", "release/stable"],
+    durableOwnership: {
+      complete: true,
+      items: [{ name: "agent/owned", state: "handoff" }],
+    },
+  });
+
+  assert.equal(report.ready, true, "advisory branch hygiene must not silently change parallel readiness");
+  assert.deepEqual(report.diagnostics.branchHygiene, {
+    ok: true,
+    persistentBranches: [
+      { name: "gh-pages", sha: PUBLISH, protected: false },
+      { name: "main", sha: MAIN, protected: true },
+      { name: "release/stable", sha: RELEASE, protected: false },
+    ],
+    activePullRequestHeads: [{ number: 7, name: "feature/open", sha: OPEN }],
+    ownedPrePullRequestBranches: [{ name: "agent/owned", sha: OWNED, state: "handoff" }],
+    staleOwnershipBranches: [],
+    orphanCandidates: [
+      { name: "feature/merged", sha: MERGED, protected: false },
+      { name: "feature/orphan", sha: ORPHAN, protected: false },
+    ],
+    mergedPullRequestHeadsStillPresent: [{ number: 6, name: "feature/merged", sha: MERGED }],
+    deleteBranchOnMergeDrift: { state: "disabled", residualMergedBranchCount: 1 },
+  });
+
+  const json = JSON.parse(renderParallelDoctorReport(report, "json"));
+  assert.equal(json.diagnostics.branchHygiene.ok, true);
+  assert.equal(json.diagnostics.branchHygiene.deleteBranchOnMergeDrift.state, "disabled");
+  assert.equal(json.diagnostics.branchHygiene.orphanCandidates.length, 2);
+
+  const text = renderParallelDoctorReport(report, "text");
+  assert.match(text, /branch hygiene: advisory/);
+  assert.match(text, /persistent branches: gh-pages, main, release\/stable/);
+  assert.match(text, /merged PR heads still present: feature\/merged/);
+  assert.match(text, /orphan candidates: feature\/merged, feature\/orphan/);
+  assert.match(text, /delete_branch_on_merge: disabled/);
 }
 
 console.log("\n--- user-owned classic protection preserves trusted owner type through doctor projection ---");

--- a/tests/test-portable-github-write-adapter.mjs
+++ b/tests/test-portable-github-write-adapter.mjs
@@ -217,6 +217,41 @@ async function run() {
   }
 
   {
+    const calls = [];
+    const adapter = createGitHubWriteAdapter({
+      request: async (request) => {
+        calls.push(request);
+        if (request.method === "GET") {
+          return {
+            status: 200,
+            body: { ref: "refs/heads/feature/work", object: { sha: HEAD, type: "commit" } },
+          };
+        }
+        if (request.method === "DELETE") return { status: 204, body: null };
+        throw new Error(`unexpected method ${request.method}`);
+      },
+    });
+    const result = await adapter.deleteMergedBranchExact({
+      repository: REPO,
+      kind: "delete_merged_branch",
+      branchName: "feature/work",
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+    });
+    expect("merged branch deletion rereads exact ref before mutation", calls, [
+      { method: "GET", path: "/repos/netkeep80/repo-guard/git/ref/heads/feature/work" },
+      { method: "DELETE", path: "/repos/netkeep80/repo-guard/git/refs/heads/feature/work" },
+    ]);
+    expect("successful exact branch delete returns typed evidence", result, {
+      ok: true,
+      kind: "deleted",
+      branchName: "feature/work",
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+    });
+  }
+
+  {
     const adapter = createGitHubWriteAdapter({
       request: async () => {
         throw new Error("network unavailable");

--- a/tests/test-portable-github-write-adapter.mjs
+++ b/tests/test-portable-github-write-adapter.mjs
@@ -252,6 +252,57 @@ async function run() {
   }
 
   {
+    const calls = [];
+    const adapter = createGitHubWriteAdapter({
+      request: async (request) => {
+        calls.push(request);
+        return {
+          status: 200,
+          body: { ref: "refs/heads/feature/work", object: { sha: MERGE, type: "commit" } },
+        };
+      },
+    });
+    const result = await adapter.deleteMergedBranchExact({
+      repository: REPO,
+      kind: "delete_merged_branch",
+      branchName: "feature/work",
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+    });
+    expect("moved branch is rejected as stale", result.error, "stale_head");
+    expect("moved branch never reaches DELETE", calls, [
+      { method: "GET", path: "/repos/netkeep80/repo-guard/git/ref/heads/feature/work" },
+    ]);
+  }
+
+  {
+    const calls = [];
+    const adapter = createGitHubWriteAdapter({
+      request: async (request) => {
+        calls.push(request);
+        return { status: 404, body: { message: "Reference does not exist" } };
+      },
+    });
+    const result = await adapter.deleteMergedBranchExact({
+      repository: REPO,
+      kind: "delete_merged_branch",
+      branchName: "feature/work",
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+    });
+    expect("branch already absent at fresh reread is idempotent", result, {
+      ok: true,
+      kind: "already_absent",
+      branchName: "feature/work",
+      prNumber: 42,
+      expectedHeadSha: HEAD,
+    });
+    expect("already absent branch never reaches DELETE", calls, [
+      { method: "GET", path: "/repos/netkeep80/repo-guard/git/ref/heads/feature/work" },
+    ]);
+  }
+
+  {
     const adapter = createGitHubWriteAdapter({
       request: async () => {
         throw new Error("network unavailable");


### PR DESCRIPTION
Implements #348
Refs netkeep80/roadmap#62, netkeep80/roadmap#122.

Начальный этап намеренно RED-first: первый commit добавляет только исполняемую проверку того, что `delete_branch_on_merge=false` сохраняется как явный GitHub control-plane fact. Production implementation добавляется только после подтверждённого RED.

```repo-guard-yaml
change_type: feature
scope:
  - tests/**
  - src/**
  - dist/**
budgets:
  max_new_files: 6
  max_new_docs: 0
  max_net_added_lines: 1600
anchors:
  affects: []
  implements: []
  verifies: []
must_touch:
  - tests/**
  - src/**
  - dist/**
must_not_touch:
  - repo-policy.json
  - schemas/**
  - .github/workflows/**
  - action.yml
  - package.json
  - package-lock.json
expected_effects:
  - GitHub control-plane facts expose delete_branch_on_merge without optimistic defaults
  - branch inventory and same-repository PR ownership can be classified deterministically before any deletion primitive exists
  - merged branch cleanup remains exact-SHA guarded and fail-closed
  - no branch is deleted merely because it has no open PR
```
